### PR TITLE
fix(transfer): skip pending address outputs, wait/sync if outputs are pending

### DIFF
--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -11,12 +11,19 @@ use crate::{
 use getset::Getters;
 use iota::message::prelude::{
     Input, Message as IotaMessage, MessageId, Payload, SignatureLockedSingleOutput, Transaction, TransactionEssence,
-    TransactionId, UTXOInput,
+    UTXOInput,
 };
 use serde::{Deserialize, Serialize};
 use slip10::BIP32Path;
 
-use std::{convert::TryInto, num::NonZeroU64, path::PathBuf};
+use std::{
+    convert::TryInto,
+    num::NonZeroU64,
+    path::PathBuf,
+    sync::{mpsc::channel, Arc, Mutex},
+    thread,
+    time::Duration,
+};
 
 mod input_selection;
 
@@ -155,10 +162,10 @@ async fn sync_messages(
 }
 
 async fn update_account_messages<'a>(
-    account: &'a Account,
+    account: &'a mut Account,
     new_messages: &'a [(MessageId, IotaMessage)],
 ) -> crate::Result<()> {
-    let mut messages: Vec<Message> = account.messages().to_vec();
+    let mut messages = account.messages().to_vec();
 
     // sync `broadcasted` state
     messages
@@ -175,11 +182,14 @@ async fn update_account_messages<'a>(
     let client = client.read().unwrap();
     for message in unconfirmed_messages.iter_mut() {
         let metadata = client.get_message().metadata(message.id()).await?;
-        let confirmed = !(metadata.should_promote.unwrap_or(true) || metadata.should_reattach.unwrap_or(true));
+        let confirmed = metadata.ledger_inclusion_state == Some("included".to_string());
         if confirmed {
             message.set_confirmed(true);
+            account.on_message_confirmation_change(message.id());
         }
     }
+
+    account.set_messages(messages);
 
     Ok(())
 }
