### PR TITLE
fix(sync): output list update, message confirmation detection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ blake2 = "0.9"
 unicode-normalization = "0.1.13"
 pbkdf2 = "0.3.0"
 sha2 = "0.8.1"
-bee-common = { git = "https://github.com/iotaledger/bee/", branch = "chrysalis-pt-2" }
+bee-common = { git = "https://github.com/iotaledger/bee/", branch = "30e718917fd68320d74dc61124322bfa17556780" }
 
 # stronghold
 iota-stronghold = { git = "https://github.com/iotaledger/stronghold.rs", branch = "feat/pre-refactor", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ blake2 = "0.9"
 unicode-normalization = "0.1.13"
 pbkdf2 = "0.3.0"
 sha2 = "0.8.1"
-bee-common = { git = "https://github.com/iotaledger/bee/", branch = "30e718917fd68320d74dc61124322bfa17556780" }
+bee-common = { git = "https://github.com/iotaledger/bee/", dev = "30e718917fd68320d74dc61124322bfa17556780" }
 
 # stronghold
 iota-stronghold = { git = "https://github.com/iotaledger/stronghold.rs", branch = "feat/pre-refactor", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ blake2 = "0.9"
 unicode-normalization = "0.1.13"
 pbkdf2 = "0.3.0"
 sha2 = "0.8.1"
-bee-common = { git = "https://github.com/iotaledger/bee/", dev = "30e718917fd68320d74dc61124322bfa17556780" }
+bee-common = { git = "https://github.com/iotaledger/bee/", rev = "30e718917fd68320d74dc61124322bfa17556780" }
 
 # stronghold
 iota-stronghold = { git = "https://github.com/iotaledger/stronghold.rs", branch = "feat/pre-refactor", optional = true }

--- a/bindings/node/README.md
+++ b/bindings/node/README.md
@@ -52,6 +52,10 @@ Creates a new instance of the AccountManager.
 | [storagePath] | <code>string</code> | <code>undefined</code> | The path where the database file will be saved        |
 | [storageType] | <code>number</code> | <code>undefined</code> | The type of the database.  Stronghold = 1, Sqlite = 2 |
 
+#### startBackgroundSync(): void
+
+Initialises the background polling mechanism and MQTT monitoring. Automatically called on `setStrongholdPassword`.
+
 #### setStrongholdPassword(password): void
 
 Sets the stronghold password and initialises it.

--- a/bindings/node/lib/index.d.ts
+++ b/bindings/node/lib/index.d.ts
@@ -127,6 +127,7 @@ export declare interface ManagerOptions {
 
 export declare class AccountManager {
   constructor(storagePath?: string)
+  startBackgroundSync(): void
   setStrongholdPassword(password: string): void
   createAccount(account: AccountToCreate): Account
   getAccount(accountId: string | number): Account | undefined

--- a/bindings/node/native/src/classes/account_manager/mod.rs
+++ b/bindings/node/native/src/classes/account_manager/mod.rs
@@ -120,6 +120,17 @@ declare_types! {
             Ok(cx.undefined().upcast())
         }
 
+        method startBackgroundSync(mut cx) {
+            {
+                let this = cx.this();
+                let guard = cx.lock();
+                let ref_ = &this.borrow(&guard).0;
+                let mut manager = ref_.write().unwrap();
+                manager.start_background_sync();
+            }
+            Ok(cx.undefined().upcast())
+        }
+
         method createAccount(mut cx) {
             let account = {
                 let account_to_create = cx.argument::<JsValue>(0)?;

--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -406,25 +406,9 @@ impl Account {
     pub(crate) fn append_addresses(&mut self, addresses: Vec<Address>) {
         addresses
             .into_iter()
-            .for_each(|mut address| match self.addresses.iter().position(|a| a == &address) {
+            .for_each(|address| match self.addresses.iter().position(|a| a == &address) {
                 Some(index) => {
-                    let old_address = &mut self.addresses[index];
-                    old_address.set_balance(*address.balance());
-                    old_address.outputs = address
-                        .outputs
-                        .iter_mut()
-                        .map(|output| {
-                            if let Some(old_output) = old_address.outputs().iter().find(|o| {
-                                o.message_id() == output.message_id()
-                                    && o.transaction_id() == output.transaction_id()
-                                    && o.index() == output.index()
-                                    && o.amount() == output.amount()
-                            }) {
-                                output.set_pending_on_message_id(*old_output.pending_on_message_id());
-                            }
-                            output.clone()
-                        })
-                        .collect();
+                    self.addresses[index] = address;
                 }
                 None => {
                     self.addresses.push(address);

--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -102,6 +102,10 @@ async fn sync_addresses(
                 continue;
             }
 
+            if let Some(account_address) = account.addresses().iter().find(|a| a.address() == iota_address) {
+                account_address.fill_outputs_lock(&mut curr_found_outputs);
+            }
+
             let address = AddressBuilder::new()
                 .address(iota_address.clone())
                 .key_index(*iota_address_index)
@@ -156,7 +160,7 @@ async fn sync_messages(
             outputs.push(output);
         }
 
-        address.append_outputs(outputs);
+        address.filter_outputs(outputs);
         address.set_balance(balance);
     }
 
@@ -184,11 +188,13 @@ async fn update_account_messages<'a>(
     let client = client.read().unwrap();
     for message in unconfirmed_messages.iter_mut() {
         let metadata = client.get_message().metadata(message.id()).await?;
-        let confirmed = metadata.ledger_inclusion_state.as_deref() == Some("included");
-        if confirmed {
-            message.set_confirmed(true);
-        } else {
-            account.on_message_unconfirmed(message.id());
+        if let Some(inclusion_state) = metadata.ledger_inclusion_state {
+            let confirmed = inclusion_state == "included";
+            if confirmed {
+                message.set_confirmed(true);
+            } else {
+                account.on_message_unconfirmed(message.id());
+            }
         }
     }
 

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -91,6 +91,15 @@ impl AccountManager {
         Ok(())
     }
 
+    /// Initialises the background polling and MQTT monitoring.
+    pub fn start_background_sync(&mut self) {
+        if !self.started_monitoring {
+            let monitoring_disabled = self.start_monitoring().is_err();
+            self.start_polling(monitoring_disabled);
+            self.started_monitoring = true;
+        }
+    }
+
     /// Sets the stronghold password.
     pub fn set_stronghold_password<P: AsRef<str>>(&mut self, password: P) -> crate::Result<()> {
         let stronghold_path = self.storage_path.join(crate::storage::stronghold_snapshot_filename());
@@ -101,11 +110,7 @@ impl AccountManager {
             None,
         )?;
         crate::init_stronghold(&self.storage_path, stronghold);
-        if !self.started_monitoring {
-            let monitoring_disabled = self.start_monitoring().is_err();
-            self.start_polling(monitoring_disabled);
-            self.started_monitoring = true;
-        }
+        self.start_background_sync();
         Ok(())
     }
 
@@ -347,9 +352,6 @@ async fn poll(storage_path: PathBuf, syncing: bool) -> crate::Result<()> {
                     None => false,
                 };
                 if changed {
-                    if !message.confirmed() && account_after_sync.on_message_unconfirmed(message.id()) {
-                        account_after_sync.save()?;
-                    }
                     emit_confirmation_state_change(account_after_sync.id().clone(), &message, true);
                 }
             }

--- a/src/address.rs
+++ b/src/address.rs
@@ -190,22 +190,23 @@ impl Address {
         }
     }
 
-    pub(crate) fn append_outputs(&mut self, outputs: Vec<AddressOutput>) {
-        for output in outputs {
-            let is_new_output = self
-                .outputs
-                .iter()
-                .position(|o| {
-                    o.transaction_id == output.transaction_id
-                        && o.message_id == output.message_id
-                        && o.amount == output.amount
-                        && o.index == output.index
-                })
-                .is_none();
-            if is_new_output {
-                self.outputs.push(output);
+    pub(crate) fn fill_outputs_lock(&self, outputs: &mut Vec<AddressOutput>) {
+        for output in outputs.iter_mut() {
+            let original_output_opt = self.outputs.iter().find(|o| {
+                o.transaction_id == output.transaction_id
+                    && o.message_id == output.message_id
+                    && o.amount == output.amount
+                    && o.index == output.index
+            });
+            if let Some(original_output) = original_output_opt {
+                output.set_pending_on_message_id(original_output.pending_on_message_id().clone());
             }
         }
+    }
+
+    pub(crate) fn filter_outputs(&mut self, mut outputs: Vec<AddressOutput>) {
+        self.fill_outputs_lock(&mut outputs);
+        self.outputs = outputs;
     }
 
     pub(crate) fn outputs_mut(&mut self) -> &mut Vec<AddressOutput> {

--- a/src/address.rs
+++ b/src/address.rs
@@ -199,7 +199,7 @@ impl Address {
                     && o.index == output.index
             });
             if let Some(original_output) = original_output_opt {
-                output.set_pending_on_message_id(original_output.pending_on_message_id().clone());
+                output.set_pending_on_message_id(*original_output.pending_on_message_id());
             }
         }
     }


### PR DESCRIPTION
# Description of change

- Properly keep the output lock after a sync.
- Properly detect message confirmation state change (if the ledger inclusion state field is empty, ignore it).

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Faucet with two requests on the same time.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked that new and existing unit tests pass locally with my changes
