### PR TITLE
fix(sync): append addresses before appending messages

### DIFF
--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -254,14 +254,6 @@ impl<'a> AccountSynchronizer<'a> {
         }
 
         sync_transactions(self.account, &new_messages).await?;
-        self.account.append_messages(
-            new_messages
-                .iter()
-                .map(|(id, message)| {
-                    Message::from_iota_message(*id, self.account.addresses(), &message).unwrap()
-                })
-                .collect(),
-        );
 
         let mut addresses_to_save = vec![];
         let mut ignored_addresses = vec![];
@@ -290,6 +282,15 @@ impl<'a> AccountSynchronizer<'a> {
             previous_address_is_unused = address_is_unused;
         }
         self.account.append_addresses(addresses_to_save);
+
+        self.account.append_messages(
+            new_messages
+                .iter()
+                .map(|(id, message)| {
+                    Message::from_iota_message(*id, self.account.addresses(), &message).unwrap()
+                })
+                .collect(),
+        );
 
         if !self.skip_persistance {
             crate::storage::with_adapter(&self.storage_path, |storage| {


### PR DESCRIPTION
# Description of change

The `Message::from_iota_message` conversion uses the account addresses, so after a sync process the addresses should be appended before the conversion so the message can properly determine if it's an incoming or outgoing transaction. 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

With the new wallet frontend.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have checked that new and existing unit tests pass locally with my changes
