### PR TITLE
fix(manager) `import_accounts` regression on `init_stronghold` call

### DIFF
--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -235,7 +235,7 @@ impl AccountManager {
             "password".to_string(),
             None,
         )?;
-        crate::init_stronghold(&backup_stronghold_path, backup_stronghold);
+        crate::init_stronghold(&source.as_ref().to_path_buf(), backup_stronghold);
 
         let backup_storage = crate::storage::get_adapter_from_path(&source)?;
         let accounts = backup_storage.get_all()?;


### PR DESCRIPTION
# Description of change

The `init_stronghold` function was changed to take the path to the folder of the stronghold snapshot and not the full path. The `import_accounts` was calling it with the full path. 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Unit tests from the #18 PR.

