### PR TITLE
chore(sync): change default gap limit to 10 for performance reasons

### DIFF
--- a/specs/wallet-ENGINEERING-SPEC-0000.md
+++ b/specs/wallet-ENGINEERING-SPEC-0000.md
@@ -1162,7 +1162,7 @@ Syncs addresses with the Tangle. The method should ensure that the wallet's loca
 The following should be considered when implementing this method:
 
 *   The updated address history should not be written down in the database/persistent storage. Instead the method should only return the updated address history (with transaction hashes).  This will ensure that there are no partial writes to the database;
-*   To sync addresses for an account from scratch, index = 0 and gap_limit = 20 should be provided;
+*   To sync addresses for an account from scratch, index = 0 and gap_limit = 10 should be provided;
 *   To sync addresses from the latest address, index = latest address index and gap_limit = 1 should be provided. 
 
 <table>

--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -20,7 +20,7 @@ mod input_selection;
 /// Syncs addresses with the tangle.
 /// The method ensures that the wallet local state has all used addresses plus an unused address.
 ///
-/// To sync addresses for an account from scratch, `address_index` = 0 and `gap_limit` = 20 should be provided.
+/// To sync addresses for an account from scratch, `address_index` = 0 and `gap_limit` = 10 should be provided.
 /// To sync addresses from the latest address, `address_index` = latest address index and `gap_limit` = 1 should be provided.
 ///
 /// # Arguments
@@ -199,7 +199,7 @@ impl<'a> AccountSynchronizer<'a> {
             } else {
                 address_index - 1
             },
-            gap_limit: if address_index == 0 { 20 } else { 1 },
+            gap_limit: if address_index == 0 { 10 } else { 1 },
             skip_persistance: false,
             storage_path,
         }


### PR DESCRIPTION
# Description of change

The syncing process also checks change addresses so gap limit = 10 is a better fit for performance reasons. 

## Type of change

- Performance improvement

## Change checkl

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have checked that new and existing unit tests pass locally with my changes
