### PR TITLE
feat(account) simplify AccountIdentifier usage

### DIFF
--- a/examples/custom_storage.rs
+++ b/examples/custom_storage.rs
@@ -23,7 +23,7 @@ impl MyStorage {
 
 fn account_id_value(account_id: AccountIdentifier) -> anyhow::Result<String> {
     match account_id {
-        AccountIdentifier::Id(val) => Ok(val),
+        AccountIdentifier::Id(val) => Ok(String::from_utf8_lossy(&val).to_string()),
         _ => Err(anyhow::anyhow!("Unexpected AccountIdentifier type")),
     }
 }

--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -134,7 +134,6 @@ impl AccountInitialiser {
             client_options: self.client_options,
         };
         adapter.set(account_id, serde_json::to_string(&account)?)?;
-        println!("created");
         Ok(account)
     }
 }

--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -30,7 +30,7 @@ impl From<[u8; 32]> for AccountIdentifier {
 }
 impl From<&[u8; 32]> for AccountIdentifier {
     fn from(value: &[u8; 32]) -> Self {
-        Self::Id(value.clone())
+        Self::Id(*value)
     }
 }
 

--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -14,29 +14,23 @@ pub use sync::{AccountSynchronizer, SyncedAccount};
 
 /// The account identifier.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
 pub enum AccountIdentifier {
-    /// An Id (string) identifier.
-    Id(String),
+    /// A stronghold record id identifier.
+    Id([u8; 32]),
     /// An index identifier.
     Index(u64),
-}
-
-// When the identifier is a String (id).
-impl From<String> for AccountIdentifier {
-    fn from(value: String) -> Self {
-        Self::Id(value)
-    }
 }
 
 // When the identifier is a stronghold id.
 impl From<[u8; 32]> for AccountIdentifier {
     fn from(value: [u8; 32]) -> Self {
-        Self::Id(String::from_utf8_lossy(&value).to_string())
+        Self::Id(value)
     }
 }
 impl From<&[u8; 32]> for AccountIdentifier {
     fn from(value: &[u8; 32]) -> Self {
-        Self::Id(String::from_utf8_lossy(value).to_string())
+        Self::Id(value.clone())
     }
 }
 
@@ -140,6 +134,7 @@ impl AccountInitialiser {
             client_options: self.client_options,
         };
         adapter.set(account_id, serde_json::to_string(&account)?)?;
+        println!("created");
         Ok(account)
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -11,7 +11,7 @@ use std::sync::{Arc, Mutex};
 #[getset(get = "pub")]
 pub struct BalanceEvent {
     /// The associated account identifier.
-    account_id: String,
+    account_id: [u8; 32],
     /// The associated address.
     address: Address,
     /// The new balance.
@@ -23,7 +23,7 @@ pub struct BalanceEvent {
 #[getset(get = "pub")]
 pub struct TransactionEvent {
     /// The associated account identifier.
-    account_id: String,
+    account_id: [u8; 32],
     /// The event transaction hash.
     transaction_hash: Hash,
 }
@@ -33,7 +33,7 @@ pub struct TransactionEvent {
 #[getset(get = "pub")]
 pub struct TransactionConfirmationChangeEvent {
     /// The associated account identifier.
-    account_id: String,
+    account_id: [u8; 32],
     /// The event transaction hash.
     transaction_hash: Hash,
     /// The confirmed state of the transaction.
@@ -97,8 +97,7 @@ pub fn on_balance_change<F: Fn(BalanceEvent) + Send + 'static>(cb: F) {
 }
 
 /// Emits a balance change event.
-pub(crate) fn emit_balance_change(account_id: impl Into<String>, address: Address, balance: u64) {
-    let account_id = account_id.into();
+pub(crate) fn emit_balance_change(account_id: [u8; 32], address: Address, balance: u64) {
     let listeners = balance_listeners()
         .lock()
         .expect("Failed to lock balance_listeners: emit_balance_change()");
@@ -114,10 +113,9 @@ pub(crate) fn emit_balance_change(account_id: impl Into<String>, address: Addres
 /// Emits a transaction-related event.
 pub(crate) fn emit_transaction_event(
     event_type: TransactionEventType,
-    account_id: impl Into<String>,
+    account_id: [u8; 32],
     transaction_hash: Hash,
 ) {
-    let account_id = account_id.into();
     let listeners = transaction_listeners()
         .lock()
         .expect("Failed to lock balance_listeners: emit_balance_change()");
@@ -183,12 +181,12 @@ mod tests {
     #[test]
     fn balance_events() {
         on_balance_change(|event| {
-            assert!(event.account_id == "the account id");
+            assert!(event.account_id == [1; 32]);
             assert!(event.balance == 0);
         });
 
         emit_balance_change(
-            "the account id",
+            [1; 32],
             AddressBuilder::new()
                 .address(IotaAddress::from_ed25519_bytes(&[0; 32]))
                 .balance(0)

--- a/src/event.rs
+++ b/src/event.rs
@@ -103,7 +103,7 @@ pub(crate) fn emit_balance_change(account_id: [u8; 32], address: Address, balanc
         .expect("Failed to lock balance_listeners: emit_balance_change()");
     for listener in listeners.deref() {
         (listener.on_event)(BalanceEvent {
-            account_id: account_id.clone(),
+            account_id,
             address: address.clone(),
             balance,
         })
@@ -122,7 +122,7 @@ pub(crate) fn emit_transaction_event(
     for listener in listeners.deref() {
         if listener.event_type == event_type {
             (listener.on_event)(TransactionEvent {
-                account_id: account_id.clone(),
+                account_id,
                 transaction_hash: transaction_hash.clone(),
             })
         }

--- a/src/storage/sqlite.rs
+++ b/src/storage/sqlite.rs
@@ -49,7 +49,9 @@ impl StorageAdapter for SqliteStorageAdapter {
                     "SELECT value FROM {} WHERE key = ?1 LIMIT 1",
                     self.table_name
                 ),
-                vec![ToSqlOutput::Owned(Value::Text(id))],
+                vec![ToSqlOutput::Owned(Value::Text(
+                    String::from_utf8_lossy(&id).to_string(),
+                ))],
             ),
             AccountIdentifier::Index(index) => (
                 format!(
@@ -110,7 +112,11 @@ impl StorageAdapter for SqliteStorageAdapter {
                     "INSERT OR REPLACE INTO {} VALUES (?1, ?2, ?3)",
                     self.table_name
                 ),
-                params![id, account, Utc::now().timestamp()],
+                params![
+                    String::from_utf8_lossy(&id).to_string(),
+                    account,
+                    Utc::now().timestamp()
+                ],
             )
             .map_err(|_| anyhow::anyhow!("failed to insert data"))?;
         Ok(())
@@ -120,7 +126,7 @@ impl StorageAdapter for SqliteStorageAdapter {
         let (sql, params) = match account_id {
             AccountIdentifier::Id(id) => (
                 format!("DELETE FROM {} WHERE key = ?1", self.table_name),
-                vec![ToSqlOutput::Owned(Value::Text(id))],
+                vec![ToSqlOutput::Owned(Value::Text(String::from_utf8_lossy(&id).to_string()))],
             ),
             AccountIdentifier::Index(index) => (
                 format!(


### PR DESCRIPTION
# Description of change

Change the `AccountIdentifier` enum type Id to take a `[u8; 32]` instead of String so it aligns with the `Account` struct `id` type (simplifies usage from the front end). 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Unit tests, wallet backend nodejs binding.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have checked that new and existing unit tests pass locally with my changes
