### PR TITLE
fix(account) account discovery process returning LatestAccountIsEmpty, closes #81

### DIFF
--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -118,10 +118,13 @@ impl<'a> AccountInitialiser<'a> {
         let created_at_timestamp: u128 = created_at.timestamp().try_into().unwrap(); // safe to unwrap since it's > 0
         let mnemonic = self.mnemonic;
 
-        if let Some(latest_account) = accounts.last() {
-            let latest_account: Account = serde_json::from_str(&latest_account)?;
-            if latest_account.messages().is_empty() && latest_account.total_balance() == 0 {
-                return Err(crate::WalletError::LatestAccountIsEmpty);
+        // check for empty latest account only when not skipping persistance (account discovery process)
+        if !self.skip_persistance {
+            if let Some(latest_account) = accounts.last() {
+                let latest_account: Account = serde_json::from_str(&latest_account)?;
+                if latest_account.messages().is_empty() && latest_account.total_balance() == 0 {
+                    return Err(crate::WalletError::LatestAccountIsEmpty);
+                }
             }
         }
 


### PR DESCRIPTION
# Description of change

When discovering accounts as part of the syncing process, the account initialiser shouldn't check for latest account empty. 

## Links to any relevant issues

#81

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Manually.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked that new and existing unit tests pass locally with my changes
