### PR TITLE
fix(ci): Use env files for setting env vars

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -27,7 +27,7 @@ jobs:
         override: true
 
     - name: Get current date
-      run: echo "::set-env name=CURRENT_DATE::$(date +'%Y-%m-%d')"
+      run: echo "CURRENT_DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
 
     - name: Cache cargo registry
       uses: actions/cache@v2


### PR DESCRIPTION
# Description of change

The `set-env` command is now deprecated (see [GitHub blog](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/))

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Workflow functions correctly

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code