### PR TITLE
fix(manager): fill storage path on `parse_accounts` fn

### DIFF
--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -73,17 +73,15 @@ pub(crate) fn parse_accounts(
     let mut err = None;
     let accounts: Vec<Option<Account>> = accounts
         .iter()
-        .map(|account| {
-            let res = serde_json::from_str::<Account>(&account)
-                .map(|mut acc| {
-                    acc.set_storage_path(storage_path.clone());
-                    Some(acc)
-                })
-                .unwrap_or_else(|e| {
-                    err = Some(e);
-                    None
-                });
-            res
+        .map(|account| match serde_json::from_str::<Account>(&account) {
+            Ok(mut acc) => {
+                acc.set_storage_path(storage_path.clone());
+                Some(acc)
+            }
+            Err(e) => {
+                err = Some(e);
+                None
+            }
         })
         .collect();
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -66,18 +66,23 @@ pub trait StorageAdapter {
     fn remove(&self, account_id: AccountIdentifier) -> crate::Result<()>;
 }
 
-pub(crate) fn parse_accounts(accounts: &[String]) -> crate::Result<Vec<Account>> {
+pub(crate) fn parse_accounts(
+    storage_path: &PathBuf,
+    accounts: &[String],
+) -> crate::Result<Vec<Account>> {
     let mut err = None;
     let accounts: Vec<Option<Account>> = accounts
         .iter()
         .map(|account| {
-            let res: Option<Account> =
-                serde_json::from_str(&account)
-                    .map(Some)
-                    .unwrap_or_else(|e| {
-                        err = Some(e);
-                        None
-                    });
+            let res = serde_json::from_str::<Account>(&account)
+                .map(|mut acc| {
+                    acc.set_storage_path(storage_path.clone());
+                    Some(acc)
+                })
+                .unwrap_or_else(|e| {
+                    err = Some(e);
+                    None
+                });
             res
         })
         .collect();


### PR DESCRIPTION
# Description of change

Fixes an issue where the account's storage_path field isn't filled. 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
