### PR TITLE
feat(lib) serialize/deserialize MessageId as hex string, closes #98

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ rand = "0.3"
 rusqlite = { version = "0.23", features = ["bundled"], optional = true }
 slip10 = "0.4"
 bech32 = "0.7"
+hex = "0.4"
 
 # stronghold
 iota-stronghold = { git = "https://github.com/iotaledger/stronghold.rs", branch = "feat/refactoring", optional = true }

--- a/src/event.rs
+++ b/src/event.rs
@@ -27,7 +27,7 @@ pub struct TransactionEvent {
     #[serde(rename = "accountId")]
     /// The associated account identifier.
     account_id: [u8; 32],
-    #[serde(rename = "messageId")]
+    #[serde(rename = "messageId", with = "crate::serde::message_id_serde")]
     /// The event transaction hash.
     message_id: MessageId,
 }
@@ -39,7 +39,7 @@ pub struct TransactionConfirmationChangeEvent {
     #[serde(rename = "accountId")]
     /// The associated account identifier.
     account_id: [u8; 32],
-    #[serde(rename = "messageId")]
+    #[serde(rename = "messageId", with = "crate::serde::message_id_serde")]
     /// The event transaction hash.
     message_id: MessageId,
     /// The confirmed state of the transaction.

--- a/src/message.rs
+++ b/src/message.rs
@@ -136,12 +136,15 @@ impl Value {
 #[getset(get = "pub", set = "pub(crate)")]
 pub struct Message {
     /// The message identifier.
+    #[serde(with = "crate::serde::message_id_serde")]
     pub(crate) id: MessageId,
     /// The message version.
     pub(crate) version: u64,
     /// Message id of the first message this message refers to.
+    #[serde(with = "crate::serde::message_id_serde")]
     pub(crate) trunk: MessageId,
     /// Message id of the second message this message refers to.
+    #[serde(with = "crate::serde::message_id_serde")]
     pub(crate) branch: MessageId,
     /// Length of the payload.
     #[serde(rename = "payloadLength")]

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -51,6 +51,46 @@ pub(crate) mod iota_address_serde {
     }
 }
 
+pub(crate) mod message_id_serde {
+    use iota::message::prelude::MessageId;
+    use serde::{
+        de::{Error as DeError, Visitor},
+        Deserializer, Serializer,
+    };
+    use std::convert::TryInto;
+
+    pub fn serialize<S: Serializer>(id: &MessageId, s: S) -> std::result::Result<S::Ok, S::Error> {
+        s.serialize_str(&id.to_string())
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<MessageId, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct MessageIdVisitor;
+        impl<'de> Visitor<'de> for MessageIdVisitor {
+            type Value = MessageId;
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("a message id as hex string")
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                let decoded = hex::decode(v).map_err(|e| DeError::custom(e.to_string()))?;
+                let id = MessageId::new(
+                    decoded[..]
+                        .try_into()
+                        .map_err(|_| DeError::custom("invalid serialized message id length"))?,
+                );
+                Ok(id)
+            }
+        }
+        deserializer.deserialize_str(MessageIdVisitor)
+    }
+}
+
 impl serde::Serialize for crate::WalletError {
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
     where


### PR DESCRIPTION
# Description of change

MessageId serde as hex string is better for readability and for quick checks with the node API. 

## Links to any relevant issues

#98 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Manually ser/de

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have checked that new and existing unit tests pass locally with my changes
