### PR TITLE
fix(transfer) address field should be the bech32 string instead of Address type

### DIFF
--- a/examples/transfer.rs
+++ b/examples/transfer.rs
@@ -19,7 +19,7 @@ async fn main() -> iota_wallet::Result<()> {
     let sync_account = sync_accounts.first().unwrap();
     sync_account
         .transfer(Transfer::new(
-            account.latest_address().unwrap().clone(),
+            account.latest_address().unwrap().address().clone(),
             150,
         ))
         .await?;

--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -1,5 +1,5 @@
 use crate::account::{Account, AccountIdentifier};
-use crate::address::{Address, AddressBuilder};
+use crate::address::{Address, AddressBuilder, IotaAddress};
 use crate::client::get_client;
 use crate::message::{Message, Transfer};
 
@@ -327,13 +327,13 @@ impl SyncedAccount {
         &self,
         threshold: u64,
         account: &'a Account,
-        address: &'a Address,
+        address: &'a IotaAddress,
     ) -> crate::Result<(Vec<Address>, Option<&'a Address>)> {
         let mut available_addresses: Vec<Address> = account
             .addresses()
             .iter()
             .cloned()
-            .filter(|a| a != address && *a.balance() > 0)
+            .filter(|a| a.address() != address && *a.balance() > 0)
             .collect();
         let addresses = input_selection::select_input(threshold, &mut available_addresses)?;
         let remainder = if addresses.iter().fold(0, |acc, a| acc + a.balance()) > threshold {

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -202,7 +202,7 @@ impl AccountManager {
             .clone();
         let from_synchronized = from_account.sync().execute().await?;
         from_synchronized
-            .transfer(Transfer::new(to_address, amount))
+            .transfer(Transfer::new(to_address.address().clone(), amount))
             .await
     }
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,4 +1,4 @@
-use crate::address::Address;
+use crate::address::{Address, IotaAddress};
 use chrono::prelude::{DateTime, Utc};
 use getset::{Getters, Setters};
 use iota::message::{
@@ -48,7 +48,8 @@ pub struct Transfer {
     /// The transfer value.
     amount: u64,
     /// The transfer address.
-    address: Address,
+    #[serde(with = "crate::serde::iota_address_serde")]
+    address: IotaAddress,
     /// (Optional) transfer data.
     #[getset(set = "pub")]
     data: Option<String>,
@@ -56,7 +57,7 @@ pub struct Transfer {
 
 impl Transfer {
     /// Initialises a new transfer to the given address.
-    pub fn new(address: Address, amount: u64) -> Self {
+    pub fn new(address: IotaAddress, amount: u64) -> Self {
         Self {
             address,
             amount,


### PR DESCRIPTION
# Description of change

Changes the Transfer's `address` from `crate::address::Address` to `iota::message::prelude::Address` (deserialized from bech32 string), following the spec.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
