### PR TITLE
refactor(storage) enable different storage instances per AccountManager

### DIFF
--- a/examples/account_operations.rs
+++ b/examples/account_operations.rs
@@ -4,7 +4,7 @@ use iota_wallet::{
 
 #[tokio::main]
 async fn main() -> iota_wallet::Result<()> {
-    let manager = AccountManager::new();
+    let manager = AccountManager::new().unwrap();
     manager.set_stronghold_password("password").unwrap();
 
     // first we'll create an example account and store it
@@ -15,7 +15,7 @@ async fn main() -> iota_wallet::Result<()> {
         .initialise()?;
 
     // update alias
-    account.set_alias("the new alias")?;
+    manager.set_alias(account.id().into(), "the new alias")?;
     // list unspent addresses
     let _ = account.list_addresses(false);
     // list spent addresses

--- a/examples/backup_and_restore.rs
+++ b/examples/backup_and_restore.rs
@@ -1,7 +1,7 @@
 use iota_wallet::{account_manager::AccountManager, client::ClientOptionsBuilder};
 
 fn main() -> iota_wallet::Result<()> {
-    let manager = AccountManager::new();
+    let manager = AccountManager::new().unwrap();
     manager.set_stronghold_password("password").unwrap();
 
     // first we'll create an example account

--- a/examples/custom_storage.rs
+++ b/examples/custom_storage.rs
@@ -1,9 +1,7 @@
 ///! An example of using a custom storage adapter (in this case, using rocksdb).
 use iota_wallet::{
-    account::AccountIdentifier,
-    account_manager::AccountManager,
-    client::ClientOptionsBuilder,
-    storage::{set_adapter, StorageAdapter},
+    account::AccountIdentifier, account_manager::AccountManager, client::ClientOptionsBuilder,
+    storage::StorageAdapter,
 };
 use rocksdb::{IteratorMode, DB};
 use std::path::Path;
@@ -62,9 +60,11 @@ impl StorageAdapter for MyStorage {
 }
 
 fn main() -> iota_wallet::Result<()> {
-    // set the custom adapter
-    set_adapter(MyStorage::new("./example-database/rocksdb")?)?;
-    let manager = AccountManager::new();
+    let manager = AccountManager::with_storage_adapter(
+        "./example-database/rocksdb",
+        MyStorage::new("./example-database/rocksdb")?,
+    )
+    .unwrap();
     manager.set_stronghold_password("password").unwrap();
 
     // first we'll create an example account

--- a/examples/transfer.rs
+++ b/examples/transfer.rs
@@ -4,7 +4,7 @@ use iota_wallet::{
 
 #[tokio::main]
 async fn main() -> iota_wallet::Result<()> {
-    let manager = AccountManager::new();
+    let manager = AccountManager::new().unwrap();
     manager.set_stronghold_password("password").unwrap();
 
     // first we'll create an example account and store it

--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -192,7 +192,7 @@ impl Account {
     }
 
     /// Returns the builder to setup the process to synchronize this account with the Tangle.
-    pub(crate) fn sync<'a>(&'a mut self) -> AccountSynchronizer<'a> {
+    pub(crate) fn sync(&'_ mut self) -> AccountSynchronizer<'_> {
         AccountSynchronizer::new(self, self.storage_path.clone())
     }
 

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -16,6 +16,8 @@ use std::time::Duration;
 use iota::message::prelude::MessageId;
 use stronghold::Stronghold;
 
+const DEFAULT_STORAGE_PATH: &str = "./example-database";
+
 /// The account manager.
 ///
 /// Used to manage multiple accounts.
@@ -42,7 +44,7 @@ fn mutate_account_transaction<F: FnOnce(&Account, &mut Vec<Message>)>(
 impl AccountManager {
     /// Initialises a new instance of the account manager with the default storage adapter.
     pub fn new() -> crate::Result<Self> {
-        Self::with_storage_path("./example-database")
+        Self::with_storage_path(DEFAULT_STORAGE_PATH)
     }
 
     /// Initialises a new instance of the account manager with the default storage adapter using the specified storage path.
@@ -76,7 +78,7 @@ impl AccountManager {
             password.as_ref().to_string(),
             None,
         )?;
-        crate::init_stronghold(self.storage_path.clone(), stronghold);
+        crate::init_stronghold(&self.storage_path, stronghold);
         Ok(())
     }
 
@@ -230,7 +232,7 @@ impl AccountManager {
             "password".to_string(),
             None,
         )?;
-        crate::init_stronghold(backup_stronghold_path.clone(), backup_stronghold);
+        crate::init_stronghold(&backup_stronghold_path, backup_stronghold);
 
         let backup_storage = crate::storage::get_adapter_from_path(&source)?;
         let accounts = backup_storage.get_all()?;

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -83,12 +83,13 @@ impl AccountManager {
     }
 
     /// Enables syncing through node events.
-    pub fn sync_through_events(&'static self) {
+    pub fn sync_through_events(&self) {
+        let storage_path = self.storage_path.clone();
         // sync confirmation state changes
         crate::event::on_confirmation_state_change(move |event| {
             if *event.confirmed() {
                 let _ = mutate_account_transaction(
-                    &self.storage_path,
+                    &storage_path,
                     event.account_id().clone().into(),
                     |_, transactions| {
                         if let Some(message) = transactions
@@ -102,9 +103,10 @@ impl AccountManager {
             }
         });
 
+        let storage_path = self.storage_path.clone();
         crate::event::on_broadcast(move |event| {
             let _ = mutate_account_transaction(
-                &self.storage_path,
+                &storage_path,
                 event.account_id().clone().into(),
                 |_, transactions| {
                     if let Some(message) = transactions
@@ -117,10 +119,11 @@ impl AccountManager {
             );
         });
 
+        let storage_path = self.storage_path.clone();
         crate::event::on_new_transaction(move |event| {
             let message_id = *event.message_id();
             let _ = mutate_account_transaction(
-                &self.storage_path,
+                &storage_path,
                 event.account_id().clone().into(),
                 |account, messages| {
                     let mut rt =
@@ -136,10 +139,11 @@ impl AccountManager {
     }
 
     /// Starts the polling mechanism.
-    pub fn start_polling(&'static self) {
+    pub fn start_polling(&self) {
+        let storage_path = self.storage_path.clone();
         thread::spawn(move || async move {
             loop {
-                let _ = poll(self.storage_path.clone());
+                let _ = poll(storage_path.clone());
                 thread::sleep(Duration::from_secs(5));
             }
         });

--- a/src/event.rs
+++ b/src/event.rs
@@ -230,17 +230,21 @@ mod tests {
     use super::{emit_balance_change, on_balance_change, on_error};
     use crate::address::{AddressBuilder, IotaAddress};
     use iota::message::prelude::Ed25519Address;
+    use rusty_fork::rusty_fork_test;
 
     fn _create_and_drop_error() {
         let _ = crate::WalletError::GenericError(anyhow::anyhow!("generic error"));
     }
 
-    #[test]
-    fn error_events() {
-        on_error(|error| {
-            assert!(matches!(error, crate::WalletError::GenericError(_)));
-        });
-        _create_and_drop_error();
+    // have to fork this test so other errors dropped doesn't affect it
+    rusty_fork_test! {
+        #[test]
+        fn error_events() {
+            on_error(|error| {
+                assert!(matches!(error, crate::WalletError::GenericError(_)));
+            });
+            _create_and_drop_error();
+        }
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,12 +198,12 @@ impl Drop for WalletError {
     }
 }
 
-pub(crate) fn init_stronghold(stronghold_path: PathBuf, stronghold: Stronghold) {
+pub(crate) fn init_stronghold(stronghold_path: &PathBuf, stronghold: Stronghold) {
     let mut stronghold_map = STRONGHOLD_INSTANCE
         .get_or_init(Default::default)
         .lock()
         .unwrap();
-    stronghold_map.insert(stronghold_path, stronghold);
+    stronghold_map.insert(stronghold_path.to_path_buf(), stronghold);
 }
 
 pub(crate) fn remove_stronghold(stronghold_path: PathBuf) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,10 +214,6 @@ pub(crate) fn remove_stronghold(stronghold_path: PathBuf) {
     stronghold_map.remove(&stronghold_path);
 }
 
-pub(crate) fn with_stronghold<T, F: FnOnce(&Stronghold) -> T>(cb: F) -> T {
-    with_stronghold_from_path(&crate::storage::get_stronghold_snapshot_path(), cb)
-}
-
 pub(crate) fn with_stronghold_from_path<T, F: FnOnce(&Stronghold) -> T>(
     path: &PathBuf,
     cb: F,
@@ -242,12 +238,11 @@ mod test_utils {
 
     static MANAGER_INSTANCE: OnceCell<AccountManager> = OnceCell::new();
     pub fn get_account_manager() -> &'static AccountManager {
-        let storage_path: String = thread_rng().gen_ascii_chars().take(10).collect();
-        let storage_path = PathBuf::from(format!("./example-database/{}", storage_path));
-        crate::storage::set_storage_path(&storage_path).unwrap();
-
         MANAGER_INSTANCE.get_or_init(|| {
-            let manager = AccountManager::new();
+            let storage_path: String = thread_rng().gen_ascii_chars().take(10).collect();
+            let storage_path = PathBuf::from(format!("./example-database/{}", storage_path));
+
+            let manager = AccountManager::with_storage_path(storage_path).unwrap();
             manager.set_stronghold_password("password").unwrap();
             manager
         })

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -28,7 +28,6 @@ pub(crate) fn stronghold_snapshot_filename() -> &'static str {
 }
 
 /// gets the storage adapter
-#[allow(clippy::borrowed_box)]
 pub(crate) fn with_adapter<T, F: FnOnce(&Storage) -> T>(storage_path: &PathBuf, cb: F) -> T {
     let instances = INSTANCES.get_or_init(Default::default).lock().unwrap();
     if let Some(instance) = instances.get(storage_path) {

--- a/src/storage/stronghold.rs
+++ b/src/storage/stronghold.rs
@@ -18,9 +18,7 @@ impl StrongholdStorageAdapter {
     /// Initialises the storage adapter.
     pub fn new<P: AsRef<Path>>(path: P) -> crate::Result<Self> {
         Ok(Self {
-            path: path
-                .as_ref()
-                .join(crate::storage::stronghold_snapshot_filename()),
+            path: path.as_ref().to_path_buf(),
         })
     }
 }


### PR DESCRIPTION
# Description of change

In the future, the wallet will need to support management of multiple stronghold snapshots. In order to do that, I've removed the current `OnceCell` StorageAdapter global singleton, and made it a HashMap keyed by the path to the storage file. The key is held by an AccountManager instance and used across the library to get access to the storage adapter.

## Type of change

- Refactor

## How the change has been tested

Unit tests.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have checked that new and existing unit tests pass locally with my changes
