### PR TITLE
feat(lib): add `log` usage, expose bee's logger on nodejs binding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ bech32 = "0.7"
 hex = "0.4"
 futures = "0.3"
 backtrace = "0.3"
+log = "0.4"
 
 # env mnemonic
 bee-signing-ext = { git = "https://github.com/wusyong/bee-p.git", branch = "sign-ext", version = "^0.1.0-alpha" }

--- a/bindings/node/README.md
+++ b/bindings/node/README.md
@@ -64,10 +64,11 @@ Initializes the logging system.
 
 #### LogOutput
 
-| Param | Type                | Default                | Description                                    |
-| ----- | ------------------- | ---------------------- | ---------------------------------------------- |
-| name  | <code>string</code> | <code>undefined</code> | 'stdout' or a path to a file                   |
-| level | <code>string</code> | <code>undefined</code> | The maximum log level that this output accepts |
+| Param          | Type                  | Default                | Description                                          |
+| -------------- | --------------------- | ---------------------- | ---------------------------------------------------- |
+| name           | <code>string</code>   | <code>undefined</code> | 'stdout' or a path to a file                         |
+| level_filter   | <code>string</code>   | <code>'info'</code>    | The maximum log level that this output accepts       |
+| target_filters | <code>string[]</code> | <code>[]</code>        | Filters on the log target (library and module names) |
 
 ### addEventListener(event, cb)
 

