### PR TITLE
fix(lib) `network_id` was temporarily removed from bee-message

### DIFF
--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -516,7 +516,7 @@ impl SyncedAccount {
             .with_parent1(parent1)
             .with_parent2(parent2)
             .with_payload(Payload::Transaction(Box::new(transaction)))
-            .with_network_id(0)
+            // TODO temp removed .with_network_id(0)
             .finish()
             .map_err(|e| anyhow::anyhow!(e.to_string()))?;
 

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -610,7 +610,7 @@ mod tests {
                         "index".to_string(),
                         &[0; 16],
                     ).unwrap())))
-                    .with_network_id(0)
+                    // TODO temp removed .with_network_id(0)
                     .finish()
                     .unwrap()).unwrap()])
                 .initialise().unwrap();


### PR DESCRIPTION
# Description of change

Temporary change to fix the lib compilation. 
