### PR TITLE
fix(wallet) `latest_address` and `change_address` usage, closes #110

### DIFF
--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -197,7 +197,10 @@ pub struct Account {
 impl Account {
     /// Returns the most recent address of the account.
     pub fn latest_address(&self) -> Option<&Address> {
-        self.addresses.iter().max_by_key(|a| a.key_index())
+        self.addresses
+            .iter()
+            .filter(|a| !a.internal())
+            .max_by_key(|a| a.key_index())
     }
 
     /// Returns the builder to setup the process to synchronize this account with the Tangle.
@@ -232,7 +235,6 @@ impl Account {
                 };
                 acc + val
             });
-        println!("total: {}, spent: {}", total_balance, spent);
         total_balance - (spent as u64)
     }
 
@@ -325,7 +327,7 @@ impl Account {
 
     /// Gets a new unused address and links it to this account.
     pub async fn generate_address(&mut self) -> crate::Result<Address> {
-        let address = crate::address::get_new_address(&self, false).await?;
+        let address = crate::address::get_new_address(&self)?;
         self.addresses.push(address.clone());
         crate::storage::with_adapter(&self.storage_path, |storage| {
             storage.set(self.id.into(), serde_json::to_string(self)?)

--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -375,7 +375,7 @@ impl SyncedAccount {
 
         // select the input addresses and check if a remainder address is needed
         let (input_addresses, remainder_address) =
-            self.select_inputs(*transfer_obj.amount(), &mut account, transfer_obj.address())?;
+            self.select_inputs(*transfer_obj.amount(), &account, transfer_obj.address())?;
 
         let mut utxos = vec![];
         let mut output_paths = vec![];

--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -47,29 +47,37 @@ async fn sync_addresses(
     let mut generated_addresses = vec![];
     let mut found_messages = vec![];
     loop {
-        let mut generated_iota_addresses = vec![];
+        let mut generated_iota_addresses = vec![]; // collection of (address_index, internal, address) pairs
         for i in address_index..(address_index + gap_limit) {
             // generate both `public` and `internal (change)` addresses
-            generated_iota_addresses.push(crate::address::get_iota_address(
-                &storage_path,
-                account.id(),
-                account_index,
+            generated_iota_addresses.push((
                 i,
                 false,
-            )?);
-            generated_iota_addresses.push(crate::address::get_iota_address(
-                &storage_path,
-                account.id(),
-                account_index,
+                crate::address::get_iota_address(
+                    &storage_path,
+                    account.id(),
+                    account_index,
+                    i,
+                    false,
+                )?,
+            ));
+            generated_iota_addresses.push((
                 i,
                 true,
-            )?);
+                crate::address::get_iota_address(
+                    &storage_path,
+                    account.id(),
+                    account_index,
+                    i,
+                    true,
+                )?,
+            ));
         }
 
         let mut curr_generated_addresses = vec![];
         let mut curr_found_messages = vec![];
 
-        for iota_address in &generated_iota_addresses {
+        for (iota_address_index, iota_address_internal, iota_address) in &generated_iota_addresses {
             let address_outputs = client.get_address().outputs(&iota_address).await?;
             let balance = client.get_address().balance(&iota_address).await?;
 
@@ -95,16 +103,23 @@ async fn sync_addresses(
                 curr_found_outputs.push(output.try_into()?);
             }
 
+            // ignore unused change addresses
+            if *iota_address_internal && curr_found_outputs.is_empty() {
+                continue;
+            }
+
             let address = AddressBuilder::new()
                 .address(iota_address.clone())
-                .key_index(address_index)
+                .key_index(*iota_address_index)
                 .balance(balance)
                 .outputs(curr_found_outputs)
+                .internal(*iota_address_internal)
                 .build()?;
-            address_index += 1;
 
             curr_generated_addresses.push(address);
         }
+
+        address_index += gap_limit;
 
         let is_empty = curr_found_messages.is_empty()
             && curr_generated_addresses
@@ -329,7 +344,7 @@ impl SyncedAccount {
         threshold: u64,
         account: &'a Account,
         address: &'a IotaAddress,
-    ) -> crate::Result<(Vec<Address>, Option<&'a Address>)> {
+    ) -> crate::Result<(Vec<Address>, Option<Address>)> {
         let mut available_addresses: Vec<Address> = account
             .addresses()
             .iter()
@@ -338,7 +353,7 @@ impl SyncedAccount {
             .collect();
         let addresses = input_selection::select_input(threshold, &mut available_addresses)?;
         let remainder = if addresses.iter().fold(0, |acc, a| acc + a.balance()) > threshold {
-            account.latest_address()
+            addresses.last().cloned()
         } else {
             None
         };
@@ -360,7 +375,7 @@ impl SyncedAccount {
 
         // select the input addresses and check if a remainder address is needed
         let (input_addresses, remainder_address) =
-            self.select_inputs(*transfer_obj.amount(), &account, transfer_obj.address())?;
+            self.select_inputs(*transfer_obj.amount(), &mut account, transfer_obj.address())?;
 
         let mut utxos = vec![];
         let mut output_paths = vec![];
@@ -369,7 +384,7 @@ impl SyncedAccount {
             let address_path = BIP32Path::from_str(&format!(
                 "m/44H/4218H/{}H/{}H/{}H",
                 account.index(),
-                !input_address.internal() as u32,
+                *input_address.internal() as u32,
                 input_address.key_index()
             ))
             .unwrap();
@@ -386,7 +401,7 @@ impl SyncedAccount {
                 let output_path = BIP32Path::from_str(&format!(
                     "m/44H/4218H/{}H/{}H/{}H",
                     account.index(),
-                    !input_address.internal() as u32,
+                    *input_address.internal() as u32,
                     offset as u32
                 ))
                 .unwrap();
@@ -442,17 +457,21 @@ impl SyncedAccount {
             }
         }
 
+        // if there's remainder value, we generate a change address for the remainder address and add an output for it
         if remainder_value > 0 {
             let remainder_address = remainder_address
                 .ok_or_else(|| anyhow::anyhow!("remainder address not defined"))?;
+            let change_address =
+                crate::address::get_new_change_address(&account, &remainder_address)?;
             utxo_outputs.push(
                 SignatureLockedSingleOutput::new(
-                    remainder_address.address().clone(),
+                    change_address.address().clone(),
                     NonZeroU64::new(remainder_value)
                         .ok_or_else(|| anyhow::anyhow!("invalid amount"))?,
                 )
                 .into(),
             );
+            account.append_addresses(vec![change_address]);
         }
 
         let (parent1, parent2) = client.get_tips().await?;
@@ -491,6 +510,13 @@ impl SyncedAccount {
             .map_err(|e| anyhow::anyhow!(e.to_string()))?;
 
         let message_id = client.post_message(&message).await?;
+
+        // if this is a transfer to the account's latest address, we generate a new one to keep the latest address unused
+        if account.latest_address().unwrap().address() == transfer_obj.address() {
+            let addr = crate::address::get_new_address(&account)?;
+            account.append_addresses(vec![addr]);
+        }
+
         let message = client.get_message().data(&message_id).await?;
 
         account.append_messages(vec![Message::from_iota_message(message_id, &message)?]);

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -98,6 +98,7 @@ pub(crate) fn get_account(
     account_id: AccountIdentifier,
 ) -> crate::Result<Account> {
     let account_str = with_adapter(&storage_path, |storage| storage.get(account_id))?;
-    let account: Account = serde_json::from_str(&account_str)?;
+    let mut account: Account = serde_json::from_str(&account_str)?;
+    account.set_storage_path(storage_path.clone());
     Ok(account)
 }


### PR DESCRIPTION
# Description of change

The wallet was incorrectly generating change/latest addresses and using the change address for remaining values on transfers. 

## Links to any relevant issues

#110 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Manually with Hornet.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked that new and existing unit tests pass locally with my changes