--- a/bindings/node/README.md
+++ b/bindings/node/README.md
@@ -40,6 +40,35 @@ const account = await manager.createAccount({
 
 ## API Reference
 
+### initLogger(config: LogOptions)
+
+Initializes the logging system.
+
+#### LogOptions
+
+| Param         | Type                     | Default                | Description                             |
+| ------------- | ------------------------ | ---------------------- | --------------------------------------- |
+| color_enabled | <code>boolean</code>     | <code>undefined</code> | Whether to enable colored output or not |
+| outputs       | <code>LogOutput[]</code> | <code>undefined</code> | The log outputs                         |
+
+#### LogOutput
+
+| Param | Type                | Default                | Description                                    |
+| ----- | ------------------- | ---------------------- | ---------------------------------------------- |
+| name  | <code>string</code> | <code>undefined</code> | 'stdout' or a path to a file                   |
+| level | <code>string</code> | <code>undefined</code> | The maximum log level that this output accepts |
+
+### addEventListener(event, cb)
+
+Adds a new event listener with a callback in the form of `(err, data) => {}`.
+Supported event names:
+- ErrorThrown
+- BalanceChange
+- NewTransaction
+- ConfirmationStateChange
+- Reattachment
+- Broadcast
+
 ### AccountManager
 
 #### constructor([options])

--- a/bindings/node/lib/index.d.ts
+++ b/bindings/node/lib/index.d.ts
@@ -154,7 +154,8 @@ export declare type Event = 'ErrorThrown' |
 
 export interface LoggerOutput {
   name?: string
-  level?: 'off' | 'error' | 'warn' | 'info' | 'debug' | 'trace'
+  level_filter: 'off' | 'error' | 'warn' | 'info' | 'debug' | 'trace' = 'info'
+  target_filters?: string[]
 }
 
 export interface LoggerConfig {

--- a/bindings/node/lib/index.d.ts
+++ b/bindings/node/lib/index.d.ts
@@ -148,4 +148,15 @@ export declare type Event = 'ErrorThrown' |
   'Reattachment' |
   'Broadcast'
 
+export interface LoggerOutput {
+  name?: string
+  level?: 'off' | 'error' | 'warn' | 'info' | 'debug' | 'trace'
+}
+
+export interface LoggerConfig {
+  color_enabled?: boolean
+  outputs?: LoggerOutput[]
+}
+
 export declare function addEventListener(event: Event, cb: (err?: any, data?: { [k: string]: any }) => void): void
+export declare function initLogger(config: LoggerConfig)

--- a/bindings/node/lib/index.js
+++ b/bindings/node/lib/index.js
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 var addon = require('../native')
-const { AccountManager, Account, SyncedAccount, EventListener } = addon
+const { AccountManager, Account, SyncedAccount, EventListener, initLogger } = addon
 
 function promisify (fn) {
   return function () {
@@ -64,6 +64,7 @@ AccountManager.prototype.internalTransfer = promisify(AccountManager.prototype.i
 module.exports = {
   AccountManager,
   addEventListener,
+  initLogger: config => initLogger(JSON.stringify(config)),
   RemainderValueStrategy,
   StorageType: {
     Stronghold: 1,

--- a/bindings/node/native/Cargo.toml
+++ b/bindings/node/native/Cargo.toml
@@ -17,6 +17,7 @@ neon-build = "0.4.0"
 [dependencies]
 neon = "0.4.0"
 iota-wallet = { path = "../../../", version = "0.1.0", features = ["sqlite"] }
+iota-core = { git = "https://github.com/iotaledger/iota.rs", branch = "dev" }
 serde = "1.0"
 serde_json = "1.0"
 serde_repr = "0.1"

--- a/bindings/node/native/src/lib.rs
+++ b/bindings/node/native/src/lib.rs
@@ -10,6 +10,7 @@ use std::{
 };
 
 use futures::{Future, FutureExt};
+use iota::common::logger::{logger_init, LoggerConfigBuilder};
 use iota_wallet::{
     account::{Account, AccountIdentifier},
     WalletError,
@@ -148,8 +149,16 @@ pub(crate) fn block_on<C: futures::Future>(cb: C) -> C::Output {
     runtime.lock().unwrap().block_on(cb)
 }
 
+pub fn init_logger(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+    let config = cx.argument::<JsString>(0)?.value();
+    let config: LoggerConfigBuilder = serde_json::from_str(&config).expect("invalid logger config");
+    logger_init(config.finish()).expect("failed to init logger");
+    Ok(cx.undefined())
+}
+
 // Export the class
 register_module!(mut m, {
+    m.export_function("initLogger", init_logger)?;
     m.export_class::<JsAccountManager>("AccountManager")?;
     m.export_class::<JsAccount>("Account")?;
     m.export_class::<JsSyncedAccount>("SyncedAccount")?;

--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -371,7 +371,7 @@ impl Account {
 
         // ignore errors because we fallback to the polling system
         if let Err(e) = crate::monitor::monitor_address_balance(&self, address.address()) {
-            log::error!("error monitoring newly generated address: {:?}", e);
+            log::error!("[MQTT] error monitoring newly generated address: {:?}", e);
         }
 
         Ok(address)
@@ -408,7 +408,7 @@ impl Account {
 impl Drop for Account {
     fn drop(&mut self) {
         if let Err(e) = self.save_pending_changes() {
-            log::error!("error saving account pending changes: {:?}", e);
+            log::error!("[MQTT] error saving account pending changes: {:?}", e);
         }
     }
 }

--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -370,7 +370,10 @@ impl Account {
         })?;
 
         // ignore errors because we fallback to the polling system
-        let _ = crate::monitor::monitor_address_balance(&self, address.address());
+        if let Err(e) = crate::monitor::monitor_address_balance(&self, address.address()) {
+            log::error!("error monitoring newly generated address: {:?}", e);
+        }
+
         Ok(address)
     }
 
@@ -404,7 +407,9 @@ impl Account {
 
 impl Drop for Account {
     fn drop(&mut self) {
-        let _ = self.save_pending_changes();
+        if let Err(e) = self.save_pending_changes() {
+            log::error!("error saving account pending changes: {:?}", e);
+        }
     }
 }
 

--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -141,7 +141,9 @@ async fn sync_addresses(
         generated_addresses.extend(curr_generated_addresses.into_iter());
 
         if is_empty {
-            log::debug!("[SYNC] finishing address syncing because the current messages list and address list are empty");
+            log::debug!(
+                "[SYNC] finishing address syncing because the current messages list and address list are empty"
+            );
             break;
         }
     }

--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -202,7 +202,17 @@ async fn sync_messages(
                     outputs.push(output);
                 }
 
+                log::debug!(
+                    "[SYNC] synced address `{}` outputs; old array: {:?}",
+                    address.address().to_bech32(),
+                    address.outputs()
+                );
                 address.filter_outputs(outputs);
+                log::debug!(
+                    "[SYNC] address `{}` new outputs: {:?}",
+                    address.address().to_bech32(),
+                    address.outputs()
+                );
                 address.set_balance(balance);
 
                 crate::Result::Ok(messages)
@@ -393,8 +403,20 @@ impl<'a> AccountSynchronizer<'a> {
         let return_value =
             match perform_sync(&mut account_, &self.storage_path, self.address_index, self.gap_limit).await {
                 Ok(is_empty) => {
+                    log::debug!(
+                        "[SYNC] updating account `{}` addresses; old array: {:?}",
+                        self.account.alias(),
+                        self.account.addresses()
+                    );
                     self.account.set_addresses(account_.addresses().to_vec());
                     self.account.set_messages(account_.messages().to_vec());
+
+                    log::debug!(
+                        "[SYNC] updated account `{}` addresses; new array: {:?}",
+                        self.account.alias(),
+                        self.account.addresses()
+                    );
+
                     if !self.skip_persistance {
                         crate::storage::with_adapter(&self.storage_path, |storage| {
                             storage.set(self.account.id(), serde_json::to_string(&self.account)?)

--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -141,7 +141,7 @@ async fn sync_addresses(
         generated_addresses.extend(curr_generated_addresses.into_iter());
 
         if is_empty {
-            log::debug!("[SYNC] finishing address syncing because the current messages list and address list is empty");
+            log::debug!("[SYNC] finishing address syncing because the current messages list and address list are empty");
             break;
         }
     }
@@ -636,7 +636,7 @@ impl SyncedAccount {
             });
             if current_output_sum == value {
                 log::debug!(
-                    "[TRANFER] current output sum matches the transfer value, adding {} to the remainder value (currently at {})",
+                    "[TRANSFER] current output sum matches the transfer value, adding {} to the remainder value (currently at {})",
                     utxo.amount(),
                     remainder_value
                 );
@@ -644,7 +644,7 @@ impl SyncedAccount {
                 remainder_value += *utxo.amount();
             } else if current_output_sum + *utxo.amount() > value {
                 log::debug!(
-                    "[TRANFER] current output sum ({}) would exceed the transfer value if added the output amount ({})",
+                    "[TRANSFER] current output sum ({}) would exceed the transfer value if added to the output amount ({})",
                     current_output_sum,
                     utxo.amount()
                 );
@@ -695,7 +695,7 @@ impl SyncedAccount {
                 .find(|a| a.address() == &remainder_address.address)
                 .unwrap();
 
-            println!("[TRANFER] remainder value is {}", remainder_value);
+            println!("[TRANSFER] remainder value is {}", remainder_value);
 
             let remainder_target_address = match transfer_obj.remainder_value_strategy {
                 // use one of the account's addresses to send the remainder value
@@ -710,7 +710,7 @@ impl SyncedAccount {
                 RemainderValueStrategy::ChangeAddress => {
                     if *remainder_address.internal() {
                         let deposit_address = account_.latest_address().unwrap().address().clone();
-                        log::debug!("[TRANFER] the remainder address is internal, so using latest address as remainder target: {}", deposit_address.to_bech32());
+                        log::debug!("[TRANSFER] the remainder address is internal, so using latest address as remainder target: {}", deposit_address.to_bech32());
                         deposit_address
                     } else {
                         let change_address = crate::address::get_new_change_address(&account_, &remainder_address)?;

--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -592,7 +592,7 @@ impl SyncedAccount {
             if current_output_sum == value {
                 log::debug!(
                     "[TRANFER] current output sum matches the transfer value, adding {} to the remainder value (currently at {})",
-                    utxo.amount,
+                    utxo.amount(),
                     remainder_value
                 );
                 // already filled the transfer value; just collect the output value as remainder
@@ -623,7 +623,7 @@ impl SyncedAccount {
             } else {
                 log::debug!(
                     "[TRANSFER] adding output amount {}, current sum {}",
-                    utxo.amount,
+                    utxo.amount(),
                     current_output_sum
                 );
                 essence_builder = essence_builder.add_output(

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -347,7 +347,7 @@ async fn poll(storage_path: PathBuf, syncing: bool) -> crate::Result<()> {
                 .iter()
                 .filter(|message| !account_before_sync.messages().contains(message))
                 .for_each(|message| {
-                    log::debug!("[POLLING] new message: {:?}", message.id());
+                    log::info!("[POLLING] new message: {:?}", message.id());
                     emit_transaction_event(TransactionEventType::NewTransaction, account_after_sync.id(), &message)
                 });
 
@@ -358,14 +358,14 @@ async fn poll(storage_path: PathBuf, syncing: bool) -> crate::Result<()> {
                     None => false,
                 };
                 if changed {
-                    log::debug!("[POLLING] message confirmed: {:?}", message.id());
+                    log::info!("[POLLING] message confirmed: {:?}", message.id());
                     emit_confirmation_state_change(account_after_sync.id(), &message, true);
                 }
             }
         }
         retry_unconfirmed_transactions(synced_accounts.iter().zip(accounts_after_sync.iter()).collect()).await?
     } else {
-        log::debug!("[POLLING] skipping syncing process because MQTT is running");
+        log::info!("[POLLING] skipping syncing process because MQTT is running");
         let accounts = crate::storage::with_adapter(&storage_path, |storage| storage.get_all())?;
         let mut retried_messages = vec![];
         for mut account in crate::storage::parse_accounts(&storage_path, &accounts)? {
@@ -377,15 +377,15 @@ async fn poll(storage_path: PathBuf, syncing: bool) -> crate::Result<()> {
             let mut reattached_messages = Vec::new();
             let mut updated = false;
             for message in unconfirmed_messages {
-                log::debug!("[POLLING] retrying {:?}", message);
+                log::info!("[POLLING] retrying {:?}", message);
                 let new_message =
                     repost_message(account.id(), &storage_path, message.id(), RepostAction::Retry).await?;
                 if new_message.payload() == message.payload() {
-                    log::debug!("[POLLING] reattached and new message is {:?}", new_message.id());
+                    log::info!("[POLLING] reattached and new message is {:?}", new_message.id());
                     reattached_messages.push((*message.id(), *new_message.id()));
                     reattachments.push(new_message);
                 } else {
-                    log::debug!("[POLLING] promoted and new message is {:?}", new_message.id());
+                    log::info!("[POLLING] promoted and new message is {:?}", new_message.id());
                     promotions.push(new_message);
                 }
             }

--- a/src/address.rs
+++ b/src/address.rs
@@ -178,9 +178,11 @@ impl Address {
                     && (!o.is_spent && output.is_spent)
             });
             if let Some(spent_output) = spent_existing_output {
+                log::debug!("[ADDRESS] got spent of {:?}", spent_output);
                 self.balance -= output.amount;
                 self.outputs.remove(spent_output);
             } else {
+                log::debug!("[ADDRESS] got new output {:?}", output);
                 self.balance += output.amount;
                 self.outputs.push(output);
             }

--- a/src/address.rs
+++ b/src/address.rs
@@ -201,6 +201,11 @@ impl Address {
                     && o.index == output.index
             });
             if let Some(original_output) = original_output_opt {
+                log::debug!(
+                    "[SYNC] filling output lock on; output: {:?}, lock: {:?}",
+                    output,
+                    original_output.pending_on_message_id()
+                );
                 output.set_pending_on_message_id(*original_output.pending_on_message_id());
             }
         }

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -113,7 +113,7 @@ pub fn monitor_address_balance(account: &Account, address: &IotaAddress) -> crat
                     )
                     .await
                     {
-                        log::error!("error processing output: {:?}", e);
+                        log::error!("[MQTT] error processing output: {:?}", e);
                     }
                 });
             });
@@ -207,7 +207,7 @@ pub fn monitor_confirmation_state_change(account: &Account, message_id: &Message
                 &message,
                 &storage_path,
             ) {
-                log::error!("error processing metadata: {:?}", e);
+                log::error!("[MQTT] error processing metadata: {:?}", e);
             }
         },
     )?;

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -97,6 +97,7 @@ pub fn monitor_address_balance(account: &Account, address: &IotaAddress) -> crat
         account.client_options(),
         format!("addresses/{}/outputs", address_bech32),
         move |topic_event| {
+            log::debug!("[MQTT] got {:?}", topic_event);
             let topic_event = topic_event.clone();
             let account_id_raw = account_id_raw.clone();
             let address = address.clone();
@@ -200,6 +201,7 @@ pub fn monitor_confirmation_state_change(account: &Account, message_id: &Message
         account.client_options(),
         format!("messages/{}/metadata", message_id.to_string()),
         move |topic_event| {
+            log::debug!("[MQTT] got {:?}", topic_event);
             if let Err(e) = process_metadata(
                 topic_event.payload.clone(),
                 account_id_raw.clone(),

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -92,7 +92,7 @@ pub fn monitor_address_balance(account: &Account, address: &IotaAddress) -> crat
         account.client_options(),
         format!("addresses/{}/outputs", address_bech32),
         move |topic_event| {
-            log::debug!("[MQTT] got {:?}", topic_event);
+            log::info!("[MQTT] got {:?}", topic_event);
             let topic_event = topic_event.clone();
             let address = address.clone();
             let client_options = client_options.clone();
@@ -201,7 +201,7 @@ pub fn monitor_confirmation_state_change(account: &Account, message_id: &Message
         format!("messages/{}/metadata", message_id.to_string()),
         move |topic_event| {
             let account_id = account_id.clone();
-            log::debug!("[MQTT] got {:?}", topic_event);
+            log::info!("[MQTT] got {:?}", topic_event);
             if let Err(e) = process_metadata(
                 topic_event.payload.clone(),
                 account_id,


### PR DESCRIPTION
# Description of change

Use the `log` crate to log debug info and expose the bee-common logger on the binding. 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Faucet.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
