### PR TITLE
fix(lib) updates for the new Message builder signature

### DIFF
--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -272,10 +272,11 @@ impl SyncedAccount {
             });
         let signed_transaction =
             signed_transaction_res.map_err(|e| anyhow::anyhow!(format!("{:?}", e)))?;
-        let message = IotaMessage::new()
+        let message = IotaMessage::builder()
             .tips(tips)
             .payload(Payload::SignedTransaction(Box::new(signed_transaction)))
-            .build()?;
+            .build()
+            .map_err(|e| anyhow::anyhow!(e.to_string()))?;
 
         let attached = client.post_messages(vec![message])?;
         let messages: Vec<Message> = client


### PR DESCRIPTION
# Description of change

bee-p changed the Message builder initialization from `Message::new()` to `Message::builder()`. 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Unit tests.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have checked that new and existing unit tests pass locally with my changes
