### PR TITLE
fix(account) default alias should be `Account $index`

### DIFF
--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -109,13 +109,14 @@ impl<'a> AccountInitialiser<'a> {
 
     /// Initialises the account.
     pub fn initialise(self) -> crate::Result<Account> {
-        let alias = self.alias.unwrap_or_else(|| "".to_string());
+        let accounts =
+            crate::storage::with_adapter(self.storage_path, |storage| storage.get_all())?;
+        let alias = self
+            .alias
+            .unwrap_or_else(|| format!("Account {}", accounts.len()));
         let created_at = self.created_at.unwrap_or_else(chrono::Utc::now);
         let created_at_timestamp: u128 = created_at.timestamp().try_into().unwrap(); // safe to unwrap since it's > 0
         let mnemonic = self.mnemonic;
-
-        let accounts =
-            crate::storage::with_adapter(self.storage_path, |storage| storage.get_all())?;
 
         if let Some(latest_account) = accounts.last() {
             let latest_account: Account = serde_json::from_str(&latest_account)?;


### PR DESCRIPTION
# Description of change

Right now the account default alias is incorrectly set to an empty string but it should be `Account $index`. 

## Links to any relevant issues

https://github.com/iotaledger/new-wallet/issues/20

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Manual test.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
