### PR TITLE
fix(lib) AccountManager shouldn't derive Default

### DIFF
--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -21,7 +21,6 @@ const DEFAULT_STORAGE_PATH: &str = "./example-database";
 /// The account manager.
 ///
 /// Used to manage multiple accounts.
-#[derive(Default)]
 pub struct AccountManager {
     storage_path: PathBuf,
 }


### PR DESCRIPTION
# Description of change

`Default` derivation on AccountManager makes the storage_path field default to `""` and skips the initialisation process, which leads to issues all around.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
