### PR TITLE
fix(storage) do not panic when the account index doesn't exist, fix #102

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,6 +110,9 @@ pub enum WalletError {
     /// Transfer amount can't be zero.
     #[error("transfer amount can't be zero")]
     ZeroAmount,
+    /// Account not found
+    #[error("account not found")]
+    AccountNotFound,
 }
 
 impl Drop for WalletError {

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -167,6 +167,7 @@ impl serde::Serialize for crate::WalletError {
                 serialize_variant(serializer, "LatestAccountIsEmpty", None)
             }
             Self::ZeroAmount => serialize_variant(serializer, "ZeroAmount", None),
+            Self::AccountNotFound => serialize_variant(serializer, "AccountNotFound", None),
         }
     }
 }

--- a/src/storage/sqlite.rs
+++ b/src/storage/sqlite.rs
@@ -73,7 +73,7 @@ impl StorageAdapter for SqliteStorageAdapter {
         let account = results
             .first()
             .map(|val| val.as_ref().unwrap().to_string())
-            .ok_or_else(|| anyhow::anyhow!("account isn't stored"))?;
+            .ok_or_else(|| crate::WalletError::AccountNotFound)?;
         Ok(account)
     }
 

--- a/src/storage/stronghold.rs
+++ b/src/storage/stronghold.rs
@@ -77,7 +77,7 @@ impl StorageAdapter for StrongholdStorageAdapter {
             let stronghold_id = get_from_index(&index, &account_id)?;
             stronghold
                 .record_read(&stronghold_id)
-                .map_err(|e| crate::WalletError::GenericError(e))
+                .map_err(crate::WalletError::GenericError)
         })?;
         Ok(account)
     }


### PR DESCRIPTION
# Description of change

The wallet shouldn't panic when reading an account index that doesn't exist. 

## Links to any relevant issues

#102 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

With the wallet backend.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have checked that new and existing unit tests pass locally with my changes