@@ -206,7 +216,7 @@ async fn perform_sync(
     let synced_messages = sync_messages(&mut account, address_index).await?;
     new_messages.extend(synced_messages.into_iter());
 
-    update_account_messages(&account, &new_messages).await?;
+    update_account_messages(&mut account, &new_messages).await?;
 
     let mut addresses_to_save = vec![];
     let mut ignored_addresses = vec![];
@@ -380,21 +390,22 @@ impl SyncedAccount {
     fn select_inputs<'a>(
         &self,
         threshold: u64,
-        account: &'a Account,
+        account: &'a mut Account,
         address: &'a IotaAddress,
     ) -> crate::Result<(Vec<Address>, Option<Address>)> {
         let mut available_addresses: Vec<Address> = account
             .addresses()
             .iter()
             .cloned()
-            .filter(|a| a.address() != address && *a.balance() > 0)
+            .filter(|a| a.address() != address && a.available_balance() > 0)
             .collect();
         let addresses = input_selection::select_input(threshold, &mut available_addresses)?;
-        let remainder = if addresses.iter().fold(0, |acc, a| acc + a.balance()) > threshold {
+        let remainder = if addresses.iter().fold(0, |acc, a| acc + a.available_balance()) > threshold {
             addresses.last().cloned()
         } else {
             None
         };
+
         Ok((addresses, remainder))
     }
 
@@ -410,6 +421,43 @@ impl SyncedAccount {
         let account_id: AccountIdentifier = self.account_id.clone().into();
         let mut account = crate::storage::get_account(&self.storage_path, account_id.clone())?;
         let mut addresses_to_watch = vec![];
+
+        if value > account.total_balance() {
+            return Err(crate::WalletError::InsufficientFunds);
+        }
+
+        // if the transfer value exceeds the account's available balance,
+        // wait for an account update or sync it with the tangle
+        if value > account.available_balance() {
+            let (tx, rx) = channel();
+            let tx = Arc::new(Mutex::new(tx));
+
+            let storage_path = self.storage_path.clone();
+            let account_id = account_id.clone();
+            let timeout = 5000;
+            thread::spawn(move || {
+                let tx = tx.lock().unwrap();
+                for _ in 1..5 {
+                    thread::sleep(Duration::from_millis(timeout / 5));
+                    if let Ok(account) = crate::storage::get_account(&storage_path, account_id.clone()) {
+                        // the account received an update and now the balance is sufficient
+                        if value <= account.available_balance() {
+                            let _ = tx.send(account);
+                        }
+                    }
+                }
+            });
+
+            match rx.recv_timeout(Duration::from_millis(timeout)) {
+                Ok(acc) => {
+                    account = acc;
+                }
+                Err(_) => {
+                    // if we got a timeout waiting for the account update, we try to sync it
+                    account.sync().execute().await?;
+                }
+            }
+        }
 
         let client = crate::client::get_client(account.client_options());
         let client = client.read().unwrap();
@@ -428,29 +476,27 @@ impl SyncedAccount {
 
         // select the input addresses and check if a remainder address is needed
         let (input_addresses, remainder_address) =
-            self.select_inputs(transfer_obj.amount, &account, &transfer_obj.address)?;
+            self.select_inputs(transfer_obj.amount, &mut account, &transfer_obj.address)?;
 
         let mut utxos = vec![];
         let mut address_index_recorders = vec![];
 
         for input_address in &input_addresses {
-            let address_outputs = input_address.outputs();
             let mut outputs = vec![];
             let address_path = BIP32Path::from_str(&format!(
                 "m/44H/4218H/{}H/{}H/{}H",
-                account.index(),
+                *account.index(),
                 *input_address.internal() as u32,
                 *input_address.key_index()
             ))
             .unwrap();
-            for (offset, output) in address_outputs.iter().enumerate() {
-                let output = client
-                    .get_output(
-                        &UTXOInput::new(*output.transaction_id(), *output.index())
-                            .map_err(|e| anyhow::anyhow!(e.to_string()))?,
-                    )
-                    .await?;
-                outputs.push((output, *input_address.key_index(), address_path.clone()));
+
+            for (offset, address_output) in input_address.available_outputs().iter().enumerate() {
+                outputs.push((
+                    (*address_output).clone(),
+                    *input_address.key_index(),
+                    address_path.clone(),
+                ));
             }
             utxos.extend(outputs.into_iter());
         }
@@ -459,16 +505,9 @@ impl SyncedAccount {
         let mut current_output_sum = 0;
         let mut remainder_value = 0;
         for (utxo, address_index, address_path) in utxos {
-            let input: Input = UTXOInput::new(
-                TransactionId::new(
-                    utxo.transaction_id[..]
-                        .try_into()
-                        .map_err(|_| crate::WalletError::InvalidTransactionIdLength)?,
-                ),
-                utxo.output_index,
-            )
-            .map_err(|e| anyhow::anyhow!(e.to_string()))?
-            .into();
+            let input: Input = UTXOInput::new(*utxo.transaction_id(), *utxo.index())
+                .map_err(|e| anyhow::anyhow!(e.to_string()))?
+                .into();
             essence_builder = essence_builder.add_input(input.clone());
             address_index_recorders.push(crate::signing::TransactionInput {
                 input,
@@ -477,12 +516,12 @@ impl SyncedAccount {
             });
             if current_output_sum == value {
                 // already filled the transfer value; just collect the output value as remainder
-                remainder_value += utxo.amount;
-            } else if current_output_sum + utxo.amount > value {
+                remainder_value += *utxo.amount();
+            } else if current_output_sum + *utxo.amount() > value {
                 // if the used UTXO amount is greater than the transfer value, this is the last iteration and we'll have
                 // remainder value. we add an Output for the missing value and collect the remainder
                 let missing_value = value - current_output_sum;
-                remainder_value += utxo.amount - missing_value;
+                remainder_value += *utxo.amount() - missing_value;
                 essence_builder = essence_builder.add_output(
                     SignatureLockedSingleOutput::new(
                         transfer_obj.address.clone(),
@@ -495,11 +534,11 @@ impl SyncedAccount {
                 essence_builder = essence_builder.add_output(
                     SignatureLockedSingleOutput::new(
                         transfer_obj.address.clone(),
-                        NonZeroU64::new(utxo.amount).ok_or_else(|| anyhow::anyhow!("invalid amount"))?,
+                        NonZeroU64::new(*utxo.amount()).ok_or_else(|| anyhow::anyhow!("invalid amount"))?,
                     )
                     .into(),
                 );
-                current_output_sum += utxo.amount;
+                current_output_sum += *utxo.amount();
             }
         }
 
@@ -562,6 +601,19 @@ impl SyncedAccount {
             .map_err(|e| anyhow::anyhow!(e.to_string()))?;
 
         let message_id = client.post_message(&message).await?;
+
+        for input_address in &input_addresses {
+            // get a mutable reference to the account address
+            let account_address = account
+                .addresses_mut()
+                .iter_mut()
+                .find(|a| a == &input_address)
+                .unwrap();
+            for output in account_address.available_outputs_mut().iter_mut() {
+                output.set_pending_on_message_id(Some(message_id));
+            }
+        }
+
         // if this is a transfer to the account's latest address or we used the latest as deposit of the remainder
         // value, we generate a new one to keep the latest address unused
         let latest_address = account.latest_address().unwrap().address();
@@ -643,10 +695,10 @@ pub(crate) async fn repost_message(
     action: RepostAction,
 ) -> crate::Result<Message> {
     let mut account: Account = crate::storage::get_account(&storage_path, account_id)?;
-    match account.get_message(message_id) {
+    let message = match account.get_message(message_id) {
         Some(message_to_repost) => {
             // get the latest reattachment of the message we want to promote/rettry/reattach
-            let messages = account.list_messages(0, 0, None);
+            let messages: Vec<Message> = account.list_messages(0, 0, None).into_iter().cloned().collect();
             let message_to_repost = messages
                 .iter()
                 .find(|m| m.payload() == message_to_repost.payload())
@@ -685,6 +737,10 @@ pub(crate) async fn repost_message(
             };
             let message = Message::from_iota_message(id, account.addresses(), &message)?;
 
+            if message.payload() == message_to_repost.payload() {
+                account.on_reattachment(message_to_repost.id(), message.id());
+            }
+
             account.append_messages(vec![message.clone()]);
             crate::storage::with_adapter(&storage_path, |storage| {
                 storage.set(account.id().into(), serde_json::to_string(&account)?)
@@ -693,7 +749,9 @@ pub(crate) async fn repost_message(
             Ok(message)
         }
         None => Err(crate::WalletError::MessageNotFound),
-    }
+    }?;
+
+    Ok(message)
 }
 
 #[cfg(test)]

--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -184,7 +184,7 @@ async fn update_account_messages<'a>(
     let client = client.read().unwrap();
     for message in unconfirmed_messages.iter_mut() {
         let metadata = client.get_message().metadata(message.id()).await?;
-        let confirmed = metadata.ledger_inclusion_state == Some("included".to_string());
+        let confirmed = metadata.ledger_inclusion_state.as_deref() == Some("included");
         if confirmed {
             message.set_confirmed(true);
         } else {

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -347,7 +347,7 @@ async fn poll(storage_path: PathBuf, syncing: bool) -> crate::Result<()> {
                     None => false,
                 };
                 if changed {
-                    if account_after_sync.on_message_confirmation_change(message.id()) {
+                    if !message.confirmed() && account_after_sync.on_message_unconfirmed(message.id()) {
                         account_after_sync.save()?;
                     }
                     emit_confirmation_state_change(account_after_sync.id().clone(), &message, true);

--- a/src/address.rs
+++ b/src/address.rs
@@ -191,7 +191,7 @@ impl Address {
     }
 
     pub(crate) fn append_outputs(&mut self, outputs: Vec<AddressOutput>) {
-        outputs.into_iter().for_each(|output| {
+        for output in outputs {
             let is_new_output = self
                 .outputs
                 .iter()
@@ -205,7 +205,7 @@ impl Address {
             if is_new_output {
                 self.outputs.push(output);
             }
-        });
+        }
     }
 
     pub(crate) fn outputs_mut(&mut self) -> &mut Vec<AddressOutput> {

--- a/src/address.rs
+++ b/src/address.rs
@@ -17,7 +17,7 @@ use std::{
 };
 
 /// An Address output.
-#[derive(Debug, Getters, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Getters, Setters, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[getset(get = "pub")]
 pub struct AddressOutput {
     /// Transaction ID of the output
@@ -28,8 +28,11 @@ pub struct AddressOutput {
     index: u16,
     /// Output amount.
     amount: u64,
-    /// Spend status of the output.
+    /// Spend status of the output,
     is_spent: bool,
+    /// The message id this output is pending spent.
+    #[getset(set = "pub(crate)")]
+    pending_on_message_id: Option<MessageId>,
 }
 
 impl TryFrom<OutputMetadata> for AddressOutput {
@@ -50,6 +53,7 @@ impl TryFrom<OutputMetadata> for AddressOutput {
             index: output.output_index,
             amount: output.amount,
             is_spent: output.is_spent,
+            pending_on_message_id: None,
         };
         Ok(output)
     }
@@ -185,6 +189,36 @@ impl Address {
                 self.outputs.push(output);
             }
         }
+    }
+
+    pub(crate) fn outputs_mut(&mut self) -> &mut Vec<AddressOutput> {
+        &mut self.outputs
+    }
+
+    /// Gets the list of outputs that aren't spent or pending.
+    pub fn available_outputs(&self) -> Vec<&AddressOutput> {
+        self.outputs
+            .iter()
+            .filter(|o| !(*o.is_spent() || o.pending_on_message_id().is_some()))
+            .collect()
+    }
+
+    pub(crate) fn available_outputs_mut(&mut self) -> Vec<&mut AddressOutput> {
+        self.outputs
+            .iter_mut()
+            .filter(|o| !(*o.is_spent() || o.pending_on_message_id().is_some()))
+            .collect()
+    }
+
+    pub(crate) fn available_balance(&self) -> u64 {
+        let spent = self.outputs().iter().fold(0, |acc, o| {
+            acc + if o.pending_on_message_id().is_some() {
+                *o.amount()
+            } else {
+                0
+            }
+        });
+        self.balance - spent
     }
 }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -62,6 +62,13 @@ pub struct TransactionConfirmationChangeEvent<'a> {
     confirmed: bool,
 }
 
+impl<'a> TransactionConfirmationChangeEvent<'a> {
+    #[doc(hidden)]
+    pub fn cloned_message(&self) -> Message {
+        self.message.clone()
+    }
+}
+
 struct BalanceEventHandler {
     /// The on event callback.
     on_event: Box<dyn Fn(&BalanceEvent<'_>) + Send>,
@@ -138,7 +145,7 @@ pub(crate) fn emit_balance_change(account_id: String, address: &Address, balance
         balance,
     };
     for listener in listeners.deref() {
-        (listener.on_event)(&event)
+        (listener.on_event)(&event);
     }
 }
 
@@ -153,7 +160,7 @@ pub(crate) fn emit_transaction_event(event_type: TransactionEventType, account_i
     };
     for listener in listeners.deref() {
         if listener.event_type == event_type {
-            (listener.on_event)(&event)
+            (listener.on_event)(&event);
         }
     }
 }
@@ -169,7 +176,7 @@ pub(crate) fn emit_confirmation_state_change(account_id: String, message: &Messa
         confirmed,
     };
     for listener in listeners.deref() {
-        (listener.on_event)(&event)
+        (listener.on_event)(&event);
     }
 }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -24,6 +24,13 @@ pub struct BalanceEvent<'a> {
     balance: u64,
 }
 
+impl<'a> BalanceEvent<'a> {
+    #[doc(hidden)]
+    pub fn cloned_address(&self) -> Address {
+        self.address.clone()
+    }
+}
+
 /// A transaction-related event data.
 #[derive(Getters, Serialize)]
 #[getset(get = "pub")]

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -220,7 +220,7 @@ fn process_metadata(
 ) -> crate::Result<()> {
     let account_id: AccountIdentifier = account_id_raw.clone().into();
     let metadata: MessageMetadata = serde_json::from_str(&payload)?;
-    let confirmed = metadata.ledger_inclusion_state == Some("included".to_string());
+    let confirmed = metadata.ledger_inclusion_state.as_deref() == Some("included");
 
     if confirmed != *message.confirmed() {
         mutate_account(&account_id, &storage_path, |account, addresses, messages| {

--- a/src/signing/env_mnemonic.rs
+++ b/src/signing/env_mnemonic.rs
@@ -51,7 +51,7 @@ fn derive_into_address(private_key: ed25519::Ed25519PrivateKey) -> String {
         result.extend(res.to_vec());
     });
 
-    bech32::encode("iota", result.to_base32()).unwrap()
+    bech32::encode("iot", result.to_base32()).unwrap()
 }
 
 #[derive(Default)]


### PR DESCRIPTION
# Description of change

Fixes a transfer issue when the current address output list isn't synchronized with the tangle UTXO state (previous messages aren't confirmed, leading to inputs being used on multiple messages). 

## Links to any relevant issues

Be sure to reference any related issues by adding `fixes issue #`.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

With the Faucet.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked that new and existing unit tests pass locally with my changes
