### PR TITLE
feat(lib): add account types for different signing providers

### DIFF
--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -155,12 +155,6 @@ impl<'a> AccountInitialiser<'a> {
             }
         }
 
-        if mnemonic.is_some() && !accounts.is_empty() {
-            return Err(
-                anyhow::anyhow!("can't set mnemonic because an account already exists").into(),
-            );
-        }
-
         let mut account = Account {
             id: "".to_string(),
             account_type: account_type.clone(),

--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -66,7 +66,7 @@ pub struct AccountInitialiser<'a> {
     client_options: ClientOptions,
     skip_persistance: bool,
     storage_path: &'a PathBuf,
-    account_type: Option<SignerType>,
+    signer_type: Option<SignerType>,
 }
 
 impl<'a> AccountInitialiser<'a> {
@@ -82,15 +82,15 @@ impl<'a> AccountInitialiser<'a> {
             skip_persistance: false,
             storage_path,
             #[cfg(feature = "stronghold")]
-            account_type: Some(SignerType::Stronghold),
+            signer_type: Some(SignerType::Stronghold),
             #[cfg(not(feature = "stronghold"))]
-            account_type: None,
+            signer_type: None,
         }
     }
 
-    /// Sets the account type.
-    pub fn account_type(mut self, account_type: SignerType) -> Self {
-        self.account_type.replace(account_type);
+    /// Sets the account's signer type.
+    pub fn signer_type(mut self, signer_type: SignerType) -> Self {
+        self.signer_type.replace(signer_type);
         self
     }
 
@@ -139,9 +139,9 @@ impl<'a> AccountInitialiser<'a> {
         let alias = self
             .alias
             .unwrap_or_else(|| format!("Account {}", accounts.len()));
-        let account_type = self
-            .account_type
-            .ok_or_else(|| anyhow::anyhow!("account type is required"))?;
+        let signer_type = self
+            .signer_type
+            .ok_or_else(|| anyhow::anyhow!("account signer type is required"))?;
         let created_at = self.created_at.unwrap_or_else(chrono::Utc::now);
         let mnemonic = self.mnemonic;
 
@@ -157,7 +157,7 @@ impl<'a> AccountInitialiser<'a> {
 
         let mut account = Account {
             id: "".to_string(),
-            account_type: account_type.clone(),
+            signer_type: signer_type.clone(),
             index: accounts.len(),
             alias,
             created_at,
@@ -168,7 +168,7 @@ impl<'a> AccountInitialiser<'a> {
             has_pending_changes: false,
         };
 
-        let id = with_signer(&account_type, |signer| {
+        let id = with_signer(&signer_type, |signer| {
             signer.init_account(&account, mnemonic)
         })?;
         account.set_id(id.clone());
@@ -200,8 +200,8 @@ pub struct Account {
     /// The account identifier.
     #[getset(set = "pub(crate)")]
     id: String,
-    /// The account type.
-    account_type: SignerType,
+    /// The account's signer type.
+    signer_type: SignerType,
     /// The account index
     index: usize,
     /// The account alias.

--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -173,7 +173,7 @@ impl<'a> AccountInitialiser<'a> {
         })?;
         account.set_id(id.clone());
 
-        let account_id: AccountIdentifier = id.clone().into();
+        let account_id: AccountIdentifier = id.into();
 
         if !self.skip_persistance {
             crate::storage::with_adapter(&self.storage_path, |storage| {

--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -12,6 +12,7 @@
 use crate::address::Address;
 use crate::client::ClientOptions;
 use crate::message::{Message, MessageType};
+use crate::signing::{with_signer, SignerType};
 
 use chrono::prelude::{DateTime, Utc};
 use getset::{Getters, Setters};
@@ -65,6 +66,7 @@ pub struct AccountInitialiser<'a> {
     client_options: ClientOptions,
     skip_persistance: bool,
     storage_path: &'a PathBuf,
+    account_type: Option<SignerType>,
 }
 
 impl<'a> AccountInitialiser<'a> {
@@ -79,7 +81,17 @@ impl<'a> AccountInitialiser<'a> {
             client_options,
             skip_persistance: false,
             storage_path,
+            #[cfg(feature = "stronghold")]
+            account_type: Some(SignerType::Stronghold),
+            #[cfg(not(feature = "stronghold"))]
+            account_type: None,
         }
+    }
+
+    /// Sets the account type.
+    pub fn account_type(mut self, account_type: SignerType) -> Self {
+        self.account_type.replace(account_type);
+        self
     }
 
     /// Defines the account BIP-39 mnemonic.
@@ -127,8 +139,10 @@ impl<'a> AccountInitialiser<'a> {
         let alias = self
             .alias
             .unwrap_or_else(|| format!("Account {}", accounts.len()));
+        let account_type = self
+            .account_type
+            .ok_or_else(|| anyhow::anyhow!("account type is required"))?;
         let created_at = self.created_at.unwrap_or_else(chrono::Utc::now);
-        let created_at_timestamp: u128 = created_at.timestamp().try_into().unwrap(); // safe to unwrap since it's > 0
         let mnemonic = self.mnemonic;
 
         // check for empty latest account only when not skipping persistance (account discovery process)
@@ -141,27 +155,15 @@ impl<'a> AccountInitialiser<'a> {
             }
         }
 
-        let stronghold_account_res: crate::Result<stronghold::Account> =
-            crate::with_stronghold_from_path(&self.storage_path, |stronghold| {
-                let account = match mnemonic {
-                    Some(mnemonic) => stronghold.account_import(
-                        Some(created_at_timestamp),
-                        Some(created_at_timestamp),
-                        mnemonic,
-                        Some("password"),
-                    )?,
-                    None => stronghold.account_create(Some("password".to_string()))?,
-                };
-                Ok(account)
-            });
-        let stronghold_account = stronghold_account_res?;
+        if mnemonic.is_some() && !accounts.is_empty() {
+            return Err(
+                anyhow::anyhow!("can't set mnemonic because an account already exists").into(),
+            );
+        }
 
-        let id = stronghold_account.id();
-        let id = hex::encode(id);
-        let account_id: AccountIdentifier = id.clone().into();
-
-        let account = Account {
-            id,
+        let mut account = Account {
+            id: "".to_string(),
+            account_type: account_type.clone(),
             index: accounts.len(),
             alias,
             created_at,
@@ -171,6 +173,14 @@ impl<'a> AccountInitialiser<'a> {
             storage_path: self.storage_path.clone(),
             has_pending_changes: false,
         };
+
+        let id = with_signer(&account_type, |signer| {
+            signer.init_account(&account, mnemonic)
+        })?;
+        account.set_id(id.clone());
+
+        let account_id: AccountIdentifier = id.clone().into();
+
         if !self.skip_persistance {
             crate::storage::with_adapter(&self.storage_path, |storage| {
                 storage.set(account_id, serde_json::to_string(&account)?)
@@ -194,7 +204,10 @@ pub(crate) fn account_id_to_stronghold_record_id(account_id: &str) -> crate::Res
 #[getset(get = "pub")]
 pub struct Account {
     /// The account identifier.
+    #[getset(set = "pub(crate)")]
     id: String,
+    /// The account type.
+    account_type: SignerType,
     /// The account index
     index: usize,
     /// The account alias.

--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -590,7 +590,7 @@ impl SyncedAccount {
             .finish()
             .map_err(|e| anyhow::anyhow!(format!("{:?}", e)))?;
 
-        let unlock_blocks = crate::signing::with_signer(account.account_type(), |signer| {
+        let unlock_blocks = crate::signing::with_signer(account.signer_type(), |signer| {
             signer.sign_message(&account, &essence, &mut address_index_recorders)
         })?;
         let mut tx_builder = Transaction::builder().with_essence(essence);

--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -9,7 +9,7 @@
 // an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and limitations under the License.
 
-use crate::account::{account_id_to_stronghold_record_id, Account, AccountIdentifier};
+use crate::account::{Account, AccountIdentifier};
 use crate::address::{Address, AddressBuilder, AddressOutput, IotaAddress};
 use crate::client::get_client;
 use crate::message::{Message, RemainderValueStrategy, Transfer};
@@ -51,7 +51,6 @@ async fn sync_addresses(
     gap_limit: usize,
 ) -> crate::Result<(Vec<Address>, Vec<(MessageId, IotaMessage)>)> {
     let mut address_index = address_index;
-    let account_index = *account.index();
 
     let client = crate::client::get_client(account.client_options());
     let client = client.read().unwrap();
@@ -65,24 +64,12 @@ async fn sync_addresses(
             generated_iota_addresses.push((
                 i,
                 false,
-                crate::address::get_iota_address(
-                    &storage_path,
-                    account.id(),
-                    account_index,
-                    i,
-                    false,
-                )?,
+                crate::address::get_iota_address(&account, i, false)?,
             ));
             generated_iota_addresses.push((
                 i,
                 true,
-                crate::address::get_iota_address(
-                    &storage_path,
-                    account.id(),
-                    account_index,
-                    i,
-                    true,
-                )?,
+                crate::address::get_iota_address(&account, i, true)?,
             ));
         }
 
@@ -525,7 +512,7 @@ impl SyncedAccount {
             .map_err(|e| anyhow::anyhow!(e.to_string()))?
             .into();
             essence_builder = essence_builder.add_input(input.clone());
-            address_index_recorders.push(stronghold::AddressIndexRecorder {
+            address_index_recorders.push(crate::signing::TransactionInput {
                 input,
                 address_index,
                 address_path,
@@ -599,20 +586,12 @@ impl SyncedAccount {
 
         let (parent1, parent2) = client.get_tips().await?;
 
-        let stronghold_account =
-            crate::with_stronghold_from_path(&self.storage_path, |stronghold| {
-                stronghold.account_get_by_id(&account_id_to_stronghold_record_id(account.id())?)
-            })?;
-
         let essence = essence_builder
             .finish()
             .map_err(|e| anyhow::anyhow!(format!("{:?}", e)))?;
-        let unlock_blocks = crate::with_stronghold_from_path(&self.storage_path, |stronghold| {
-            stronghold.get_transaction_unlock_blocks(
-                &account_id_to_stronghold_record_id(account.id())?,
-                &essence,
-                &mut address_index_recorders,
-            )
+
+        let unlock_blocks = crate::signing::with_signer(account.account_type(), |signer| {
+            signer.sign_message(&account, &essence, &mut address_index_recorders)
         })?;
         let mut tx_builder = Transaction::builder().with_essence(essence);
         for unlock_block in unlock_blocks {

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -162,9 +162,6 @@ impl AccountManager {
         if !(account.messages().is_empty() && account.total_balance() == 0) {
             return Err(crate::WalletError::MessageNotEmpty);
         }
-        crate::with_stronghold_from_path(&self.storage_path, |stronghold| {
-            stronghold.account_remove(&account_id_to_stronghold_record_id(account.id())?)
-        })?;
         crate::storage::with_adapter(&self.storage_path, |storage| storage.remove(account_id))?;
         Ok(())
     }

--- a/src/address.rs
+++ b/src/address.rs
@@ -209,7 +209,7 @@ pub(crate) fn get_iota_address(
     address_index: usize,
     internal: bool,
 ) -> crate::Result<IotaAddress> {
-    crate::signing::with_signer(account.account_type(), |signer| {
+    crate::signing::with_signer(account.signer_type(), |signer| {
         signer.generate_address(&account, address_index, internal)
     })
 }

--- a/src/address.rs
+++ b/src/address.rs
@@ -9,7 +9,7 @@
 // an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and limitations under the License.
 
-use crate::account::{account_id_to_stronghold_record_id, Account};
+use crate::account::Account;
 use crate::message::MessageType;
 use bech32::FromBase32;
 use getset::{Getters, Setters};
@@ -20,7 +20,6 @@ use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::convert::{TryFrom, TryInto};
 use std::hash::{Hash, Hasher};
-use std::path::PathBuf;
 
 /// An Address output.
 #[derive(Debug, Getters, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -206,33 +205,19 @@ pub fn parse(address: String) -> crate::Result<IotaAddress> {
 }
 
 pub(crate) fn get_iota_address(
-    storage_path: &PathBuf,
-    account_id: &str,
-    account_index: usize,
+    account: &Account,
     address_index: usize,
     internal: bool,
 ) -> crate::Result<IotaAddress> {
-    crate::with_stronghold_from_path(&storage_path, |stronghold| {
-        let address_str = stronghold.address_get(
-            &account_id_to_stronghold_record_id(account_id)?,
-            Some(account_index),
-            address_index,
-            internal,
-        )?;
-        parse(address_str)
+    crate::signing::with_signer(account.account_type(), |signer| {
+        signer.generate_address(&account, address_index, internal)
     })
 }
 
 /// Gets an unused public address for the given account.
 pub(crate) fn get_new_address(account: &Account) -> crate::Result<Address> {
     let key_index = account.addresses().iter().filter(|a| !a.internal()).count();
-    let iota_address = get_iota_address(
-        account.storage_path(),
-        account.id(),
-        *account.index(),
-        key_index,
-        false,
-    )?;
+    let iota_address = get_iota_address(&account, key_index, false)?;
     let address = Address {
         address: iota_address,
         balance: 0,
@@ -249,13 +234,7 @@ pub(crate) fn get_new_change_address(
     address: &Address,
 ) -> crate::Result<Address> {
     let key_index = *address.key_index();
-    let iota_address = get_iota_address(
-        account.storage_path(),
-        account.id(),
-        *account.index(),
-        key_index,
-        true,
-    )?;
+    let iota_address = get_iota_address(&account, key_index, true)?;
     let address = Address {
         address: iota_address,
         balance: 0,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,8 @@ pub mod message;
 /// The monitor module.
 pub mod monitor;
 pub(crate) mod serde;
+/// Signing interfaces.
+pub mod signing;
 /// The storage module.
 pub mod storage;
 

--- a/src/signing/mod.rs
+++ b/src/signing/mod.rs
@@ -47,7 +47,7 @@ pub trait Signer {
         index: usize,
         internal: bool,
     ) -> crate::Result<iota::Address>;
-    /// Sign message.
+    /// Signs message.
     fn sign_message(
         &self,
         account: &Account,
@@ -80,7 +80,7 @@ pub fn set_signer<S: Signer + Sync + Send + 'static>(signer_type: SignerType, si
     instances.insert(signer_type, Box::new(signer));
 }
 
-/// gets the signer interface.
+/// Gets the signer interface.
 pub(crate) fn with_signer<T, F: FnOnce(&BoxedSigner) -> T>(signer_type: &SignerType, cb: F) -> T {
     let instances = SIGNER_INSTANCES
         .get_or_init(default_signers)

--- a/src/signing/mod.rs
+++ b/src/signing/mod.rs
@@ -1,0 +1,94 @@
+use std::{
+  collections::HashMap,
+  sync::{Arc, RwLock},
+};
+
+use crate::account::Account;
+use iota::Input;
+use once_cell::sync::OnceCell;
+use serde::{Deserialize, Serialize};
+use slip10::BIP32Path;
+
+mod stronghold;
+use self::stronghold::StrongholdSigner;
+
+type BoxedSigner = Box<dyn Signer + Sync + Send>;
+type Signers = Arc<RwLock<HashMap<SignerType, BoxedSigner>>>;
+static SIGNER_INSTANCES: OnceCell<Signers> = OnceCell::new();
+
+/// The signer types.
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
+pub enum SignerType {
+  /// Stronghold signer.
+  #[cfg(feature = "stronghold")]
+  Stronghold,
+  /// Custom signer with its identifier.
+  Custom(String),
+}
+
+/// One of the transaction inputs and its address information needed for signing it.
+pub struct TransactionInput {
+  /// The input.
+  pub input: Input,
+  /// Input's address index.
+  pub address_index: usize,
+  /// Input's address BIP32 derivation path.
+  pub address_path: BIP32Path,
+}
+
+/// Signer interface.
+pub trait Signer {
+  /// Initialises an account.
+  fn init_account(&self, account: &Account, mnemonic: Option<String>) -> crate::Result<String>;
+  /// Generates an address.
+  fn generate_address(
+    &self,
+    account: &Account,
+    index: usize,
+    internal: bool,
+  ) -> crate::Result<iota::Address>;
+  /// Sign message.
+  fn sign_message(
+    &self,
+    account: &Account,
+    essence: &iota::TransactionEssence,
+    inputs: &mut Vec<TransactionInput>,
+  ) -> crate::Result<Vec<iota::UnlockBlock>>;
+}
+
+#[allow(unused_mut)]
+fn default_signers() -> Signers {
+  let mut signers = HashMap::new();
+
+  #[cfg(feature = "stronghold")]
+  {
+    signers.insert(
+      SignerType::Stronghold,
+      Box::new(StrongholdSigner::default()) as Box<dyn Signer + Sync + Send>,
+    );
+  }
+
+  Arc::new(RwLock::new(signers))
+}
+
+/// Sets the signer interface for the given type.
+pub fn set_signer<S: Signer + Sync + Send + 'static>(signer_type: SignerType, signer: S) {
+  let mut instances = SIGNER_INSTANCES
+    .get_or_init(default_signers)
+    .write()
+    .unwrap();
+  instances.insert(signer_type, Box::new(signer));
+}
+
+/// gets the signer interface.
+pub(crate) fn with_signer<T, F: FnOnce(&BoxedSigner) -> T>(signer_type: &SignerType, cb: F) -> T {
+  let instances = SIGNER_INSTANCES
+    .get_or_init(default_signers)
+    .read()
+    .unwrap();
+  if let Some(instance) = instances.get(signer_type) {
+    cb(instance)
+  } else {
+    panic!(format!("signer not initialized for type {:?}", signer_type))
+  }
+}

--- a/src/signing/mod.rs
+++ b/src/signing/mod.rs
@@ -1,6 +1,6 @@
 use std::{
-  collections::HashMap,
-  sync::{Arc, RwLock},
+    collections::HashMap,
+    sync::{Arc, RwLock},
 };
 
 use crate::account::Account;
@@ -19,76 +19,76 @@ static SIGNER_INSTANCES: OnceCell<Signers> = OnceCell::new();
 /// The signer types.
 #[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub enum SignerType {
-  /// Stronghold signer.
-  #[cfg(feature = "stronghold")]
-  Stronghold,
-  /// Custom signer with its identifier.
-  Custom(String),
+    /// Stronghold signer.
+    #[cfg(feature = "stronghold")]
+    Stronghold,
+    /// Custom signer with its identifier.
+    Custom(String),
 }
 
 /// One of the transaction inputs and its address information needed for signing it.
 pub struct TransactionInput {
-  /// The input.
-  pub input: Input,
-  /// Input's address index.
-  pub address_index: usize,
-  /// Input's address BIP32 derivation path.
-  pub address_path: BIP32Path,
+    /// The input.
+    pub input: Input,
+    /// Input's address index.
+    pub address_index: usize,
+    /// Input's address BIP32 derivation path.
+    pub address_path: BIP32Path,
 }
 
 /// Signer interface.
 pub trait Signer {
-  /// Initialises an account.
-  fn init_account(&self, account: &Account, mnemonic: Option<String>) -> crate::Result<String>;
-  /// Generates an address.
-  fn generate_address(
-    &self,
-    account: &Account,
-    index: usize,
-    internal: bool,
-  ) -> crate::Result<iota::Address>;
-  /// Sign message.
-  fn sign_message(
-    &self,
-    account: &Account,
-    essence: &iota::TransactionEssence,
-    inputs: &mut Vec<TransactionInput>,
-  ) -> crate::Result<Vec<iota::UnlockBlock>>;
+    /// Initialises an account.
+    fn init_account(&self, account: &Account, mnemonic: Option<String>) -> crate::Result<String>;
+    /// Generates an address.
+    fn generate_address(
+        &self,
+        account: &Account,
+        index: usize,
+        internal: bool,
+    ) -> crate::Result<iota::Address>;
+    /// Sign message.
+    fn sign_message(
+        &self,
+        account: &Account,
+        essence: &iota::TransactionEssence,
+        inputs: &mut Vec<TransactionInput>,
+    ) -> crate::Result<Vec<iota::UnlockBlock>>;
 }
 
 #[allow(unused_mut)]
 fn default_signers() -> Signers {
-  let mut signers = HashMap::new();
+    let mut signers = HashMap::new();
 
-  #[cfg(feature = "stronghold")]
-  {
-    signers.insert(
-      SignerType::Stronghold,
-      Box::new(StrongholdSigner::default()) as Box<dyn Signer + Sync + Send>,
-    );
-  }
+    #[cfg(feature = "stronghold")]
+    {
+        signers.insert(
+            SignerType::Stronghold,
+            Box::new(StrongholdSigner::default()) as Box<dyn Signer + Sync + Send>,
+        );
+    }
 
-  Arc::new(RwLock::new(signers))
+    Arc::new(RwLock::new(signers))
 }
 
 /// Sets the signer interface for the given type.
 pub fn set_signer<S: Signer + Sync + Send + 'static>(signer_type: SignerType, signer: S) {
-  let mut instances = SIGNER_INSTANCES
-    .get_or_init(default_signers)
-    .write()
-    .unwrap();
-  instances.insert(signer_type, Box::new(signer));
+    let mut instances = SIGNER_INSTANCES
+        .get_or_init(default_signers)
+        .write()
+        .unwrap();
+    instances.insert(signer_type, Box::new(signer));
 }
 
 /// gets the signer interface.
 pub(crate) fn with_signer<T, F: FnOnce(&BoxedSigner) -> T>(signer_type: &SignerType, cb: F) -> T {
-  let instances = SIGNER_INSTANCES
-    .get_or_init(default_signers)
-    .read()
-    .unwrap();
-  if let Some(instance) = instances.get(signer_type) {
-    cb(instance)
-  } else {
-    panic!(format!("signer not initialized for type {:?}", signer_type))
-  }
+    let instances = SIGNER_INSTANCES
+        .get_or_init(default_signers)
+        .read()
+        .unwrap();
+    if let Some(instance) = instances.get(signer_type) {
+        cb(instance)
+    } else {
+        panic!(format!("signer not initialized for type {:?}", signer_type))
+    }
 }

--- a/src/signing/mod.rs
+++ b/src/signing/mod.rs
@@ -10,8 +10,8 @@
 // See the License for the specific language governing permissions and limitations under the License.
 
 use std::{
-  collections::HashMap,
-  sync::{Arc, RwLock},
+    collections::HashMap,
+    sync::{Arc, RwLock},
 };
 
 use crate::account::Account;
@@ -30,21 +30,21 @@ static SIGNERS_INSTANCE: OnceCell<Signers> = OnceCell::new();
 /// The signer types.
 #[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub enum SignerType {
-  /// Stronghold signer.
-  #[cfg(feature = "stronghold")]
-  Stronghold,
-  /// Custom signer with its identifier.
-  Custom(String),
+    /// Stronghold signer.
+    #[cfg(feature = "stronghold")]
+    Stronghold,
+    /// Custom signer with its identifier.
+    Custom(String),
 }
 
 /// One of the transaction inputs and its address information needed for signing it.
 pub struct TransactionInput {
-  /// The input.
-  pub input: Input,
-  /// Input's address index.
-  pub address_index: usize,
-  /// Input's address BIP32 derivation path.
-  pub address_path: BIP32Path,
+    /// The input.
+    pub input: Input,
+    /// Input's address index.
+    pub address_index: usize,
+    /// Input's address BIP32 derivation path.
+    pub address_path: BIP32Path,
 }
 
 /// Signer interface.
@@ -69,37 +69,37 @@ pub trait Signer {
 
 #[allow(unused_mut)]
 fn default_signers() -> Signers {
-  let mut signers = HashMap::new();
+    let mut signers = HashMap::new();
 
-  #[cfg(feature = "stronghold")]
-  {
-    signers.insert(
-      SignerType::Stronghold,
-      Box::new(StrongholdSigner::default()) as Box<dyn Signer + Sync + Send>,
-    );
-  }
+    #[cfg(feature = "stronghold")]
+    {
+        signers.insert(
+            SignerType::Stronghold,
+            Box::new(StrongholdSigner::default()) as Box<dyn Signer + Sync + Send>,
+        );
+    }
 
-  Arc::new(RwLock::new(signers))
+    Arc::new(RwLock::new(signers))
 }
 
 /// Sets the signer interface for the given type.
 pub fn set_signer<S: Signer + Sync + Send + 'static>(signer_type: SignerType, signer: S) {
-  let mut instances = SIGNERS_INSTANCE
-    .get_or_init(default_signers)
-    .write()
-    .unwrap();
-  instances.insert(signer_type, Box::new(signer));
+    let mut instances = SIGNERS_INSTANCE
+        .get_or_init(default_signers)
+        .write()
+        .unwrap();
+    instances.insert(signer_type, Box::new(signer));
 }
 
 /// Gets the signer interface.
 pub(crate) fn with_signer<T, F: FnOnce(&BoxedSigner) -> T>(signer_type: &SignerType, cb: F) -> T {
-  let instances = SIGNERS_INSTANCE
-    .get_or_init(default_signers)
-    .read()
-    .unwrap();
-  if let Some(instance) = instances.get(signer_type) {
-    cb(instance)
-  } else {
-    panic!(format!("signer not initialized for type {:?}", signer_type))
-  }
+    let instances = SIGNERS_INSTANCE
+        .get_or_init(default_signers)
+        .read()
+        .unwrap();
+    if let Some(instance) = instances.get(signer_type) {
+        cb(instance)
+    } else {
+        panic!(format!("signer not initialized for type {:?}", signer_type))
+    }
 }

--- a/src/signing/mod.rs
+++ b/src/signing/mod.rs
@@ -1,6 +1,17 @@
+// Copyright 2020 IOTA Stiftung
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and limitations under the License.
+
 use std::{
-    collections::HashMap,
-    sync::{Arc, RwLock},
+  collections::HashMap,
+  sync::{Arc, RwLock},
 };
 
 use crate::account::Account;
@@ -14,26 +25,26 @@ use self::stronghold::StrongholdSigner;
 
 type BoxedSigner = Box<dyn Signer + Sync + Send>;
 type Signers = Arc<RwLock<HashMap<SignerType, BoxedSigner>>>;
-static SIGNER_INSTANCES: OnceCell<Signers> = OnceCell::new();
+static SIGNERS_INSTANCE: OnceCell<Signers> = OnceCell::new();
 
 /// The signer types.
 #[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub enum SignerType {
-    /// Stronghold signer.
-    #[cfg(feature = "stronghold")]
-    Stronghold,
-    /// Custom signer with its identifier.
-    Custom(String),
+  /// Stronghold signer.
+  #[cfg(feature = "stronghold")]
+  Stronghold,
+  /// Custom signer with its identifier.
+  Custom(String),
 }
 
 /// One of the transaction inputs and its address information needed for signing it.
 pub struct TransactionInput {
-    /// The input.
-    pub input: Input,
-    /// Input's address index.
-    pub address_index: usize,
-    /// Input's address BIP32 derivation path.
-    pub address_path: BIP32Path,
+  /// The input.
+  pub input: Input,
+  /// Input's address index.
+  pub address_index: usize,
+  /// Input's address BIP32 derivation path.
+  pub address_path: BIP32Path,
 }
 
 /// Signer interface.
@@ -58,37 +69,37 @@ pub trait Signer {
 
 #[allow(unused_mut)]
 fn default_signers() -> Signers {
-    let mut signers = HashMap::new();
+  let mut signers = HashMap::new();
 
-    #[cfg(feature = "stronghold")]
-    {
-        signers.insert(
-            SignerType::Stronghold,
-            Box::new(StrongholdSigner::default()) as Box<dyn Signer + Sync + Send>,
-        );
-    }
+  #[cfg(feature = "stronghold")]
+  {
+    signers.insert(
+      SignerType::Stronghold,
+      Box::new(StrongholdSigner::default()) as Box<dyn Signer + Sync + Send>,
+    );
+  }
 
-    Arc::new(RwLock::new(signers))
+  Arc::new(RwLock::new(signers))
 }
 
 /// Sets the signer interface for the given type.
 pub fn set_signer<S: Signer + Sync + Send + 'static>(signer_type: SignerType, signer: S) {
-    let mut instances = SIGNER_INSTANCES
-        .get_or_init(default_signers)
-        .write()
-        .unwrap();
-    instances.insert(signer_type, Box::new(signer));
+  let mut instances = SIGNERS_INSTANCE
+    .get_or_init(default_signers)
+    .write()
+    .unwrap();
+  instances.insert(signer_type, Box::new(signer));
 }
 
 /// Gets the signer interface.
 pub(crate) fn with_signer<T, F: FnOnce(&BoxedSigner) -> T>(signer_type: &SignerType, cb: F) -> T {
-    let instances = SIGNER_INSTANCES
-        .get_or_init(default_signers)
-        .read()
-        .unwrap();
-    if let Some(instance) = instances.get(signer_type) {
-        cb(instance)
-    } else {
-        panic!(format!("signer not initialized for type {:?}", signer_type))
-    }
+  let instances = SIGNERS_INSTANCE
+    .get_or_init(default_signers)
+    .read()
+    .unwrap();
+  if let Some(instance) = instances.get(signer_type) {
+    cb(instance)
+  } else {
+    panic!(format!("signer not initialized for type {:?}", signer_type))
+  }
 }

--- a/src/signing/stronghold.rs
+++ b/src/signing/stronghold.rs
@@ -6,64 +6,65 @@ use std::convert::TryInto;
 pub struct StrongholdSigner;
 
 impl super::Signer for StrongholdSigner {
-  fn init_account(&self, account: &Account, mnemonic: Option<String>) -> crate::Result<String> {
-    let stronghold_account_res: crate::Result<stronghold::Account> =
-      crate::with_stronghold_from_path(account.storage_path(), |stronghold| {
-        let created_at_timestamp: u128 = account.created_at().timestamp().try_into().unwrap(); // safe to unwrap since it's > 0;
-        let account = match mnemonic {
-          Some(mnemonic) => stronghold.account_import(
-            Some(created_at_timestamp),
-            Some(created_at_timestamp),
-            mnemonic,
-            Some("password"),
-          )?,
-          None => stronghold.account_create(Some("password".to_string()))?,
-        };
-        Ok(account)
-      });
-    let stronghold_account = stronghold_account_res?;
-    let id = stronghold_account.id();
-    Ok(hex::encode(id))
-  }
+    fn init_account(&self, account: &Account, mnemonic: Option<String>) -> crate::Result<String> {
+        let stronghold_account_res: crate::Result<stronghold::Account> =
+            crate::with_stronghold_from_path(account.storage_path(), |stronghold| {
+                let created_at_timestamp: u128 =
+                    account.created_at().timestamp().try_into().unwrap(); // safe to unwrap since it's > 0;
+                let account = match mnemonic {
+                    Some(mnemonic) => stronghold.account_import(
+                        Some(created_at_timestamp),
+                        Some(created_at_timestamp),
+                        mnemonic,
+                        Some("password"),
+                    )?,
+                    None => stronghold.account_create(Some("password".to_string()))?,
+                };
+                Ok(account)
+            });
+        let stronghold_account = stronghold_account_res?;
+        let id = stronghold_account.id();
+        Ok(hex::encode(id))
+    }
 
-  fn generate_address(
-    &self,
-    account: &Account,
-    address_index: usize,
-    internal: bool,
-  ) -> crate::Result<iota::Address> {
-    crate::with_stronghold_from_path(account.storage_path(), |stronghold| {
-      let address_str = stronghold.address_get(
-        &account_id_to_stronghold_record_id(account.id())?,
-        Some(*account.index()),
-        address_index,
-        internal,
-      )?;
-      crate::address::parse(address_str)
-    })
-  }
+    fn generate_address(
+        &self,
+        account: &Account,
+        address_index: usize,
+        internal: bool,
+    ) -> crate::Result<iota::Address> {
+        crate::with_stronghold_from_path(account.storage_path(), |stronghold| {
+            let address_str = stronghold.address_get(
+                &account_id_to_stronghold_record_id(account.id())?,
+                Some(*account.index()),
+                address_index,
+                internal,
+            )?;
+            crate::address::parse(address_str)
+        })
+    }
 
-  fn sign_message(
-    &self,
-    account: &Account,
-    essence: &iota::TransactionEssence,
-    inputs: &mut Vec<super::TransactionInput>,
-  ) -> crate::Result<Vec<iota::UnlockBlock>> {
-    let mut inputs = inputs
-      .into_iter()
-      .map(|i| stronghold::AddressIndexRecorder {
-        input: i.input.clone(),
-        address_index: i.address_index,
-        address_path: i.address_path.clone(),
-      })
-      .collect::<Vec<stronghold::AddressIndexRecorder>>();
-    crate::with_stronghold_from_path(account.storage_path(), |stronghold| {
-      stronghold.get_transaction_unlock_blocks(
-        &account_id_to_stronghold_record_id(account.id())?,
-        &essence,
-        &mut inputs,
-      )
-    })
-    .map_err(|e| e.into())
-  }
+    fn sign_message(
+        &self,
+        account: &Account,
+        essence: &iota::TransactionEssence,
+        inputs: &mut Vec<super::TransactionInput>,
+    ) -> crate::Result<Vec<iota::UnlockBlock>> {
+        let mut inputs = inputs
+            .into_iter()
+            .map(|i| stronghold::AddressIndexRecorder {
+                input: i.input.clone(),
+                address_index: i.address_index,
+                address_path: i.address_path.clone(),
+            })
+            .collect::<Vec<stronghold::AddressIndexRecorder>>();
+        crate::with_stronghold_from_path(account.storage_path(), |stronghold| {
+            stronghold.get_transaction_unlock_blocks(
+                &account_id_to_stronghold_record_id(account.id())?,
+                &essence,
+                &mut inputs,
+            )
+        })
+        .map_err(|e| e.into())
+    }
 }

--- a/src/signing/stronghold.rs
+++ b/src/signing/stronghold.rs
@@ -17,64 +17,65 @@ use std::convert::TryInto;
 pub struct StrongholdSigner;
 
 impl super::Signer for StrongholdSigner {
-  fn init_account(&self, account: &Account, mnemonic: Option<String>) -> crate::Result<String> {
-    let stronghold_account_res: crate::Result<stronghold::Account> =
-      crate::with_stronghold_from_path(account.storage_path(), |stronghold| {
-        let created_at_timestamp: u128 = account.created_at().timestamp().try_into().unwrap(); // safe to unwrap since it's > 0;
-        let account = match mnemonic {
-          Some(mnemonic) => stronghold.account_import(
-            Some(created_at_timestamp),
-            Some(created_at_timestamp),
-            mnemonic,
-            Some("password"),
-          )?,
-          None => stronghold.account_create(Some("password".to_string()))?,
-        };
-        Ok(account)
-      });
-    let stronghold_account = stronghold_account_res?;
-    let id = stronghold_account.id();
-    Ok(hex::encode(id))
-  }
+    fn init_account(&self, account: &Account, mnemonic: Option<String>) -> crate::Result<String> {
+        let stronghold_account_res: crate::Result<stronghold::Account> =
+            crate::with_stronghold_from_path(account.storage_path(), |stronghold| {
+                let created_at_timestamp: u128 =
+                    account.created_at().timestamp().try_into().unwrap(); // safe to unwrap since it's > 0;
+                let account = match mnemonic {
+                    Some(mnemonic) => stronghold.account_import(
+                        Some(created_at_timestamp),
+                        Some(created_at_timestamp),
+                        mnemonic,
+                        Some("password"),
+                    )?,
+                    None => stronghold.account_create(Some("password".to_string()))?,
+                };
+                Ok(account)
+            });
+        let stronghold_account = stronghold_account_res?;
+        let id = stronghold_account.id();
+        Ok(hex::encode(id))
+    }
 
-  fn generate_address(
-    &self,
-    account: &Account,
-    address_index: usize,
-    internal: bool,
-  ) -> crate::Result<iota::Address> {
-    crate::with_stronghold_from_path(account.storage_path(), |stronghold| {
-      let address_str = stronghold.address_get(
-        &account_id_to_stronghold_record_id(account.id())?,
-        Some(*account.index()),
-        address_index,
-        internal,
-      )?;
-      crate::address::parse(address_str)
-    })
-  }
+    fn generate_address(
+        &self,
+        account: &Account,
+        address_index: usize,
+        internal: bool,
+    ) -> crate::Result<iota::Address> {
+        crate::with_stronghold_from_path(account.storage_path(), |stronghold| {
+            let address_str = stronghold.address_get(
+                &account_id_to_stronghold_record_id(account.id())?,
+                Some(*account.index()),
+                address_index,
+                internal,
+            )?;
+            crate::address::parse(address_str)
+        })
+    }
 
-  fn sign_message(
-    &self,
-    account: &Account,
-    essence: &iota::TransactionEssence,
-    inputs: &mut Vec<super::TransactionInput>,
-  ) -> crate::Result<Vec<iota::UnlockBlock>> {
-    let mut inputs = inputs
-      .iter_mut()
-      .map(|i| stronghold::AddressIndexRecorder {
-        input: i.input.clone(),
-        address_index: i.address_index,
-        address_path: i.address_path.clone(),
-      })
-      .collect::<Vec<stronghold::AddressIndexRecorder>>();
-    crate::with_stronghold_from_path(account.storage_path(), |stronghold| {
-      stronghold.get_transaction_unlock_blocks(
-        &account_id_to_stronghold_record_id(account.id())?,
-        &essence,
-        &mut inputs,
-      )
-    })
-    .map_err(|e| e.into())
-  }
+    fn sign_message(
+        &self,
+        account: &Account,
+        essence: &iota::TransactionEssence,
+        inputs: &mut Vec<super::TransactionInput>,
+    ) -> crate::Result<Vec<iota::UnlockBlock>> {
+        let mut inputs = inputs
+            .iter_mut()
+            .map(|i| stronghold::AddressIndexRecorder {
+                input: i.input.clone(),
+                address_index: i.address_index,
+                address_path: i.address_path.clone(),
+            })
+            .collect::<Vec<stronghold::AddressIndexRecorder>>();
+        crate::with_stronghold_from_path(account.storage_path(), |stronghold| {
+            stronghold.get_transaction_unlock_blocks(
+                &account_id_to_stronghold_record_id(account.id())?,
+                &essence,
+                &mut inputs,
+            )
+        })
+        .map_err(|e| e.into())
+    }
 }

--- a/src/signing/stronghold.rs
+++ b/src/signing/stronghold.rs
@@ -1,3 +1,14 @@
+// Copyright 2020 IOTA Stiftung
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and limitations under the License.
+
 use crate::account::{account_id_to_stronghold_record_id, Account};
 
 use std::convert::TryInto;

--- a/src/signing/stronghold.rs
+++ b/src/signing/stronghold.rs
@@ -1,0 +1,69 @@
+use crate::account::{account_id_to_stronghold_record_id, Account};
+
+use std::convert::TryInto;
+
+#[derive(Default)]
+pub struct StrongholdSigner;
+
+impl super::Signer for StrongholdSigner {
+  fn init_account(&self, account: &Account, mnemonic: Option<String>) -> crate::Result<String> {
+    let stronghold_account_res: crate::Result<stronghold::Account> =
+      crate::with_stronghold_from_path(account.storage_path(), |stronghold| {
+        let created_at_timestamp: u128 = account.created_at().timestamp().try_into().unwrap(); // safe to unwrap since it's > 0;
+        let account = match mnemonic {
+          Some(mnemonic) => stronghold.account_import(
+            Some(created_at_timestamp),
+            Some(created_at_timestamp),
+            mnemonic,
+            Some("password"),
+          )?,
+          None => stronghold.account_create(Some("password".to_string()))?,
+        };
+        Ok(account)
+      });
+    let stronghold_account = stronghold_account_res?;
+    let id = stronghold_account.id();
+    Ok(hex::encode(id))
+  }
+
+  fn generate_address(
+    &self,
+    account: &Account,
+    address_index: usize,
+    internal: bool,
+  ) -> crate::Result<iota::Address> {
+    crate::with_stronghold_from_path(account.storage_path(), |stronghold| {
+      let address_str = stronghold.address_get(
+        &account_id_to_stronghold_record_id(account.id())?,
+        Some(*account.index()),
+        address_index,
+        internal,
+      )?;
+      crate::address::parse(address_str)
+    })
+  }
+
+  fn sign_message(
+    &self,
+    account: &Account,
+    essence: &iota::TransactionEssence,
+    inputs: &mut Vec<super::TransactionInput>,
+  ) -> crate::Result<Vec<iota::UnlockBlock>> {
+    let mut inputs = inputs
+      .into_iter()
+      .map(|i| stronghold::AddressIndexRecorder {
+        input: i.input.clone(),
+        address_index: i.address_index,
+        address_path: i.address_path.clone(),
+      })
+      .collect::<Vec<stronghold::AddressIndexRecorder>>();
+    crate::with_stronghold_from_path(account.storage_path(), |stronghold| {
+      stronghold.get_transaction_unlock_blocks(
+        &account_id_to_stronghold_record_id(account.id())?,
+        &essence,
+        &mut inputs,
+      )
+    })
+    .map_err(|e| e.into())
+  }
+}

--- a/src/signing/stronghold.rs
+++ b/src/signing/stronghold.rs
@@ -6,65 +6,64 @@ use std::convert::TryInto;
 pub struct StrongholdSigner;
 
 impl super::Signer for StrongholdSigner {
-    fn init_account(&self, account: &Account, mnemonic: Option<String>) -> crate::Result<String> {
-        let stronghold_account_res: crate::Result<stronghold::Account> =
-            crate::with_stronghold_from_path(account.storage_path(), |stronghold| {
-                let created_at_timestamp: u128 =
-                    account.created_at().timestamp().try_into().unwrap(); // safe to unwrap since it's > 0;
-                let account = match mnemonic {
-                    Some(mnemonic) => stronghold.account_import(
-                        Some(created_at_timestamp),
-                        Some(created_at_timestamp),
-                        mnemonic,
-                        Some("password"),
-                    )?,
-                    None => stronghold.account_create(Some("password".to_string()))?,
-                };
-                Ok(account)
-            });
-        let stronghold_account = stronghold_account_res?;
-        let id = stronghold_account.id();
-        Ok(hex::encode(id))
-    }
+  fn init_account(&self, account: &Account, mnemonic: Option<String>) -> crate::Result<String> {
+    let stronghold_account_res: crate::Result<stronghold::Account> =
+      crate::with_stronghold_from_path(account.storage_path(), |stronghold| {
+        let created_at_timestamp: u128 = account.created_at().timestamp().try_into().unwrap(); // safe to unwrap since it's > 0;
+        let account = match mnemonic {
+          Some(mnemonic) => stronghold.account_import(
+            Some(created_at_timestamp),
+            Some(created_at_timestamp),
+            mnemonic,
+            Some("password"),
+          )?,
+          None => stronghold.account_create(Some("password".to_string()))?,
+        };
+        Ok(account)
+      });
+    let stronghold_account = stronghold_account_res?;
+    let id = stronghold_account.id();
+    Ok(hex::encode(id))
+  }
 
-    fn generate_address(
-        &self,
-        account: &Account,
-        address_index: usize,
-        internal: bool,
-    ) -> crate::Result<iota::Address> {
-        crate::with_stronghold_from_path(account.storage_path(), |stronghold| {
-            let address_str = stronghold.address_get(
-                &account_id_to_stronghold_record_id(account.id())?,
-                Some(*account.index()),
-                address_index,
-                internal,
-            )?;
-            crate::address::parse(address_str)
-        })
-    }
+  fn generate_address(
+    &self,
+    account: &Account,
+    address_index: usize,
+    internal: bool,
+  ) -> crate::Result<iota::Address> {
+    crate::with_stronghold_from_path(account.storage_path(), |stronghold| {
+      let address_str = stronghold.address_get(
+        &account_id_to_stronghold_record_id(account.id())?,
+        Some(*account.index()),
+        address_index,
+        internal,
+      )?;
+      crate::address::parse(address_str)
+    })
+  }
 
-    fn sign_message(
-        &self,
-        account: &Account,
-        essence: &iota::TransactionEssence,
-        inputs: &mut Vec<super::TransactionInput>,
-    ) -> crate::Result<Vec<iota::UnlockBlock>> {
-        let mut inputs = inputs
-            .into_iter()
-            .map(|i| stronghold::AddressIndexRecorder {
-                input: i.input.clone(),
-                address_index: i.address_index,
-                address_path: i.address_path.clone(),
-            })
-            .collect::<Vec<stronghold::AddressIndexRecorder>>();
-        crate::with_stronghold_from_path(account.storage_path(), |stronghold| {
-            stronghold.get_transaction_unlock_blocks(
-                &account_id_to_stronghold_record_id(account.id())?,
-                &essence,
-                &mut inputs,
-            )
-        })
-        .map_err(|e| e.into())
-    }
+  fn sign_message(
+    &self,
+    account: &Account,
+    essence: &iota::TransactionEssence,
+    inputs: &mut Vec<super::TransactionInput>,
+  ) -> crate::Result<Vec<iota::UnlockBlock>> {
+    let mut inputs = inputs
+      .iter_mut()
+      .map(|i| stronghold::AddressIndexRecorder {
+        input: i.input.clone(),
+        address_index: i.address_index,
+        address_path: i.address_path.clone(),
+      })
+      .collect::<Vec<stronghold::AddressIndexRecorder>>();
+    crate::with_stronghold_from_path(account.storage_path(), |stronghold| {
+      stronghold.get_transaction_unlock_blocks(
+        &account_id_to_stronghold_record_id(account.id())?,
+        &essence,
+        &mut inputs,
+      )
+    })
+    .map_err(|e| e.into())
+  }
 }


### PR DESCRIPTION
# Description of change

Introduces account type so different signing providers are supported (e.g. stronghold, ledger, plain mnemonic...) 

## Links to any relevant issues

#80 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Unit tests.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked that new and existing unit tests pass locally with my changes
