### PR TITLE
Add "internal" property to address interface

### DIFF
--- a/specs/wallet-ENGINEERING-SPEC-0000.md
+++ b/specs/wallet-ENGINEERING-SPEC-0000.md
@@ -460,6 +460,12 @@ Note: The library only supports Ed25519 addresses. Therefore a `type` property f
     <td>Address index.</td>
   </tr>
   <tr>
+    <td>internal</td>
+    <td>&#10004;</td>
+    <td>boolean</td>
+    <td>Determines if an address is a public or an internal (change) address. See the concept of <a href="https://medium.com/@harshagoli/hd-wallets-explained-from-high-level-to-nuts-and-bolts-9a41545f5b0">chain node</a> for more details.</td>
+  </tr>
+  <tr>
     <td>checksum</td>
     <td>&#10004;</td>
     <td>string</td>


### PR DESCRIPTION
# Description of change

This PR adds `internal` property to the [Address](https://github.com/iotaledger/wallet.rs/blob/master/specs/wallet-ENGINEERING-SPEC-0000.md#address) interface in specification. 

## Links to any relevant issues

N/A

## Type of change

- Documentation Fix

## How the change has been tested

N/A

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
