### PR TITLE
fix(storage) support AccountIdentifier::Index

### DIFF
--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -181,9 +181,11 @@ impl AccountManager {
             source
                 .as_ref()
                 .join(crate::storage::stronghold_snapshot_filename()),
+            false,
+            "",
         );
         for account in accounts {
-            let stronghold_account = backup_stronghold.account_export(account.id(), "password");
+            let stronghold_account = backup_stronghold.account_get_by_id(account.id(), "password");
             let created_at_timestamp: u128 = account.created_at().timestamp().try_into().unwrap(); // safe to unwrap since it's > 0
             let stronghold_account = crate::with_stronghold(|stronghold| {
                 stronghold.account_import(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,8 @@ static STRONGHOLD_INSTANCE: OnceCell<GlobalStronghold> = OnceCell::new();
 
 pub(crate) fn with_stronghold<T, F: FnOnce(MutexGuard<'static, Stronghold>) -> T>(cb: F) -> T {
     let stronghold = STRONGHOLD_INSTANCE.get_or_init(|| {
-        let stronghold = Stronghold::new(storage::get_stronghold_snapshot_path());
+        let path = storage::get_stronghold_snapshot_path();
+        let stronghold = Stronghold::new(&path, path.exists(), "password");
         Arc::new(Mutex::new(stronghold))
     });
     cb(stronghold.lock().expect("failed to get stronghold lock"))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ static STRONGHOLD_INSTANCE: OnceCell<GlobalStronghold> = OnceCell::new();
 pub(crate) fn with_stronghold<T, F: FnOnce(MutexGuard<'static, Stronghold>) -> T>(cb: F) -> T {
     let stronghold = STRONGHOLD_INSTANCE.get_or_init(|| {
         let path = storage::get_stronghold_snapshot_path();
-        let stronghold = Stronghold::new(&path, path.exists(), "password");
+        let stronghold = Stronghold::new(&path, !path.exists(), "password");
         Arc::new(Mutex::new(stronghold))
     });
     cb(stronghold.lock().expect("failed to get stronghold lock"))

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -79,19 +79,6 @@ pub trait StorageAdapter {
     fn set(&self, account_id: AccountIdentifier, account: String) -> crate::Result<()>;
     /// Removes an account from the storage.
     fn remove(&self, account_id: AccountIdentifier) -> crate::Result<()>;
-    /// Gets the account id (string) from the AccountIdentifier (which might be an account index).
-    fn key_from_identifier(&self, account_id: AccountIdentifier) -> crate::Result<String> {
-        let id = match account_id {
-            AccountIdentifier::Id(id) => id,
-            AccountIdentifier::Index(index) => {
-                let accounts = self.get_all()?;
-                let account = &accounts[index as usize];
-                let account: Account = serde_json::from_str(&account)?;
-                account.id().clone()
-            }
-        };
-        Ok(id)
-    }
 }
 
 pub(crate) fn parse_accounts(accounts: &[String]) -> crate::Result<Vec<Account>> {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -72,13 +72,26 @@ pub(crate) fn get_adapter_from_path<P: AsRef<Path>>(
 /// The storage adapter.
 pub trait StorageAdapter {
     /// Gets the account with the given id/alias from the storage.
-    fn get(&self, key: AccountIdentifier) -> crate::Result<String>;
+    fn get(&self, account_id: AccountIdentifier) -> crate::Result<String>;
     /// Gets all the accounts from the storage.
     fn get_all(&self) -> crate::Result<Vec<String>>;
     /// Saves or updates an account on the storage.
-    fn set(&self, key: AccountIdentifier, account: String) -> crate::Result<()>;
+    fn set(&self, account_id: AccountIdentifier, account: String) -> crate::Result<()>;
     /// Removes an account from the storage.
-    fn remove(&self, key: AccountIdentifier) -> crate::Result<()>;
+    fn remove(&self, account_id: AccountIdentifier) -> crate::Result<()>;
+    /// Gets the account id (string) from the AccountIdentifier (which might be an account index).
+    fn key_from_identifier(&self, account_id: AccountIdentifier) -> crate::Result<String> {
+        let id = match account_id {
+            AccountIdentifier::Id(id) => id,
+            AccountIdentifier::Index(index) => {
+                let accounts = self.get_all()?;
+                let account = &accounts[index as usize];
+                let account: Account = serde_json::from_str(&account)?;
+                account.id().clone()
+            }
+        };
+        Ok(id)
+    }
 }
 
 pub(crate) fn parse_accounts(accounts: &[String]) -> crate::Result<Vec<Account>> {


### PR DESCRIPTION
# Description of change

Support numeric (index) account identifiers on the default storage adapters (SQLite and Stronghold). 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

By running the unit tests.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have checked that new and existing unit tests pass locally with my changes
