### PR TITLE
fix(storage) sqlite storage uses constructor path as the .db folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /target
 Cargo.lock
-example-database
+/example-database
 backup
-wallet.db
 .DS_Store

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -30,14 +30,7 @@ pub fn set_storage_path(path: impl AsRef<Path>) -> crate::Result<()> {
 }
 
 pub(crate) fn get_storage_path() -> &'static PathBuf {
-    #[cfg(not(feature = "sqlite"))]
-    {
-        STORAGE_PATH.get_or_init(|| "./example-database".into())
-    }
-    #[cfg(feature = "sqlite")]
-    {
-        STORAGE_PATH.get_or_init(|| "wallet.db".into())
-    }
+    STORAGE_PATH.get_or_init(|| "./example-database".into())
 }
 
 /// gets the storage adapter

--- a/src/storage/sqlite.rs
+++ b/src/storage/sqlite.rs
@@ -12,8 +12,10 @@ pub struct SqliteStorageAdapter {
 
 impl SqliteStorageAdapter {
     /// Initialises the storage adapter.
-    pub fn new(db_name: impl AsRef<Path>, table_name: impl AsRef<str>) -> crate::Result<Self> {
-        let connection = Connection::open(db_name)?;
+    pub fn new(path: impl AsRef<Path>, table_name: impl AsRef<str>) -> crate::Result<Self> {
+        std::fs::create_dir_all(&path)?;
+
+        let connection = Connection::open(path.as_ref().join("wallet.db"))?;
 
         connection.execute(
             &format!(


### PR DESCRIPTION
# Description of change

Updates the SQLite storage adapter to match the `path` signature from the stronghold adapter. 

## Type of change

- Enhancement (a non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

Running unit tests.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have checked that new and existing unit tests pass locally with my changes
