### PR TITLE
chore: add .env info to readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,7 @@ fn main() {
 
 ## API reference
 
-You can read the [API reference](https://docs.rs/iota-wallet) here, or generate it yourself.
-
-If you'd like to explore the implementation in more depth, the following command generates docs for the whole crate, including private modules:
+If you'd like to explore the implementation in more depth, the following command generates docs for the whole crate:
 
 ```
 cargo doc --document-private-items --no-deps --open

--- a/README.md
+++ b/README.md
@@ -5,11 +5,13 @@
 ## Introduction
 
 The wallet library is a stateful package with a standardised interface for developers to build applications involving IOTA value transactions.
-It offers abstractions to handle IOTA payments and can optionally interact with [IOTA Stronghold](https://github.com/iotaledger/stronghold.rs/) for seed handling, seed storage and state backup. See the full specification [here](https://github.com/iotaledger/wallet.rs/blob/master/specs/wallet-ENGINEERING-SPEC-0000.md).
+It offers abstractions to handle IOTA payments and can optionally interact with [IOTA Stronghold](https://github.com/iotaledger/stronghold.rs/) for seed handling, seed storage and state backup. Alternatively you can use the EnvMnemonic SignerType and a SQLite database. See the full specification [here](https://github.com/iotaledger/wallet.rs/blob/master/specs/wallet-ENGINEERING-SPEC-0000.md).
 
 ## Warning
 
 This library is in active development. The library targets the Chrysalis testnet and does not work with current IOTA mainnet.
+
+The Stronghold integration is not complete. We recommend you use SQLite and the EnvMnemonic SignerType (allowing you to store your mnemonic as an environment variable).
 
 ## Prerequisites
 
@@ -73,11 +75,22 @@ iota-wallet = { git = "https://github.com/iotaledger/wallet.rs" }
 In order to use the library you first need to create an `AccountManager`:
 
 ```rust
-use iota_wallet::account_manager::AccountManager;
-fn main() {
-  let mut manager = AccountManager::new().unwrap();
-  manager.set_stronghold_password("my-password").unwrap();
-  // now you can create accounts with `manager.create_account`, synchronize, send transfers, backup...
+use iota_wallet::{
+    account_manager::AccountManager, client::ClientOptionsBuilder, signing::SignerType,
+    storage::sqlite::SqliteStorageAdapter,
+};
+use std::path::PathBuf;
+#[tokio::main]
+async fn main() -> iota_wallet::Result<()> {
+    let storage_folder: PathBuf = "./my-db".into();
+    let manager =
+        AccountManager::with_storage_adapter(&storage_folder, SqliteStorageAdapter::new(&storage_folder, "accounts")?)?;
+    let client_options = ClientOptionsBuilder::node("http://api.lb-0.testnet.chrysalis2.com")?.build();
+    let account = manager
+        .create_account(client_options)
+        .signer_type(SignerType::EnvMnemonic)
+        .initialise()?;
+    Ok(())
 }
 ```
 
@@ -89,7 +102,7 @@ If you'd like to explore the implementation in more depth, the following command
 cargo doc --document-private-items --no-deps --open
 ```
 
-## Examples
+## Other Examples
 
 You can see the examples in the [examples](examples/) directory and try them with:
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,51 @@ This library is in active development. The library targets the Chrysalis testnet
 
 ## Prerequisites
 
-To use the library, we recommend you update Rust to the latest stable version [`rustup update stable`](https://github.com/rust-lang/rustup.rs#keeping-rust-up-to-date). Nightly should be fine but there's a chance some changes are not compatible.
+`Rust` and `Cargo` are required. Install them [here](https://doc.rust-lang.org/cargo/getting-started/installation.html).
+
+We recommend you update Rust to the latest stable version [`rustup update stable`](https://github.com/rust-lang/rustup.rs#keeping-rust-up-to-date). Nightly should be fine but there's a chance some changes are not compatible.
 
 `no_std` is not supported currently, but we are working on it, and will provide it as a feature once the new implementation is ready.
+
+### Dependencies
+
+`cmake` and `openssl` are required. In order to run the build process succesfully using Cargo you might need install additional build tools on your system. 
+
+### Windows
+
+`cmake` can be downloaded on the [official website](https://cmake.org/download/) and `openssl` can be installed with [vcpkg](https://github.com/microsoft/vcpkg) or [chocolatey](https://chocolatey.org/).
+
+- Installing `openssl` with `vcpkg`:
+
+```
+$ ./vcpkg.exe install openssl:x64-windows
+$ ./vcpkg.exe integrate install
+# you may want to add this to the system environment variables since you'll need it to compile the crate
+$ set VCPKGRS_DYNAMIC=1
+```
+
+- Installing `openssl` with `chocolatey`:
+
+```
+$ choco install openssl
+# you may need to set the OPENSSL_ROOT_DIR environment variable
+$ set OPENSSL_ROOT_DIR="C:\Program Files\OpenSSL-Win64"
+```
+
+### macOS
+
+`cmake` and `openssl` can be installed with `Homebrew`:
+
+```
+$ brew install cmake
+$ brew install openssl@1.1
+# you may want to add this to your .zshrc or .bashrc since you'll need it to compile the crate
+$ OPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1)
+```
+
+### Linux
+
+Install `cmake` and `openssl` with your distro's package manager or download from their websites. On Debian and Ubuntu you will also need `build-essential`.
 
 ## Usage
 

--- a/bindings/node/README.md
+++ b/bindings/node/README.md
@@ -27,15 +27,22 @@ $ yarn link iota-wallet
 
 After you linked the library, you can create an `AccountManager` instance and interface with it.
 
+While Stronghold is not ready, we recommend using the Sqlite StorageType and `EnvMnemonic` SignerType (this simply means you store your mnemonic as an environment variable).
+
+### Example 
+
 ```javascript
-const { AccountManager } = require('iota-wallet')
-const manager = new AccountManager()
-const account = await manager.createAccount({
-  alias: 'my first account',
-  clientOptions: {
-    node: 'http://localhost:14265'
-  }
+const { AccountManager, StorageType, SignerType } = require('iota-wallet')
+const manager = new AccountManager({
+    storagePath: './storage',
+    storageType: StorageType.Sqlite
 })
+const account = await manager.createAccount({
+  alias: 'Account1',
+  clientOptions: { node: 'http://api.lb-0.testnet.chrysalis2.com', localPow: false },
+  signerType: SignerType.EnvMnemonic
+})
+account.sync()
 ```
 
 ## API Reference


### PR DESCRIPTION
# Description of change

Adds information on how to use .env mnemonics to both main and neon readmes.

## Type of change

- Documentation Fix