### PR TITLE
refactor(event): payloads with Message instead of MessageId, remove clone

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ iota-stronghold = { git = "https://github.com/iotaledger/stronghold.rs", branch 
 
 [dev-dependencies]
 tokio = { version = "0.2", features = ["full"] }
-rocksdb = "0.15"
+sled = "0.34"
 rusty-fork = "0.3.0"
 
 [features]

--- a/examples/custom_storage.rs
+++ b/examples/custom_storage.rs
@@ -3,25 +3,25 @@ use iota_wallet::{
     account::AccountIdentifier, account_manager::AccountManager, client::ClientOptionsBuilder,
     storage::StorageAdapter,
 };
-use rocksdb::{IteratorMode, DB};
+use sled::Db;
 use std::path::Path;
 
 struct MyStorage {
-    db: DB,
+    db: Db,
 }
 
 impl MyStorage {
     pub fn new<P: AsRef<Path>>(path: P) -> anyhow::Result<Self> {
         let instance = Self {
-            db: DB::open_default(path)?,
+            db: sled::open(path)?,
         };
         Ok(instance)
     }
 }
 
-fn account_id_value(account_id: AccountIdentifier) -> anyhow::Result<String> {
+fn account_id_value(account_id: AccountIdentifier) -> anyhow::Result<[u8; 32]> {
     match account_id {
-        AccountIdentifier::Id(val) => Ok(String::from_utf8_lossy(&val).to_string()),
+        AccountIdentifier::Id(val) => Ok(val),
         _ => Err(anyhow::anyhow!("Unexpected AccountIdentifier type")),
     }
 }
@@ -29,7 +29,7 @@ fn account_id_value(account_id: AccountIdentifier) -> anyhow::Result<String> {
 impl StorageAdapter for MyStorage {
     fn get(&self, account_id: AccountIdentifier) -> iota_wallet::Result<String> {
         match self.db.get(account_id_value(account_id)?) {
-            Ok(Some(value)) => Ok(String::from_utf8(value).unwrap()),
+            Ok(Some(value)) => Ok(String::from_utf8(value.to_vec()).unwrap()),
             Ok(None) => Err(anyhow::anyhow!("Value not found").into()),
             Err(e) => Err(anyhow::anyhow!("operational problem encountered: {}", e).into()),
         }
@@ -37,8 +37,8 @@ impl StorageAdapter for MyStorage {
 
     fn get_all(&self) -> iota_wallet::Result<std::vec::Vec<String>> {
         let mut accounts = vec![];
-        let iter = self.db.iterator(IteratorMode::Start);
-        for (_, value) in iter {
+        for tuple in self.db.iter() {
+            let (_, value) = tuple.unwrap();
             accounts.push(String::from_utf8(value.to_vec()).unwrap());
         }
         Ok(accounts)
@@ -46,14 +46,14 @@ impl StorageAdapter for MyStorage {
 
     fn set(&self, account_id: AccountIdentifier, account: String) -> iota_wallet::Result<()> {
         self.db
-            .put(account_id_value(account_id)?, account)
+            .insert(account_id_value(account_id)?, account.as_bytes())
             .map_err(|e| iota_wallet::WalletError::UnknownError(e.to_string()))?;
         Ok(())
     }
 
     fn remove(&self, account_id: AccountIdentifier) -> iota_wallet::Result<()> {
         self.db
-            .delete(account_id_value(account_id)?)
+            .remove(account_id_value(account_id)?)
             .map_err(|e| iota_wallet::WalletError::UnknownError(e.to_string()))?;
         Ok(())
     }
@@ -61,8 +61,8 @@ impl StorageAdapter for MyStorage {
 
 fn main() -> iota_wallet::Result<()> {
     let manager = AccountManager::with_storage_adapter(
-        "./example-database/rocksdb",
-        MyStorage::new("./example-database/rocksdb")?,
+        "./example-database/sled",
+        MyStorage::new("./example-database/sled")?,
     )
     .unwrap();
     manager.set_stronghold_password("password").unwrap();

--- a/examples/custom_storage.rs
+++ b/examples/custom_storage.rs
@@ -1,4 +1,4 @@
-///! An example of using a custom storage adapter (in this case, using rocksdb).
+///! An example of using a custom storage adapter (in this case, using sled).
 use iota_wallet::{
     account::AccountIdentifier, account_manager::AccountManager, client::ClientOptionsBuilder,
     storage::StorageAdapter,

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -482,7 +482,7 @@ async fn reattach(
     let message = messages
         .iter_mut()
         .find(|message| message.id() == message_id)
-        .ok_or_else(|| crate::WalletError::MessageNotFound)?;
+        .ok_or(crate::WalletError::MessageNotFound)?;
 
     if message.confirmed {
         Err(crate::WalletError::MessageAlreadyConfirmed)

--- a/src/storage/sqlite.rs
+++ b/src/storage/sqlite.rs
@@ -73,7 +73,7 @@ impl StorageAdapter for SqliteStorageAdapter {
         let account = results
             .first()
             .map(|val| val.as_ref().unwrap().to_string())
-            .ok_or_else(|| crate::WalletError::AccountNotFound)?;
+            .ok_or(crate::WalletError::AccountNotFound)?;
         Ok(account)
     }
 

--- a/src/storage/stronghold.rs
+++ b/src/storage/stronghold.rs
@@ -57,7 +57,7 @@ fn get_from_index(
         AccountIdentifier::Id(id) => index
             .iter()
             .find(|(acc_id, _)| acc_id == account_id)
-            .ok_or_else(|| crate::WalletError::AccountNotFound)?,
+            .ok_or(crate::WalletError::AccountNotFound)?,
         AccountIdentifier::Index(pos) => {
             let pos = *pos as usize;
             if index.len() > pos {


### PR DESCRIPTION
# Description of change

Changes the event payloads to take references to remove `clone()`s and changes the payloads to include `Message` instead of `MessageId` to simplify usage by consumers. 

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

Manually with the frontend.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have checked that new and existing unit tests pass locally with my changes
