### PR TITLE
fix(stronghold) properly manage stronghold instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ In order to use the library you first need to create an `AccountManager`:
 use iota_wallet::account_manager::AccountManager;
 fn main() {
   let manager = AccountManager::new();
+  manager.set_stronghold_password("my-password").unwrap();
   // now you can create accounts with `manager.create_account`, synchronize, send transfers, backup...
 }
 ```

--- a/examples/account_operations.rs
+++ b/examples/account_operations.rs
@@ -5,6 +5,7 @@ use iota_wallet::{
 #[tokio::main]
 async fn main() -> iota_wallet::Result<()> {
     let manager = AccountManager::new();
+    manager.set_stronghold_password("password").unwrap();
 
     // first we'll create an example account and store it
     let client_options = ClientOptionsBuilder::node("https://nodes.devnet.iota.org:443")?.build();

--- a/examples/backup_and_restore.rs
+++ b/examples/backup_and_restore.rs
@@ -2,6 +2,7 @@ use iota_wallet::{account_manager::AccountManager, client::ClientOptionsBuilder}
 
 fn main() -> iota_wallet::Result<()> {
     let manager = AccountManager::new();
+    manager.set_stronghold_password("password").unwrap();
 
     // first we'll create an example account
     let client_options = ClientOptionsBuilder::node("https://nodes.devnet.iota.org:443")?.build();

--- a/examples/custom_storage.rs
+++ b/examples/custom_storage.rs
@@ -61,6 +61,7 @@ fn main() -> iota_wallet::Result<()> {
     // set the custom adapter
     set_adapter(MyStorage::new("./example-database/rocksdb")?)?;
     let manager = AccountManager::new();
+    manager.set_stronghold_password("password").unwrap();
 
     // first we'll create an example account
     let client_options = ClientOptionsBuilder::node("https://nodes.devnet.iota.org:443")?.build();

--- a/examples/transfer.rs
+++ b/examples/transfer.rs
@@ -5,6 +5,7 @@ use iota_wallet::{
 #[tokio::main]
 async fn main() -> iota_wallet::Result<()> {
     let manager = AccountManager::new();
+    manager.set_stronghold_password("password").unwrap();
 
     // first we'll create an example account and store it
     let client_options = ClientOptionsBuilder::node("https://nodes.devnet.iota.org:443")?.build();

--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -224,6 +224,7 @@ impl Account {
     ///  .expect("invalid node URL")
     ///  .build();
     /// let mut manager = AccountManager::new();
+    /// manager.set_stronghold_password("password").unwrap();
     /// let mut account = manager.create_account(client_options)
     ///   .initialise()
     ///   .expect("failed to add account");
@@ -301,12 +302,12 @@ pub struct InitialisedAccount<'a> {
 
 #[cfg(test)]
 mod tests {
-    use crate::account_manager::AccountManager;
     use crate::client::ClientOptionsBuilder;
 
     #[test]
     fn set_alias() {
-        let manager = AccountManager::new();
+        let manager = crate::test_utils::get_account_manager();
+
         let updated_alias = "updated alias";
         let client_options = ClientOptionsBuilder::node("https://nodes.devnet.iota.org:443")
             .expect("invalid node URL")

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -46,7 +46,7 @@ impl AccountManager {
             password.as_ref().to_string(),
             None,
         )?;
-        crate::init_stronghold(stronghold_path.to_path_buf(), stronghold);
+        crate::init_stronghold(stronghold_path, stronghold);
         Ok(())
     }
 

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -340,12 +340,12 @@ fn copy_dir<U: AsRef<Path>, V: AsRef<Path>>(from: U, to: V) -> Result<(), std::i
 
 #[cfg(test)]
 mod tests {
-    use super::AccountManager;
     use crate::client::ClientOptionsBuilder;
 
     #[test]
     fn store_accounts() {
-        let manager = AccountManager::new();
+        let manager = crate::test_utils::get_account_manager();
+
         let client_options = ClientOptionsBuilder::node("https://nodes.devnet.iota.org:443")
             .expect("invalid node URL")
             .build();

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -10,6 +10,7 @@ use std::thread;
 use std::time::Duration;
 
 use iota::transaction::prelude::Hash;
+use stronghold::Stronghold;
 
 /// The account manager.
 ///
@@ -34,6 +35,19 @@ impl AccountManager {
     /// Initialises a new instance of the account manager with the default storage adapter.
     pub fn new() -> Self {
         Default::default()
+    }
+
+    /// Sets the stronghold password.
+    pub fn set_stronghold_password<P: AsRef<str>>(&self, password: P) -> crate::Result<()> {
+        let stronghold_path = crate::storage::get_stronghold_snapshot_path();
+        let stronghold = Stronghold::new(
+            &stronghold_path,
+            !stronghold_path.exists(),
+            password.as_ref().to_string(),
+            None,
+        )?;
+        crate::init_stronghold(stronghold_path.to_path_buf(), stronghold);
+        Ok(())
     }
 
     /// Enables syncing through node events.
@@ -137,11 +151,11 @@ impl AccountManager {
         let storage_path = crate::storage::get_storage_path();
         if storage_path.exists() {
             let metadata = fs::metadata(&storage_path)?;
-            let backup_path = destination.as_ref().join("backup");
+            let backup_path = destination.as_ref().to_path_buf();
             if metadata.is_dir() {
                 copy_dir(storage_path, &backup_path)?;
             } else {
-                fs::create_dir_all(destination)?;
+                fs::create_dir_all(&destination)?;
                 fs::copy(storage_path, &backup_path)?;
             }
             Ok(backup_path)
@@ -152,14 +166,25 @@ impl AccountManager {
 
     /// Import backed up accounts.
     pub fn import_accounts<P: AsRef<Path>>(&self, source: P) -> crate::Result<()> {
-        let storage = crate::storage::get_adapter()?;
-        let backup_storage = crate::storage::get_adapter_from_path(&source)?;
+        let backup_stronghold_path = source
+            .as_ref()
+            .join(crate::storage::stronghold_snapshot_filename());
+        let backup_stronghold = stronghold::Stronghold::new(
+            &backup_stronghold_path,
+            false,
+            "password".to_string(),
+            None,
+        )?;
+        crate::init_stronghold(backup_stronghold_path.clone(), backup_stronghold);
 
+        let backup_storage = crate::storage::get_adapter_from_path(&source)?;
         let accounts = backup_storage.get_all()?;
         let accounts = crate::storage::parse_accounts(&accounts)?;
 
+        let storage = crate::storage::get_adapter()?;
         let stored_accounts = storage.get_all()?;
         let stored_accounts = crate::storage::parse_accounts(&stored_accounts)?;
+
         let already_imported_account = stored_accounts.iter().find(|stored_account| {
             stored_account.addresses().iter().any(|stored_address| {
                 accounts.iter().any(|account| {
@@ -178,9 +203,7 @@ impl AccountManager {
         }
 
         let backup_stronghold = stronghold::Stronghold::new(
-            source
-                .as_ref()
-                .join(crate::storage::stronghold_snapshot_filename()),
+            &backup_stronghold_path,
             false,
             "password".to_string(),
             None,
@@ -202,6 +225,7 @@ impl AccountManager {
                 serde_json::to_string(&account)?,
             )?;
         }
+        crate::remove_stronghold(backup_stronghold_path);
         Ok(())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ static STRONGHOLD_INSTANCE: OnceCell<Arc<Mutex<HashMap<PathBuf, Stronghold>>>> =
 
 pub(crate) fn init_stronghold(stronghold_path: PathBuf, stronghold: Stronghold) {
     let mut stronghold_map = STRONGHOLD_INSTANCE
-        .get_or_init(|| Default::default())
+        .get_or_init(Default::default)
         .lock()
         .unwrap();
     stronghold_map.insert(stronghold_path, stronghold);
@@ -40,7 +40,7 @@ pub(crate) fn init_stronghold(stronghold_path: PathBuf, stronghold: Stronghold) 
 
 pub(crate) fn remove_stronghold(stronghold_path: PathBuf) {
     let mut stronghold_map = STRONGHOLD_INSTANCE
-        .get_or_init(|| Default::default())
+        .get_or_init(Default::default)
         .lock()
         .unwrap();
     stronghold_map.remove(&stronghold_path);
@@ -55,7 +55,7 @@ pub(crate) fn with_stronghold_from_path<T, F: FnOnce(&Stronghold) -> T>(
     cb: F,
 ) -> T {
     let stronghold_map = STRONGHOLD_INSTANCE
-        .get_or_init(|| Default::default())
+        .get_or_init(Default::default)
         .lock()
         .unwrap();
     if let Some(stronghold) = stronghold_map.get(path) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,3 +64,18 @@ pub(crate) fn with_stronghold_from_path<T, F: FnOnce(&Stronghold) -> T>(
         panic!("should initialize stronghold instance before using it")
     }
 }
+
+#[cfg(test)]
+mod test_utils {
+    use super::account_manager::AccountManager;
+    use once_cell::sync::OnceCell;
+
+    static MANAGER_INSTANCE: OnceCell<AccountManager> = OnceCell::new();
+    pub fn get_account_manager() -> &'static AccountManager {
+        MANAGER_INSTANCE.get_or_init(|| {
+            let manager = AccountManager::new();
+            manager.set_stronghold_password("password").unwrap();
+            manager
+        })
+    }
+}


### PR DESCRIPTION
# Description of change

Currently the stronghold storage adapter uses a singleton as stronghold instance. This is an issue when using the `import_accounts` feature, since we need to use a stronghold instance pointing to the backup's snapshot file instead of the current app instance. This PR changes the singleton to manage a HashMap instead, so we can use multiple singleton instances based on the snapshot path.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Unit tests, `backup and import` test from new-wallet.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked that new and existing unit tests pass locally with my changes
