### PR TITLE
feat(lib) add error types, implement global error handler

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
+thiserror = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
 getset = "0.1"
 serde = { version = "1.0", features = ["derive"] }

--- a/examples/custom_storage.rs
+++ b/examples/custom_storage.rs
@@ -29,15 +29,15 @@ fn account_id_value(account_id: AccountIdentifier) -> anyhow::Result<String> {
 }
 
 impl StorageAdapter for MyStorage {
-    fn get(&self, account_id: AccountIdentifier) -> anyhow::Result<String> {
+    fn get(&self, account_id: AccountIdentifier) -> iota_wallet::Result<String> {
         match self.db.get(account_id_value(account_id)?) {
             Ok(Some(value)) => Ok(String::from_utf8(value).unwrap()),
-            Ok(None) => Err(anyhow::anyhow!("Value not found")),
-            Err(e) => Err(anyhow::anyhow!("operational problem encountered: {}", e)),
+            Ok(None) => Err(anyhow::anyhow!("Value not found").into()),
+            Err(e) => Err(anyhow::anyhow!("operational problem encountered: {}", e).into()),
         }
     }
 
-    fn get_all(&self) -> anyhow::Result<std::vec::Vec<String>> {
+    fn get_all(&self) -> iota_wallet::Result<std::vec::Vec<String>> {
         let mut accounts = vec![];
         let iter = self.db.iterator(IteratorMode::Start);
         for (_, value) in iter {
@@ -46,13 +46,17 @@ impl StorageAdapter for MyStorage {
         Ok(accounts)
     }
 
-    fn set(&self, account_id: AccountIdentifier, account: String) -> anyhow::Result<()> {
-        self.db.put(account_id_value(account_id)?, account)?;
+    fn set(&self, account_id: AccountIdentifier, account: String) -> iota_wallet::Result<()> {
+        self.db
+            .put(account_id_value(account_id)?, account)
+            .map_err(|e| iota_wallet::WalletError::UnknownError(e.to_string()))?;
         Ok(())
     }
 
-    fn remove(&self, account_id: AccountIdentifier) -> anyhow::Result<()> {
-        self.db.delete(account_id_value(account_id)?)?;
+    fn remove(&self, account_id: AccountIdentifier) -> iota_wallet::Result<()> {
+        self.db
+            .delete(account_id_value(account_id)?)
+            .map_err(|e| iota_wallet::WalletError::UnknownError(e.to_string()))?;
         Ok(())
     }
 }

--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -117,7 +117,7 @@ impl AccountInitialiser {
         if let Some(latest_account) = accounts.last() {
             let latest_account: Account = serde_json::from_str(&latest_account)?;
             if latest_account.messages().is_empty() && latest_account.total_balance() == 0 {
-                return Err(anyhow::anyhow!("can't create accounts when the latest account doesn't have message history and balance"));
+                return Err(crate::WalletError::LatestAccountIsEmpty);
             }
         }
 

--- a/src/account/sync/input_selection.rs
+++ b/src/account/sync/input_selection.rs
@@ -7,7 +7,7 @@ pub fn select_input(target: u64, available_utxos: &mut [Address]) -> crate::Resu
             .iter()
             .fold(0, |acc, address| acc + address.balance())
     {
-        return Err(anyhow::anyhow!("insufficient funds"));
+        return Err(crate::WalletError::InsufficientFunds);
     }
 
     available_utxos.sort_by(|a, b| b.balance().cmp(a.balance()));

--- a/src/address.rs
+++ b/src/address.rs
@@ -107,8 +107,11 @@ pub(crate) fn get_iota_address(
         let address_str =
             stronghold.address_get(account_id, Some(account_index), address_index, internal)?;
         let address_ed25519 = Vec::from_base32(&bech32::decode(&address_str)?.1)?;
-        let iota_address =
-            IotaAddress::Ed25519(Ed25519Address::new(address_ed25519[1..].try_into()?));
+        let iota_address = IotaAddress::Ed25519(Ed25519Address::new(
+            address_ed25519[1..]
+                .try_into()
+                .map_err(|_| crate::WalletError::InvalidAddressLength)?,
+        ));
         Ok(iota_address)
     })
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -165,7 +165,7 @@ impl MultiNodeClientOptionsBuilder {
             None => 0,
         };
         if node_len == 0 {
-            return Err(anyhow::anyhow!("Empty node list"));
+            return Err(crate::WalletError::EmptyNodeList);
         }
         let options = ClientOptions {
             node: None,

--- a/src/event.rs
+++ b/src/event.rs
@@ -45,6 +45,11 @@ struct BalanceEventHandler {
     on_event: Box<dyn Fn(BalanceEvent) + Send>,
 }
 
+struct ErrorHandler {
+    /// The on error callback.
+    on_error: Box<dyn Fn(&crate::WalletError) + Send>,
+}
+
 #[derive(PartialEq)]
 pub(crate) enum TransactionEventType {
     NewTransaction,
@@ -67,6 +72,7 @@ type BalanceListeners = Arc<Mutex<Vec<BalanceEventHandler>>>;
 type TransactionListeners = Arc<Mutex<Vec<TransactionEventHandler>>>;
 type TransactionConfirmationChangeListeners =
     Arc<Mutex<Vec<TransactionConfirmationChangeEventHandler>>>;
+type ErrorListeners = Arc<Mutex<Vec<ErrorHandler>>>;
 
 /// Gets the balance change listeners array.
 fn balance_listeners() -> &'static BalanceListeners {
@@ -83,6 +89,12 @@ fn transaction_listeners() -> &'static TransactionListeners {
 /// Gets the transaction confirmation change listeners array.
 fn transaction_confirmation_change_listeners() -> &'static TransactionConfirmationChangeListeners {
     static LISTENERS: Lazy<TransactionConfirmationChangeListeners> = Lazy::new(Default::default);
+    &LISTENERS
+}
+
+/// Gets the balance change listeners array.
+fn error_listeners() -> &'static ErrorListeners {
+    static LISTENERS: Lazy<ErrorListeners> = Lazy::new(Default::default);
     &LISTENERS
 }
 
@@ -170,14 +182,46 @@ pub fn on_broadcast<F: Fn(TransactionEvent) + Send + 'static>(cb: F) {
     add_transaction_listener(TransactionEventType::Broadcast, cb);
 }
 
+pub(crate) fn emit_error(error: &crate::WalletError) {
+    let listeners = error_listeners()
+        .lock()
+        .expect("Failed to lock error_listeners: emit_error()");
+    for listener in listeners.deref() {
+        (listener.on_error)(&error)
+    }
+}
+
 /// Listen to errors.
-pub fn on_error<F: Fn(anyhow::Error)>(cb: F) {}
+pub fn on_error<F: Fn(&crate::WalletError) + Send + 'static>(cb: F) {
+    let mut l = error_listeners()
+        .lock()
+        .expect("Failed to lock error_listeners: on_error()");
+    l.push(ErrorHandler {
+        on_error: Box::new(cb),
+    })
+}
 
 #[cfg(test)]
 mod tests {
-    use super::{emit_balance_change, on_balance_change};
+    use super::{emit_balance_change, on_balance_change, on_error};
     use crate::address::{AddressBuilder, IotaAddress};
     use iota::message::prelude::Ed25519Address;
+
+    fn _create_and_drop_error() {
+        let _ = crate::WalletError::GenericError(anyhow::anyhow!("generic error"));
+    }
+
+    #[test]
+    fn error_events() {
+        on_error(|error| {
+            let r = match error {
+                crate::WalletError::GenericError(_) => true,
+                _ => false,
+            };
+            assert!(r);
+        });
+        _create_and_drop_error();
+    }
 
     #[test]
     fn balance_events() {

--- a/src/event.rs
+++ b/src/event.rs
@@ -214,11 +214,7 @@ mod tests {
     #[test]
     fn error_events() {
         on_error(|error| {
-            let r = match error {
-                crate::WalletError::GenericError(_) => true,
-                _ => false,
-            };
-            assert!(r);
+            assert!(matches!(error, crate::WalletError::GenericError(_)));
         });
         _create_and_drop_error();
     }

--- a/src/storage/sqlite.rs
+++ b/src/storage/sqlite.rs
@@ -93,14 +93,10 @@ impl StorageAdapter for SqliteStorageAdapter {
         Ok(accounts)
     }
 
-    fn set(
-        &self,
-        account_id: AccountIdentifier,
-        account: String,
-    ) -> std::result::Result<(), anyhow::Error> {
+    fn set(&self, account_id: AccountIdentifier, account: String) -> crate::Result<()> {
         let id = match account_id {
             AccountIdentifier::Id(id) => id,
-            _ => return Err(anyhow::anyhow!("only Id is supported")),
+            _ => return Err(anyhow::anyhow!("only Id is supported").into()),
         };
         let connection = self
             .connection
@@ -122,7 +118,7 @@ impl StorageAdapter for SqliteStorageAdapter {
         Ok(())
     }
 
-    fn remove(&self, account_id: AccountIdentifier) -> std::result::Result<(), anyhow::Error> {
+    fn remove(&self, account_id: AccountIdentifier) -> crate::Result<()> {
         let (sql, params) = match account_id {
             AccountIdentifier::Id(id) => (
                 format!("DELETE FROM {} WHERE key = ?1", self.table_name),


### PR DESCRIPTION
# Description of change

Use `thiserror` to have error types (useful for the UI) and implement the global error handler (global listeners). When the error variable is dropped (out of scope) the error listeners are notified.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

I've added a unit test.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
