### PR TITLE
fix(address): properly handle new output found on mqtt subscription

### DIFF
--- a/src/address.rs
+++ b/src/address.rs
@@ -172,10 +172,21 @@ impl PartialEq for Address {
 }
 
 impl Address {
-    pub(crate) fn append_output(&mut self, output: AddressOutput) {
+    pub(crate) fn handle_new_output(&mut self, output: AddressOutput) {
         if !self.outputs.iter().any(|o| o == &output) {
-            self.balance += output.amount;
-            self.outputs.push(output);
+            let spent_existing_output = self.outputs.iter().position(|o| {
+                o.message_id == output.message_id
+                    && o.transaction_id == output.transaction_id
+                    && o.index == output.index
+                    && o.amount == output.amount
+                    && (o.is_spent && !output.is_spent)
+            });
+            if let Some(spent_output) = spent_existing_output {
+                self.outputs.remove(spent_output);
+            } else {
+                self.balance += output.amount;
+                self.outputs.push(output);
+            }
         }
     }
 }

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -169,7 +169,7 @@ async fn process_output(
             .iter_mut()
             .find(|a| a.address() == &address)
             .unwrap();
-        address_to_update.append_output(address_output);
+        address_to_update.handle_new_output(address_output);
         crate::event::emit_balance_change(
             account_id_raw.clone(),
             &address_to_update,


### PR DESCRIPTION
# Description of change

If a new output is sent through MQTT and `is_spent = false`, we should remove instead of push it. 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

With the Faucet.
