### PR TITLE
chore: add requirements to neon binding readme

### DIFF
--- a/bindings/node/README.md
+++ b/bindings/node/README.md
@@ -4,7 +4,7 @@ Node.js binding to the IOTA wallet library.
 
 ## Requirements
 
-`Rust` and `Cargo` are required. Install them [here](https://doc.rust-lang.org/cargo/getting-started/installation.html).
+Ensure you have first installed the required dependencies for the library [here](https://github.com/iotaledger/wallet.rs/blob/develop/README.md).
 
 ## Installation
 

--- a/bindings/node/README.md
+++ b/bindings/node/README.md
@@ -2,6 +2,10 @@
 
 Node.js binding to the IOTA wallet library.
 
+## Requirements
+
+`Rust` and `Cargo` are required. Install them [here](https://doc.rust-lang.org/cargo/getting-started/installation.html).
+
 ## Installation
 
 Currently the package isn't published so you'd need to link it to your project using `npm` or `yarn`.


### PR DESCRIPTION
# Description of change

Adds Rust and Cargo requirements to Neon binding readme.

## Type of change

- Documentation Fix