### PR TITLE
refactor(account): keep all accounts in memory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ serde_repr = "0.1"
 once_cell = "1.4"
 iota-core = { git = "https://github.com/iotaledger/iota.rs", branch = "dev" }
 url = { version = "2.1", features = [ "serde" ] }
-tokio = "0.2"
+tokio = { version = "0.2", features = ["macros", "sync"] }
 rand = "0.3"
 rusqlite = { version = "0.23", features = ["bundled"], optional = true }
 slip10 = "0.4"

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ use iota_wallet::{
     storage::sqlite::SqliteStorageAdapter,
 };
 use std::path::PathBuf;
+
 #[tokio::main]
 async fn main() -> iota_wallet::Result<()> {
     let storage_folder: PathBuf = "./my-db".into();
@@ -89,7 +90,8 @@ async fn main() -> iota_wallet::Result<()> {
     let account = manager
         .create_account(client_options)
         .signer_type(SignerType::EnvMnemonic)
-        .initialise()?;
+        .initialise()
+        .await?;
     Ok(())
 }
 ```

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ use std::path::PathBuf;
 async fn main() -> iota_wallet::Result<()> {
     let storage_folder: PathBuf = "./my-db".into();
     let manager =
-        AccountManager::with_storage_adapter(&storage_folder, SqliteStorageAdapter::new(&storage_folder, "accounts")?)?;
+        AccountManager::with_storage_adapter(&storage_folder, SqliteStorageAdapter::new(&storage_folder, "accounts")?).await?;
     let client_options = ClientOptionsBuilder::node("http://api.lb-0.testnet.chrysalis2.com")?.build();
     let account = manager
         .create_account(client_options)

--- a/bindings/node/README.md
+++ b/bindings/node/README.md
@@ -63,10 +63,6 @@ Creates a new instance of the AccountManager.
 | [storagePath] | <code>string</code> | <code>undefined</code> | The path where the database file will be saved        |
 | [storageType] | <code>number</code> | <code>undefined</code> | The type of the database.  Stronghold = 1, Sqlite = 2 |
 
-#### startBackgroundSync(): void
-
-Initialises the background polling mechanism and MQTT monitoring. Automatically called on `setStrongholdPassword`.
-
 #### setStrongholdPassword(password): void
 
 Sets the stronghold password and initialises it.

--- a/bindings/node/lib/index.d.ts
+++ b/bindings/node/lib/index.d.ts
@@ -128,7 +128,6 @@ export declare interface ManagerOptions {
 
 export declare class AccountManager {
   constructor(storagePath?: string)
-  startBackgroundSync(): void
   setStrongholdPassword(password: string): void
   createAccount(account: AccountToCreate): Account
   getAccount(accountId: string | number): Account | undefined

--- a/bindings/node/native/src/classes/account/mod.rs
+++ b/bindings/node/native/src/classes/account/mod.rs
@@ -28,9 +28,7 @@ declare_types! {
                 let this = cx.this();
                 let guard = cx.lock();
                 let id = &this.borrow(&guard).0;
-                let account_handle = crate::get_account(id);
-                let account = account_handle.read().unwrap();
-                account.id().clone()
+                id.clone()
             };
 
             match id {
@@ -45,8 +43,7 @@ declare_types! {
                 let guard = cx.lock();
                 let id = &this.borrow(&guard).0;
                 let account_handle = crate::get_account(id);
-                let account = account_handle.read().unwrap();
-                *account.index()
+                crate::block_on(async move { account_handle.index().await })
             };
 
             Ok(cx.number(index as f64).upcast())
@@ -58,8 +55,7 @@ declare_types! {
                 let guard = cx.lock();
                 let id = &this.borrow(&guard).0;
                 let account_handle = crate::get_account(id);
-                let account = account_handle.read().unwrap();
-                account.alias().clone()
+                crate::block_on(async move { account_handle.alias().await })
             };
 
             Ok(cx.string(alias).upcast())
@@ -71,8 +67,7 @@ declare_types! {
                 let guard = cx.lock();
                 let id = &this.borrow(&guard).0;
                 let account_handle = crate::get_account(id);
-                let account = account_handle.read().unwrap();
-                account.available_balance()
+                crate::block_on(async move { account_handle.available_balance().await })
             };
             Ok(cx.number(balance as f64).upcast())
         }
@@ -83,8 +78,7 @@ declare_types! {
                 let guard = cx.lock();
                 let id = &this.borrow(&guard).0;
                 let account_handle = crate::get_account(id);
-                let account = account_handle.read().unwrap();
-                account.total_balance()
+                crate::block_on(async move { account_handle.total_balance().await })
             };
             Ok(cx.number(balance as f64).upcast())
         }
@@ -109,16 +103,18 @@ declare_types! {
             let this = cx.this();
             let id = cx.borrow(&this, |r| r.0.clone());
             let account_handle = crate::get_account(&id);
-            let account = account_handle.read().unwrap();
-            let messages = account.list_messages(count, from, filter);
+            crate::block_on(async move {
+                let account = account_handle.read().await;
+                let messages = account.list_messages(count, from, filter);
 
-            let js_array = JsArray::new(&mut cx, messages.len() as u32);
-            for (index, message) in messages.iter().enumerate() {
-                let value = neon_serde::to_value(&mut cx, &message)?;
-                js_array.set(&mut cx, index as u32, value)?;
-            }
+                let js_array = JsArray::new(&mut cx, messages.len() as u32);
+                for (index, message) in messages.iter().enumerate() {
+                    let value = neon_serde::to_value(&mut cx, &message)?;
+                    js_array.set(&mut cx, index as u32, value)?;
+                }
 
-            Ok(js_array.upcast())
+                Ok(js_array.upcast())
+            })
         }
 
         method listAddresses(mut cx) {
@@ -130,16 +126,18 @@ declare_types! {
             let this = cx.this();
             let id = cx.borrow(&this, |r| r.0.clone());
             let account_handle = crate::get_account(&id);
-            let account = account_handle.read().unwrap();
-            let addresses = account.list_addresses(unspent);
+            crate::block_on(async move {
+                let account = account_handle.read().await;
+                let addresses = account.list_addresses(unspent);
 
-            let js_array = JsArray::new(&mut cx, addresses.len() as u32);
-            for (index, address) in addresses.iter().enumerate() {
-                let value = neon_serde::to_value(&mut cx, &address)?;
-                js_array.set(&mut cx, index as u32, value)?;
-            }
+                let js_array = JsArray::new(&mut cx, addresses.len() as u32);
+                for (index, address) in addresses.iter().enumerate() {
+                    let value = neon_serde::to_value(&mut cx, &address)?;
+                    js_array.set(&mut cx, index as u32, value)?;
+                }
 
-            Ok(js_array.upcast())
+                Ok(js_array.upcast())
+            })
         }
 
         method setAlias(mut cx) {
@@ -149,8 +147,7 @@ declare_types! {
                 let guard = cx.lock();
                 let id = &this.borrow(&guard).0;
                 let account_handle = crate::get_account(id);
-                let mut account = account_handle.write().unwrap();
-                account.set_alias(alias);
+                crate::block_on(async move { account_handle.set_alias(alias).await; });
             }
             Ok(cx.undefined().upcast())
         }
@@ -163,8 +160,7 @@ declare_types! {
                 let guard = cx.lock();
                 let id = &this.borrow(&guard).0;
                 let account_handle = crate::get_account(id);
-                let mut account = account_handle.write().unwrap();
-                account.set_client_options(client_options);
+                crate::block_on(async move { account_handle.set_client_options(client_options).await; });
             }
             Ok(cx.undefined().upcast())
         }
@@ -173,13 +169,15 @@ declare_types! {
             let message_id = MessageId::from_str(cx.argument::<JsString>(0)?.value().as_str()).expect("invalid message id length");
             let this = cx.this();
             let id = cx.borrow(&this, |r| r.0.clone());
-            let account_handle = crate::get_account(&id);
-            let account = account_handle.read().unwrap();
-            let message = account.get_message(&message_id);
-            match message {
-                Some(m) => Ok(neon_serde::to_value(&mut cx, &m)?),
-                None => Ok(cx.undefined().upcast())
-            }
+            crate::block_on(async move {
+                let account_handle = crate::get_account(&id);
+                let account = account_handle.read().await;
+                let message = account.get_message(&message_id);
+                match message {
+                    Some(m) => Ok(neon_serde::to_value(&mut cx, &m)?),
+                    None => Ok(cx.undefined().upcast())
+                }
+            })
         }
 
         method generateAddress(mut cx) {
@@ -187,8 +185,10 @@ declare_types! {
                 let this = cx.this();
                 let guard = cx.lock();
                 let id = &this.borrow(&guard).0;
-                let account_handle = crate::get_account(id);
-                account_handle.generate_address().expect("error generating address")
+                crate::block_on(async move {
+                    let account_handle = crate::get_account(id);
+                    account_handle.generate_address().await.expect("error generating address")
+                })
             };
             Ok(neon_serde::to_value(&mut cx, &address)?)
         }
@@ -196,13 +196,15 @@ declare_types! {
         method latestAddress(mut cx) {
             let this = cx.this();
             let id = cx.borrow(&this, |r| r.0.clone());
-            let account_handle = crate::get_account(&id);
-            let account = account_handle.read().unwrap();
-            let address = account.latest_address();
-            match address {
-                Some(a) => Ok(neon_serde::to_value(&mut cx, &a)?),
-                None => Ok(cx.undefined().upcast())
-            }
+            crate::block_on(async move {
+                let account_handle = crate::get_account(&id);
+                let account = account_handle.read().await;
+                let address = account.latest_address();
+                match address {
+                    Some(a) => Ok(neon_serde::to_value(&mut cx, &a)?),
+                    None => Ok(cx.undefined().upcast())
+                }
+            })
         }
 
         method sync(mut cx) {

--- a/bindings/node/native/src/classes/account/mod.rs
+++ b/bindings/node/native/src/classes/account/mod.rs
@@ -10,12 +10,6 @@ mod sync;
 
 pub struct AccountWrapper(pub AccountIdentifier);
 
-impl Drop for AccountWrapper {
-    fn drop(&mut self) {
-        crate::remove_account(&self.0);
-    }
-}
-
 declare_types! {
     pub class JsAccount for AccountWrapper {
         init(mut cx) {

--- a/bindings/node/native/src/classes/account/mod.rs
+++ b/bindings/node/native/src/classes/account/mod.rs
@@ -28,8 +28,8 @@ declare_types! {
                 let this = cx.this();
                 let guard = cx.lock();
                 let id = &this.borrow(&guard).0;
-                let account = crate::get_account(id);
-                let account = account.read().unwrap();
+                let account_handle = crate::get_account(id);
+                let account = account_handle.read().unwrap();
                 account.id().clone()
             };
 
@@ -44,8 +44,8 @@ declare_types! {
                 let this = cx.this();
                 let guard = cx.lock();
                 let id = &this.borrow(&guard).0;
-                let account = crate::get_account(id);
-                let account = account.read().unwrap();
+                let account_handle = crate::get_account(id);
+                let account = account_handle.read().unwrap();
                 *account.index()
             };
 
@@ -57,8 +57,8 @@ declare_types! {
                 let this = cx.this();
                 let guard = cx.lock();
                 let id = &this.borrow(&guard).0;
-                let account = crate::get_account(id);
-                let account = account.read().unwrap();
+                let account_handle = crate::get_account(id);
+                let account = account_handle.read().unwrap();
                 account.alias().clone()
             };
 
@@ -70,8 +70,8 @@ declare_types! {
                 let this = cx.this();
                 let guard = cx.lock();
                 let id = &this.borrow(&guard).0;
-                let account = crate::get_account(id);
-                let account = account.read().unwrap();
+                let account_handle = crate::get_account(id);
+                let account = account_handle.read().unwrap();
                 account.available_balance()
             };
             Ok(cx.number(balance as f64).upcast())
@@ -82,8 +82,8 @@ declare_types! {
                 let this = cx.this();
                 let guard = cx.lock();
                 let id = &this.borrow(&guard).0;
-                let account = crate::get_account(id);
-                let account = account.read().unwrap();
+                let account_handle = crate::get_account(id);
+                let account = account_handle.read().unwrap();
                 account.total_balance()
             };
             Ok(cx.number(balance as f64).upcast())
@@ -108,8 +108,8 @@ declare_types! {
 
             let this = cx.this();
             let id = cx.borrow(&this, |r| r.0.clone());
-            let account = crate::get_account(&id);
-            let account = account.read().unwrap();
+            let account_handle = crate::get_account(&id);
+            let account = account_handle.read().unwrap();
             let messages = account.list_messages(count, from, filter);
 
             let js_array = JsArray::new(&mut cx, messages.len() as u32);
@@ -129,8 +129,8 @@ declare_types! {
 
             let this = cx.this();
             let id = cx.borrow(&this, |r| r.0.clone());
-            let account = crate::get_account(&id);
-            let account = account.read().unwrap();
+            let account_handle = crate::get_account(&id);
+            let account = account_handle.read().unwrap();
             let addresses = account.list_addresses(unspent);
 
             let js_array = JsArray::new(&mut cx, addresses.len() as u32);
@@ -148,8 +148,8 @@ declare_types! {
                 let this = cx.this();
                 let guard = cx.lock();
                 let id = &this.borrow(&guard).0;
-                let account = crate::get_account(id);
-                let mut account = account.write().unwrap();
+                let account_handle = crate::get_account(id);
+                let mut account = account_handle.write().unwrap();
                 account.set_alias(alias);
             }
             Ok(cx.undefined().upcast())
@@ -162,8 +162,8 @@ declare_types! {
                 let this = cx.this();
                 let guard = cx.lock();
                 let id = &this.borrow(&guard).0;
-                let account = crate::get_account(id);
-                let mut account = account.write().unwrap();
+                let account_handle = crate::get_account(id);
+                let mut account = account_handle.write().unwrap();
                 account.set_client_options(client_options);
             }
             Ok(cx.undefined().upcast())
@@ -173,8 +173,8 @@ declare_types! {
             let message_id = MessageId::from_str(cx.argument::<JsString>(0)?.value().as_str()).expect("invalid message id length");
             let this = cx.this();
             let id = cx.borrow(&this, |r| r.0.clone());
-            let account = crate::get_account(&id);
-            let account = account.read().unwrap();
+            let account_handle = crate::get_account(&id);
+            let account = account_handle.read().unwrap();
             let message = account.get_message(&message_id);
             match message {
                 Some(m) => Ok(neon_serde::to_value(&mut cx, &m)?),
@@ -187,8 +187,8 @@ declare_types! {
                 let this = cx.this();
                 let guard = cx.lock();
                 let id = &this.borrow(&guard).0;
-                let account = crate::get_account(id);
-                account.generate_address().expect("error generating address")
+                let account_handle = crate::get_account(id);
+                account_handle.generate_address().expect("error generating address")
             };
             Ok(neon_serde::to_value(&mut cx, &address)?)
         }
@@ -196,8 +196,8 @@ declare_types! {
         method latestAddress(mut cx) {
             let this = cx.this();
             let id = cx.borrow(&this, |r| r.0.clone());
-            let account = crate::get_account(&id);
-            let account = account.read().unwrap();
+            let account_handle = crate::get_account(&id);
+            let account = account_handle.read().unwrap();
             let address = account.latest_address();
             match address {
                 Some(a) => Ok(neon_serde::to_value(&mut cx, &a)?),

--- a/bindings/node/native/src/classes/account/mod.rs
+++ b/bindings/node/native/src/classes/account/mod.rs
@@ -188,7 +188,6 @@ declare_types! {
                 let guard = cx.lock();
                 let id = &this.borrow(&guard).0;
                 let account = crate::get_account(id);
-                let mut account = account.write().unwrap();
                 account.generate_address().expect("error generating address")
             };
             Ok(neon_serde::to_value(&mut cx, &address)?)

--- a/bindings/node/native/src/classes/account_manager/internal_transfer.rs
+++ b/bindings/node/native/src/classes/account_manager/internal_transfer.rs
@@ -3,13 +3,13 @@
 
 use std::sync::{Arc, RwLock};
 
-use iota_wallet::{account_manager::AccountManager, message::Message, WalletError};
+use iota_wallet::{account::AccountIdentifier, account_manager::AccountManager, message::Message, WalletError};
 use neon::prelude::*;
 
 pub struct InternalTransferTask {
     pub manager: Arc<RwLock<AccountManager>>,
-    pub from_account_id: String,
-    pub to_account_id: String,
+    pub from_account_id: AccountIdentifier,
+    pub to_account_id: AccountIdentifier,
     pub amount: u64,
 }
 
@@ -21,18 +21,9 @@ impl Task for InternalTransferTask {
     fn perform(&self) -> Result<Self::Output, Self::Error> {
         let manager = self.manager.read().unwrap();
         crate::block_on(crate::convert_async_panics(|| async {
-            let from_account = crate::get_account(&self.from_account_id);
-            let from_account = from_account.read().unwrap();
-            let to_account = crate::get_account(&self.to_account_id);
-            let to_account = to_account.read().unwrap();
-            let res = manager
-                .internal_transfer(from_account.id(), to_account.id(), self.amount)
-                .await?;
-
-            crate::update_account(&self.from_account_id, res.from_account);
-            crate::update_account(&self.to_account_id, res.to_account);
-
-            Ok(res.message)
+            manager
+                .internal_transfer(&self.from_account_id, &self.to_account_id, self.amount)
+                .await
         }))
     }
 

--- a/bindings/node/native/src/classes/account_manager/mod.rs
+++ b/bindings/node/native/src/classes/account_manager/mod.rs
@@ -131,6 +131,17 @@ declare_types! {
             Ok(cx.undefined().upcast())
         }
 
+        method loadAccounts(mut cx) {
+            {
+                let this = cx.this();
+                let guard = cx.lock();
+                let ref_ = &this.borrow(&guard).0;
+                let mut manager = ref_.write().unwrap();
+                manager.load_accounts().expect("failed to load accounts");
+            }
+            Ok(cx.undefined().upcast())
+        }
+
         method createAccount(mut cx) {
             let account = {
                 let account_to_create = cx.argument::<JsValue>(0)?;

--- a/bindings/node/native/src/classes/account_manager/mod.rs
+++ b/bindings/node/native/src/classes/account_manager/mod.rs
@@ -190,8 +190,8 @@ declare_types! {
                 crate::block_on(async move { manager.get_account(&id).await })
             };
             match account {
-                Ok(acc) => {
-                    let id = crate::store_account(acc);
+                Ok(account) => {
+                    let id = crate::store_account(account);
                     let id = cx.string(serde_json::to_string(&id).unwrap());
                     Ok(JsAccount::new(&mut cx, vec![id])?.upcast())
                 },

--- a/bindings/node/native/src/classes/account_manager/mod.rs
+++ b/bindings/node/native/src/classes/account_manager/mod.rs
@@ -101,8 +101,8 @@ declare_types! {
                 None => Default::default(),
             };
             let manager = match options.storage_type {
-                StorageType::Sqlite => AccountManager::with_storage_adapter(&options.storage_path, SqliteStorageAdapter::new(&options.storage_path, "accounts").unwrap()),
-                StorageType::Stronghold => AccountManager::with_storage_adapter(&options.storage_path, StrongholdStorageAdapter::new(&options.storage_path).unwrap()),
+                StorageType::Sqlite => crate::block_on(AccountManager::with_storage_adapter(&options.storage_path, SqliteStorageAdapter::new(&options.storage_path, "accounts").unwrap())),
+                StorageType::Stronghold => crate::block_on(AccountManager::with_storage_adapter(&options.storage_path, StrongholdStorageAdapter::new(&options.storage_path).unwrap())),
             };
             let manager = manager.expect("error initializing account manager");
             Ok(AccountManagerWrapper(Arc::new(RwLock::new(manager))))
@@ -116,28 +116,6 @@ declare_types! {
                 let ref_ = &this.borrow(&guard).0;
                 let mut manager = ref_.write().unwrap();
                 crate::block_on(async move { manager.set_stronghold_password(password).await }).expect("error setting stronghold password");
-            }
-            Ok(cx.undefined().upcast())
-        }
-
-        method startBackgroundSync(mut cx) {
-            {
-                let this = cx.this();
-                let guard = cx.lock();
-                let ref_ = &this.borrow(&guard).0;
-                let mut manager = ref_.write().unwrap();
-                crate::block_on(async move { manager.start_background_sync().await });
-            }
-            Ok(cx.undefined().upcast())
-        }
-
-        method loadAccounts(mut cx) {
-            {
-                let this = cx.this();
-                let guard = cx.lock();
-                let ref_ = &this.borrow(&guard).0;
-                let mut manager = ref_.write().unwrap();
-                crate::block_on(async move { manager.load_accounts().await }).expect("failed to load accounts");
             }
             Ok(cx.undefined().upcast())
         }

--- a/bindings/node/native/src/classes/account_manager/mod.rs
+++ b/bindings/node/native/src/classes/account_manager/mod.rs
@@ -137,7 +137,7 @@ declare_types! {
                 let guard = cx.lock();
                 let ref_ = &this.borrow(&guard).0;
                 let mut manager = ref_.write().unwrap();
-                manager.load_accounts().expect("failed to load accounts");
+                crate::block_on(async move { manager.load_accounts().await }).expect("failed to load accounts");
             }
             Ok(cx.undefined().upcast())
         }
@@ -187,7 +187,7 @@ declare_types! {
                 let guard = cx.lock();
                 let ref_ = &this.borrow(&guard).0;
                 let manager = ref_.read().unwrap();
-                manager.get_account(&id)
+                crate::block_on(async move { manager.get_account(&id).await })
             };
             match account {
                 Ok(acc) => {
@@ -224,7 +224,7 @@ declare_types! {
                 let guard = cx.lock();
                 let ref_ = &this.borrow(&guard).0;
                 let manager = ref_.read().unwrap();
-                manager.get_accounts()
+                crate::block_on(async move { manager.get_accounts().await })
             };
 
             let js_array = JsArray::new(&mut cx, accounts.len() as u32);

--- a/bindings/node/native/src/classes/account_manager/mod.rs
+++ b/bindings/node/native/src/classes/account_manager/mod.rs
@@ -115,7 +115,7 @@ declare_types! {
                 let guard = cx.lock();
                 let ref_ = &this.borrow(&guard).0;
                 let mut manager = ref_.write().unwrap();
-                manager.set_stronghold_password(password).expect("error setting stronghold password");
+                crate::block_on(async move { manager.set_stronghold_password(password).await }).expect("error setting stronghold password");
             }
             Ok(cx.undefined().upcast())
         }
@@ -126,7 +126,7 @@ declare_types! {
                 let guard = cx.lock();
                 let ref_ = &this.borrow(&guard).0;
                 let mut manager = ref_.write().unwrap();
-                manager.start_background_sync();
+                crate::block_on(async move { manager.start_background_sync().await });
             }
             Ok(cx.undefined().upcast())
         }
@@ -170,7 +170,7 @@ declare_types! {
                         .expect("invalid account created at format"),
                     );
                 }
-                builder.initialise().expect("error creating account")
+                crate::block_on(async move { builder.initialise().await }).expect("error creating account")
             };
 
             let id = crate::store_account(account);
@@ -206,11 +206,11 @@ declare_types! {
                 let guard = cx.lock();
                 let ref_ = &this.borrow(&guard).0;
                 let manager = ref_.read().unwrap();
-                manager.get_account_by_alias(alias)
+                crate::block_on(async move { manager.get_account_by_alias(alias).await })
             };
             match account {
-                Some(acc) => {
-                    let id = crate::store_account(acc);
+                Some(account) => {
+                    let id = crate::store_account(account);
                     let id = cx.string(serde_json::to_string(&id).unwrap());
                     Ok(JsAccount::new(&mut cx, vec![id])?.upcast())
                 },
@@ -246,7 +246,7 @@ declare_types! {
                 let guard = cx.lock();
                 let ref_ = &this.borrow(&guard).0;
                 let manager = ref_.read().unwrap();
-                manager.remove_account(&id).expect("error removing account")
+                crate::block_on(async move { manager.remove_account(&id).await }).expect("error removing account")
             };
             Ok(cx.undefined().upcast())
         }

--- a/bindings/node/native/src/classes/account_manager/mod.rs
+++ b/bindings/node/native/src/classes/account_manager/mod.rs
@@ -161,10 +161,11 @@ declare_types! {
                 }
                 builder.initialise().expect("error creating account")
             };
-            let account = serde_json::to_string(&account).unwrap();
-            let account = cx.string(account);
 
-            Ok(JsAccount::new(&mut cx, vec![account])?.upcast())
+            let id = crate::store_account(account);
+            let id = cx.string(serde_json::to_string(&id).unwrap());
+
+            Ok(JsAccount::new(&mut cx, vec![id])?.upcast())
         }
 
         method getAccount(mut cx) {
@@ -179,9 +180,9 @@ declare_types! {
             };
             match account {
                 Ok(acc) => {
-                    let account = serde_json::to_string(&acc).unwrap();
-                    let account = cx.string(account);
-                    Ok(JsAccount::new(&mut cx, vec![account])?.upcast())
+                    let id = crate::store_account(acc);
+                    let id = cx.string(serde_json::to_string(&id).unwrap());
+                    Ok(JsAccount::new(&mut cx, vec![id])?.upcast())
                 },
                 Err(_) => Ok(cx.undefined().upcast())
             }
@@ -198,9 +199,9 @@ declare_types! {
             };
             match account {
                 Some(acc) => {
-                    let account = serde_json::to_string(&acc).unwrap();
-                    let account = cx.string(account);
-                    Ok(JsAccount::new(&mut cx, vec![account])?.upcast())
+                    let id = crate::store_account(acc);
+                    let id = cx.string(serde_json::to_string(&id).unwrap());
+                    Ok(JsAccount::new(&mut cx, vec![id])?.upcast())
                 },
                 None => Ok(cx.undefined().upcast())
             }
@@ -212,14 +213,14 @@ declare_types! {
                 let guard = cx.lock();
                 let ref_ = &this.borrow(&guard).0;
                 let manager = ref_.read().unwrap();
-                manager.get_accounts().expect("failed to get accounts")
+                manager.get_accounts()
             };
 
             let js_array = JsArray::new(&mut cx, accounts.len() as u32);
-            for (index, account) in accounts.iter().enumerate() {
-                let account = serde_json::to_string(&account).unwrap();
-                let account = cx.string(account);
-                let js_account = JsAccount::new(&mut cx, vec![account])?;
+            for (index, account) in accounts.into_iter().enumerate() {
+                let id = crate::store_account(account);
+                let id = cx.string(serde_json::to_string(&id).unwrap());
+                let js_account = JsAccount::new(&mut cx, vec![id])?;
                 js_array.set(&mut cx, index as u32, js_account)?;
             }
 

--- a/bindings/node/native/src/classes/account_manager/sync.rs
+++ b/bindings/node/native/src/classes/account_manager/sync.rs
@@ -24,10 +24,10 @@ impl Task for SyncTask {
         match value {
             Ok(synced_accounts) => {
                 let js_array = JsArray::new(&mut cx, synced_accounts.len() as u32);
-                for (index, synced_account) in synced_accounts.iter().enumerate() {
-                    let synced = serde_json::to_string(&synced_account).unwrap();
-                    let synced = cx.string(synced);
-                    let synced_instance = crate::JsSyncedAccount::new(&mut cx, vec![synced])?;
+                for (index, synced_account) in synced_accounts.into_iter().enumerate() {
+                    let id = crate::store_synced_account(synced_account);
+                    let id = cx.string(id);
+                    let synced_instance = crate::JsSyncedAccount::new(&mut cx, vec![id])?;
                     js_array.set(&mut cx, index as u32, synced_instance)?;
                 }
 

--- a/bindings/node/native/src/classes/synced_account/mod.rs
+++ b/bindings/node/native/src/classes/synced_account/mod.rs
@@ -1,13 +1,9 @@
 // Copyright 2020 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{
-    str::FromStr,
-    sync::{Arc, RwLock},
-};
+use std::str::FromStr;
 
 use iota_wallet::{
-    account::SyncedAccount,
     address::parse as parse_address,
     message::{MessageId, RemainderValueStrategy, Transfer},
 };
@@ -17,15 +13,19 @@ mod repost;
 mod send;
 
 #[derive(Clone)]
-pub struct SyncedAccountWrapper(Arc<RwLock<SyncedAccount>>, String);
+pub struct SyncedAccountWrapper(pub String);
+
+impl Drop for SyncedAccountWrapper {
+    fn drop(&mut self) {
+        crate::remove_synced_account(&self.0);
+    }
+}
 
 declare_types! {
     pub class JsSyncedAccount for SyncedAccountWrapper {
         init(mut cx) {
-            let synced = cx.argument::<JsString>(0)?.value();
-            let account_id = cx.argument::<JsString>(1)?.value();
-            let synced: SyncedAccount = serde_json::from_str(&synced).expect("invalid synced account JSON");
-            Ok(SyncedAccountWrapper(Arc::new(RwLock::new(synced)), account_id))
+            let synced_account_id = cx.argument::<JsString>(0)?.value();
+            Ok(SyncedAccountWrapper(synced_account_id))
         }
 
         method send(mut cx) {
@@ -45,10 +45,9 @@ declare_types! {
                 .remainder_value_strategy(remainder_value_strategy);
 
             let this = cx.this();
-            let instance = cx.borrow(&this, |r| r.clone());
+            let synced_account_id = cx.borrow(&this, |r| r.0.clone());
             let task = send::SendTask {
-                synced: instance.0,
-                account_id: instance.1,
+                synced_account_id,
                 transfer,
             };
             task.schedule(cb);
@@ -60,10 +59,9 @@ declare_types! {
             let cb = cx.argument::<JsFunction>(1)?;
 
             let this = cx.this();
-            let instance = cx.borrow(&this, |r| r.clone());
+            let synced_account_id = cx.borrow(&this, |r| r.0.clone());
             let task = repost::RepostTask {
-                synced: instance.0,
-                account_id: instance.1,
+                synced_account_id,
                 message_id,
                 action: repost::RepostAction::Retry,
             };
@@ -76,10 +74,9 @@ declare_types! {
             let cb = cx.argument::<JsFunction>(1)?;
 
             let this = cx.this();
-            let instance = cx.borrow(&this, |r| r.clone());
+            let synced_account_id = cx.borrow(&this, |r| r.0.clone());
             let task = repost::RepostTask {
-                synced: instance.0,
-                account_id: instance.1,
+                synced_account_id,
                 message_id,
                 action: repost::RepostAction::Reattach,
             };
@@ -92,10 +89,9 @@ declare_types! {
             let cb = cx.argument::<JsFunction>(1)?;
 
             let this = cx.this();
-            let instance = cx.borrow(&this, |r| r.clone());
+            let synced_account_id = cx.borrow(&this, |r| r.0.clone());
             let task = repost::RepostTask {
-                synced: instance.0,
-                account_id: instance.1,
+                synced_account_id,
                 message_id,
                 action: repost::RepostAction::Promote,
             };

--- a/bindings/node/native/src/classes/synced_account/send.rs
+++ b/bindings/node/native/src/classes/synced_account/send.rs
@@ -1,18 +1,14 @@
 // Copyright 2020 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::{Arc, RwLock};
-
 use iota_wallet::{
-    account::SyncedAccount,
     message::{Message, Transfer},
     WalletError,
 };
 use neon::prelude::*;
 
 pub struct SendTask {
-    pub synced: Arc<RwLock<SyncedAccount>>,
-    pub account_id: String,
+    pub synced_account_id: String,
     pub transfer: Transfer,
 }
 
@@ -22,11 +18,11 @@ impl Task for SendTask {
     type JsEvent = JsValue;
 
     fn perform(&self) -> Result<Self::Output, Self::Error> {
-        let synced = self.synced.read().unwrap();
+        let synced = crate::get_synced_account(&self.synced_account_id);
+        let synced = synced.read().unwrap();
+
         crate::block_on(crate::convert_async_panics(|| async {
-            let res = synced.transfer(self.transfer.clone()).await?;
-            crate::update_account(&self.account_id, res.account);
-            Ok(res.message)
+            synced.transfer(self.transfer.clone()).await
         }))
     }
 

--- a/bindings/node/native/src/lib.rs
+++ b/bindings/node/native/src/lib.rs
@@ -50,13 +50,6 @@ pub(crate) fn store_account(account_handle: AccountHandle) -> AccountIdentifier 
     id
 }
 
-pub(crate) fn remove_account(id: &AccountIdentifier) {
-    let mut map = account_instances()
-        .write()
-        .expect("failed to lock account instances: remove_account()");
-    map.remove(id);
-}
-
 /// Gets the synced account instances map.
 fn synced_account_instances() -> &'static SyncedAccountInstanceMap {
     static INSTANCES: Lazy<SyncedAccountInstanceMap> = Lazy::new(Default::default);

--- a/bindings/node/native/src/lib.rs
+++ b/bindings/node/native/src/lib.rs
@@ -38,12 +38,12 @@ pub(crate) fn get_account(id: &AccountIdentifier) -> AccountHandle {
     map.get(id).expect("account dropped or not initialised").clone()
 }
 
-pub(crate) fn store_account(account: AccountHandle) -> AccountIdentifier {
+pub(crate) fn store_account(account_handle: AccountHandle) -> AccountIdentifier {
     let mut map = account_instances()
         .write()
         .expect("failed to lock account instances: store_account()");
-    let id = account.id();
-    map.insert(id.clone(), account);
+    let id = account_handle.id();
+    map.insert(id.clone(), account_handle);
     id
 }
 

--- a/bindings/node/native/src/lib.rs
+++ b/bindings/node/native/src/lib.rs
@@ -10,7 +10,7 @@ use std::{
 
 use futures::{Future, FutureExt};
 use iota_wallet::{
-    account::{AccountGuard, AccountIdentifier, SyncedAccount},
+    account::{AccountHandle, AccountIdentifier, SyncedAccount},
     WalletError,
 };
 use neon::prelude::*;
@@ -21,9 +21,9 @@ use tokio::runtime::Runtime;
 mod classes;
 use classes::*;
 
-type AccountInstanceMap = Arc<RwLock<HashMap<AccountIdentifier, AccountGuard>>>;
-type SyncedAccountGuard = Arc<RwLock<SyncedAccount>>;
-type SyncedAccountInstanceMap = Arc<RwLock<HashMap<String, SyncedAccountGuard>>>;
+type AccountInstanceMap = Arc<RwLock<HashMap<AccountIdentifier, AccountHandle>>>;
+type SyncedAccountHandle = Arc<RwLock<SyncedAccount>>;
+type SyncedAccountInstanceMap = Arc<RwLock<HashMap<String, SyncedAccountHandle>>>;
 
 /// Gets the account instances map.
 fn account_instances() -> &'static AccountInstanceMap {
@@ -31,14 +31,14 @@ fn account_instances() -> &'static AccountInstanceMap {
     &INSTANCES
 }
 
-pub(crate) fn get_account(id: &AccountIdentifier) -> AccountGuard {
+pub(crate) fn get_account(id: &AccountIdentifier) -> AccountHandle {
     let map = account_instances()
         .read()
         .expect("failed to lock account instances: get_account()");
     map.get(id).expect("account dropped or not initialised").clone()
 }
 
-pub(crate) fn store_account(account: AccountGuard) -> AccountIdentifier {
+pub(crate) fn store_account(account: AccountHandle) -> AccountIdentifier {
     let mut map = account_instances()
         .write()
         .expect("failed to lock account instances: store_account()");
@@ -63,7 +63,7 @@ fn synced_account_instances() -> &'static SyncedAccountInstanceMap {
     &INSTANCES
 }
 
-pub(crate) fn get_synced_account(id: &str) -> SyncedAccountGuard {
+pub(crate) fn get_synced_account(id: &str) -> SyncedAccountHandle {
     let map = synced_account_instances()
         .read()
         .expect("failed to lock synced account instances: get_synced_account()");

--- a/bindings/node/native/src/lib.rs
+++ b/bindings/node/native/src/lib.rs
@@ -42,7 +42,10 @@ pub(crate) fn store_account(account_handle: AccountHandle) -> AccountIdentifier 
     let mut map = account_instances()
         .write()
         .expect("failed to lock account instances: store_account()");
-    let id = account_handle.id();
+
+    let handle = account_handle.clone();
+    let id = block_on(async move { handle.id().await });
+
     map.insert(id.clone(), account_handle);
     id
 }

--- a/bindings/node/native/src/lib.rs
+++ b/bindings/node/native/src/lib.rs
@@ -42,10 +42,7 @@ pub(crate) fn store_account(account: AccountHandle) -> AccountIdentifier {
     let mut map = account_instances()
         .write()
         .expect("failed to lock account instances: store_account()");
-    let id = {
-        let account_ = account.read().unwrap();
-        account_.id().clone()
-    };
+    let id = account.id();
     map.insert(id.clone(), account);
     id
 }

--- a/bindings/node/native/src/lib.rs
+++ b/bindings/node/native/src/lib.rs
@@ -6,12 +6,11 @@ use std::{
     collections::HashMap,
     panic::AssertUnwindSafe,
     sync::{Arc, Mutex, RwLock},
-    thread,
 };
 
 use futures::{Future, FutureExt};
 use iota_wallet::{
-    account::{Account, AccountIdentifier},
+    account::{AccountGuard, AccountIdentifier, SyncedAccount},
     WalletError,
 };
 use neon::prelude::*;
@@ -22,102 +21,68 @@ use tokio::runtime::Runtime;
 mod classes;
 use classes::*;
 
-type AccountInstanceMap = Arc<RwLock<HashMap<String, Arc<RwLock<Account>>>>>;
-
-/// check if the account instance is loaded on the JS side (AccountInstanceMap) and update it by running a callback
-fn mutate_account_if_exists<F: FnOnce(&mut Account) + Send + Sync + 'static>(account_id: &AccountIdentifier, cb: F) {
-    let account_id = account_id.clone();
-    thread::spawn(move || {
-        let map = instances()
-            .read()
-            .expect("failed to lock read on account instances: mutate_account_if_exists()");
-
-        for account in map.values() {
-            let account_ = account.read().unwrap();
-            if account_.id() == &account_id {
-                std::mem::drop(account_);
-                let mut account = account.write().unwrap();
-                cb(&mut account);
-                break;
-            }
-        }
-    });
-}
+type AccountInstanceMap = Arc<RwLock<HashMap<AccountIdentifier, AccountGuard>>>;
+type SyncedAccountGuard = Arc<RwLock<SyncedAccount>>;
+type SyncedAccountInstanceMap = Arc<RwLock<HashMap<String, SyncedAccountGuard>>>;
 
 /// Gets the account instances map.
-fn instances() -> &'static AccountInstanceMap {
-    static INSTANCES: Lazy<AccountInstanceMap> = Lazy::new(|| {
-        iota_wallet::event::on_balance_change(|event| {
-            let address = event.cloned_address();
-            let balance = *event.balance();
-            mutate_account_if_exists(event.account_id(), move |account| {
-                let addresses = account.addresses_mut();
-                if let Some(address) = addresses.iter_mut().find(|a| a == &&address) {
-                    address.set_balance(balance);
-                }
-            });
-        });
-        iota_wallet::event::on_new_transaction(|event| {
-            let message = event.cloned_message();
-            mutate_account_if_exists(event.account_id(), move |account| {
-                account.append_messages(vec![message]);
-            });
-        });
-        iota_wallet::event::on_confirmation_state_change(|event| {
-            let message = event.cloned_message();
-            let confirmed = *event.confirmed();
-            mutate_account_if_exists(event.account_id(), move |account| {
-                if let Some(message) = account.messages_mut().iter_mut().find(|m| m == &&message) {
-                    message.set_confirmed(Some(confirmed));
-                }
-            });
-        });
-        iota_wallet::event::on_reattachment(|event| {
-            let message = event.cloned_message();
-            mutate_account_if_exists(event.account_id(), move |account| {
-                account.append_messages(vec![message]);
-            });
-        });
-        iota_wallet::event::on_broadcast(|event| {
-            let message = event.cloned_message();
-            mutate_account_if_exists(event.account_id(), move |account| {
-                if let Some(message) = account.messages_mut().iter_mut().find(|m| m == &&message) {
-                    message.set_broadcasted(true);
-                }
-            });
-        });
-        Default::default()
-    });
+fn account_instances() -> &'static AccountInstanceMap {
+    static INSTANCES: Lazy<AccountInstanceMap> = Lazy::new(Default::default);
     &INSTANCES
 }
 
-pub(crate) fn get_account(id: &str) -> Arc<RwLock<Account>> {
-    let map = instances()
+pub(crate) fn get_account(id: &AccountIdentifier) -> AccountGuard {
+    let map = account_instances()
         .read()
         .expect("failed to lock account instances: get_account()");
     map.get(id).expect("account dropped or not initialised").clone()
 }
 
-pub(crate) fn store_account(account: Account) -> String {
-    let mut map = instances()
+pub(crate) fn store_account(account: AccountGuard) -> AccountIdentifier {
+    let mut map = account_instances()
         .write()
         .expect("failed to lock account instances: store_account()");
-    let id: String = thread_rng().sample_iter(&Alphanumeric).take(10).collect();
-    map.insert(id.clone(), Arc::new(RwLock::new(account)));
+    let id = {
+        let account_ = account.read().unwrap();
+        account_.id().clone()
+    };
+    map.insert(id.clone(), account);
     id
 }
 
-pub(crate) fn update_account(id: &str, account: Account) {
-    let mut map = instances()
-        .write()
-        .expect("failed to lock account instances: store_account()");
-    map.insert(id.to_string(), Arc::new(RwLock::new(account)));
-}
-
-pub(crate) fn remove_account(id: &str) {
-    let mut map = instances()
+pub(crate) fn remove_account(id: &AccountIdentifier) {
+    let mut map = account_instances()
         .write()
         .expect("failed to lock account instances: remove_account()");
+    map.remove(id);
+}
+
+/// Gets the synced account instances map.
+fn synced_account_instances() -> &'static SyncedAccountInstanceMap {
+    static INSTANCES: Lazy<SyncedAccountInstanceMap> = Lazy::new(Default::default);
+    &INSTANCES
+}
+
+pub(crate) fn get_synced_account(id: &str) -> SyncedAccountGuard {
+    let map = synced_account_instances()
+        .read()
+        .expect("failed to lock synced account instances: get_synced_account()");
+    map.get(id).expect("synced account dropped or not initialised").clone()
+}
+
+pub(crate) fn store_synced_account(synced_account: SyncedAccount) -> String {
+    let mut map = synced_account_instances()
+        .write()
+        .expect("failed to lock synced account instances: store_synced_account()");
+    let id: String = thread_rng().sample_iter(&Alphanumeric).take(10).collect();
+    map.insert(id.clone(), Arc::new(RwLock::new(synced_account)));
+    id
+}
+
+pub(crate) fn remove_synced_account(id: &str) {
+    let mut map = synced_account_instances()
+        .write()
+        .expect("failed to lock synced account instances: remove_synced_account()");
     map.remove(id);
 }
 

--- a/examples/account_operations.rs
+++ b/examples/account_operations.rs
@@ -5,7 +5,7 @@ use iota_wallet::{account_manager::AccountManager, client::ClientOptionsBuilder,
 
 #[tokio::main]
 async fn main() -> iota_wallet::Result<()> {
-    let mut manager = AccountManager::new().unwrap();
+    let mut manager = AccountManager::new().await.unwrap();
     manager.set_stronghold_password("password").await.unwrap();
 
     // first we'll create an example account and store it

--- a/examples/account_operations.rs
+++ b/examples/account_operations.rs
@@ -11,7 +11,6 @@ async fn main() -> iota_wallet::Result<()> {
     // first we'll create an example account and store it
     let client_options = ClientOptionsBuilder::node("https://nodes.devnet.iota.org:443")?.build();
     let account = manager.create_account(client_options).alias("alias").initialise()?;
-    let mut account = account.write().unwrap();
 
     // update alias
     account.set_alias("the new alias");

--- a/examples/account_operations.rs
+++ b/examples/account_operations.rs
@@ -10,7 +10,8 @@ async fn main() -> iota_wallet::Result<()> {
 
     // first we'll create an example account and store it
     let client_options = ClientOptionsBuilder::node("https://nodes.devnet.iota.org:443")?.build();
-    let mut account = manager.create_account(client_options).alias("alias").initialise()?;
+    let account = manager.create_account(client_options).alias("alias").initialise()?;
+    let mut account = account.write().unwrap();
 
     // update alias
     account.set_alias("the new alias");

--- a/examples/account_operations.rs
+++ b/examples/account_operations.rs
@@ -6,21 +6,25 @@ use iota_wallet::{account_manager::AccountManager, client::ClientOptionsBuilder,
 #[tokio::main]
 async fn main() -> iota_wallet::Result<()> {
     let mut manager = AccountManager::new().unwrap();
-    manager.set_stronghold_password("password").unwrap();
+    manager.set_stronghold_password("password").await.unwrap();
 
     // first we'll create an example account and store it
     let client_options = ClientOptionsBuilder::node("https://nodes.devnet.iota.org:443")?.build();
-    let account = manager.create_account(client_options).alias("alias").initialise()?;
+    let account = manager
+        .create_account(client_options)
+        .alias("alias")
+        .initialise()
+        .await?;
 
     // update alias
-    account.set_alias("the new alias");
+    account.set_alias("the new alias").await;
     // list unspent addresses
     let _ = account.list_addresses(false);
     // list spent addresses
     let _ = account.list_addresses(true);
 
     // generate a new unused address
-    let _ = account.generate_address()?;
+    let _ = account.generate_address().await?;
 
     // list messages
     let _ = account.list_messages(5, 0, Some(MessageType::Failed));

--- a/examples/actor.rs
+++ b/examples/actor.rs
@@ -26,13 +26,15 @@ impl WalletActor {
 
 fn spawn_actor() -> UnboundedSender<Message> {
     let (tx, rx) = unbounded_channel();
-    let actor = WalletActor {
-        rx,
-        message_handler: Default::default(),
-    };
     std::thread::spawn(|| {
         let mut runtime = tokio::runtime::Runtime::new().unwrap();
-        runtime.block_on(actor.run());
+        runtime.block_on(async move {
+            let actor = WalletActor {
+                rx,
+                message_handler: WalletMessageHandler::new().await.unwrap(),
+            };
+            actor.run().await
+        });
     });
     tx
 }

--- a/examples/actor.rs
+++ b/examples/actor.rs
@@ -1,7 +1,10 @@
 // Copyright 2020 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_wallet::actor::{AccountToCreate, Message, MessageType, Response, ResponseType, WalletMessageHandler};
+use iota_wallet::{
+    actor::{AccountToCreate, Message, MessageType, Response, ResponseType, WalletMessageHandler},
+    client::ClientOptionsBuilder,
+};
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 
 /// The Wallet actor.
@@ -45,7 +48,13 @@ async fn send_message(tx: &UnboundedSender<Message>, message_type: MessageType) 
 async fn main() {
     let tx = spawn_actor();
 
-    let account = AccountToCreate::default();
+    let account = AccountToCreate {
+        client_options: ClientOptionsBuilder::node("http://node.iota").unwrap().build(),
+        mnemonic: None,
+        alias: None,
+        created_at: None,
+    };
+
     send_message(&tx, MessageType::SetStrongholdPassword("password".to_string())).await;
     let response = send_message(&tx, MessageType::CreateAccount(account)).await;
     match response.response() {

--- a/examples/backup_and_restore.rs
+++ b/examples/backup_and_restore.rs
@@ -5,7 +5,7 @@ use iota_wallet::{account_manager::AccountManager, client::ClientOptionsBuilder}
 
 #[tokio::main]
 async fn main() -> iota_wallet::Result<()> {
-    let mut manager = AccountManager::new().unwrap();
+    let mut manager = AccountManager::new().await.unwrap();
     manager.set_stronghold_password("password").await.unwrap();
 
     // first we'll create an example account

--- a/examples/backup_and_restore.rs
+++ b/examples/backup_and_restore.rs
@@ -10,8 +10,7 @@ fn main() -> iota_wallet::Result<()> {
     // first we'll create an example account
     let client_options = ClientOptionsBuilder::node("https://nodes.devnet.iota.org:443")?.build();
     let account = manager.create_account(client_options).alias("alias").initialise()?;
-    let account_ = account.read().unwrap();
-    let id = account_.id();
+    let id = account.id();
 
     // backup the stored accounts to ./backup/${backup_name}
     let backup_path = manager.backup("./backup")?;
@@ -21,7 +20,9 @@ fn main() -> iota_wallet::Result<()> {
 
     // import the accounts from the backup and assert that it's the same
     manager.import_accounts(backup_path)?;
-    let imported_account = manager.get_account(id)?;
+    let imported_account = manager.get_account(&id)?;
+
+    let account_ = account.read().unwrap();
     let imported_account_ = imported_account.read().unwrap();
     assert_eq!(*account_, *imported_account_);
 

--- a/examples/backup_and_restore.rs
+++ b/examples/backup_and_restore.rs
@@ -25,7 +25,7 @@ async fn main() -> iota_wallet::Result<()> {
 
     // import the accounts from the backup and assert that it's the same
     manager.import_accounts(backup_path)?;
-    let imported_account_handle = manager.get_account(&id)?;
+    let imported_account_handle = manager.get_account(&id).await?;
 
     let account = account_handle.read().await;
     let imported_account = imported_account_handle.read().await;

--- a/examples/backup_and_restore.rs
+++ b/examples/backup_and_restore.rs
@@ -10,7 +10,8 @@ fn main() -> iota_wallet::Result<()> {
     // first we'll create an example account
     let client_options = ClientOptionsBuilder::node("https://nodes.devnet.iota.org:443")?.build();
     let account = manager.create_account(client_options).alias("alias").initialise()?;
-    let id = account.id();
+    let account_ = account.read().unwrap();
+    let id = account_.id();
 
     // backup the stored accounts to ./backup/${backup_name}
     let backup_path = manager.backup("./backup")?;
@@ -21,7 +22,8 @@ fn main() -> iota_wallet::Result<()> {
     // import the accounts from the backup and assert that it's the same
     manager.import_accounts(backup_path)?;
     let imported_account = manager.get_account(id)?;
-    assert_eq!(account, imported_account);
+    let imported_account_ = imported_account.read().unwrap();
+    assert_eq!(*account_, *imported_account_);
 
     Ok(())
 }

--- a/examples/backup_and_restore.rs
+++ b/examples/backup_and_restore.rs
@@ -3,27 +3,32 @@
 
 use iota_wallet::{account_manager::AccountManager, client::ClientOptionsBuilder};
 
-fn main() -> iota_wallet::Result<()> {
+#[tokio::main]
+async fn main() -> iota_wallet::Result<()> {
     let mut manager = AccountManager::new().unwrap();
-    manager.set_stronghold_password("password").unwrap();
+    manager.set_stronghold_password("password").await.unwrap();
 
     // first we'll create an example account
     let client_options = ClientOptionsBuilder::node("https://nodes.devnet.iota.org:443")?.build();
-    let account_handle = manager.create_account(client_options).alias("alias").initialise()?;
-    let id = account_handle.id();
+    let account_handle = manager
+        .create_account(client_options)
+        .alias("alias")
+        .initialise()
+        .await?;
+    let id = account_handle.id().await;
 
     // backup the stored accounts to ./backup/${backup_name}
     let backup_path = manager.backup("./backup")?;
 
     // delete the account on the current storage
-    manager.remove_account(&id)?;
+    manager.remove_account(&id).await?;
 
     // import the accounts from the backup and assert that it's the same
     manager.import_accounts(backup_path)?;
     let imported_account_handle = manager.get_account(&id)?;
 
-    let account = account_handle.read().unwrap();
-    let imported_account = imported_account_handle.read().unwrap();
+    let account = account_handle.read().await;
+    let imported_account = imported_account_handle.read().await;
     assert_eq!(*account, *imported_account);
 
     Ok(())

--- a/examples/backup_and_restore.rs
+++ b/examples/backup_and_restore.rs
@@ -9,8 +9,8 @@ fn main() -> iota_wallet::Result<()> {
 
     // first we'll create an example account
     let client_options = ClientOptionsBuilder::node("https://nodes.devnet.iota.org:443")?.build();
-    let account = manager.create_account(client_options).alias("alias").initialise()?;
-    let id = account.id();
+    let account_handle = manager.create_account(client_options).alias("alias").initialise()?;
+    let id = account_handle.id();
 
     // backup the stored accounts to ./backup/${backup_name}
     let backup_path = manager.backup("./backup")?;
@@ -20,11 +20,11 @@ fn main() -> iota_wallet::Result<()> {
 
     // import the accounts from the backup and assert that it's the same
     manager.import_accounts(backup_path)?;
-    let imported_account = manager.get_account(&id)?;
+    let imported_account_handle = manager.get_account(&id)?;
 
-    let account_ = account.read().unwrap();
-    let imported_account_ = imported_account.read().unwrap();
-    assert_eq!(*account_, *imported_account_);
+    let account = account_handle.read().unwrap();
+    let imported_account = imported_account_handle.read().unwrap();
+    assert_eq!(*account, *imported_account);
 
     Ok(())
 }

--- a/examples/custom_storage.rs
+++ b/examples/custom_storage.rs
@@ -63,6 +63,7 @@ impl StorageAdapter for MyStorage {
 async fn main() -> iota_wallet::Result<()> {
     let mut manager =
         AccountManager::with_storage_adapter("./example-database/sled", MyStorage::new("./example-database/sled")?)
+            .await
             .unwrap();
     manager.set_stronghold_password("password").await.unwrap();
 

--- a/examples/custom_storage.rs
+++ b/examples/custom_storage.rs
@@ -59,15 +59,20 @@ impl StorageAdapter for MyStorage {
     }
 }
 
-fn main() -> iota_wallet::Result<()> {
+#[tokio::main]
+async fn main() -> iota_wallet::Result<()> {
     let mut manager =
         AccountManager::with_storage_adapter("./example-database/sled", MyStorage::new("./example-database/sled")?)
             .unwrap();
-    manager.set_stronghold_password("password").unwrap();
+    manager.set_stronghold_password("password").await.unwrap();
 
     // first we'll create an example account
     let client_options = ClientOptionsBuilder::node("https://nodes.devnet.iota.org:443")?.build();
-    manager.create_account(client_options).alias("alias").initialise()?;
+    manager
+        .create_account(client_options)
+        .alias("alias")
+        .initialise()
+        .await?;
 
     Ok(())
 }

--- a/examples/transfer.rs
+++ b/examples/transfer.rs
@@ -6,18 +6,25 @@ use iota_wallet::{account_manager::AccountManager, client::ClientOptionsBuilder,
 #[tokio::main]
 async fn main() -> iota_wallet::Result<()> {
     let mut manager = AccountManager::new().unwrap();
-    manager.set_stronghold_password("password").unwrap();
+    manager.set_stronghold_password("password").await.unwrap();
 
     // first we'll create an example account and store it
     let client_options = ClientOptionsBuilder::node("https://nodes.devnet.iota.org:443")?.build();
-    let account = manager.create_account(client_options).alias("alias").initialise()?;
+    let account = manager
+        .create_account(client_options)
+        .alias("alias")
+        .initialise()
+        .await?;
 
     // we need to synchronize with the Tangle first
     let sync_accounts = manager.sync_accounts().await?;
     let sync_account = sync_accounts.first().unwrap();
 
     sync_account
-        .transfer(Transfer::new(account.latest_address().unwrap().address().clone(), 150))
+        .transfer(Transfer::new(
+            account.latest_address().await.unwrap().address().clone(),
+            150,
+        ))
         .await?;
 
     Ok(())

--- a/examples/transfer.rs
+++ b/examples/transfer.rs
@@ -5,7 +5,7 @@ use iota_wallet::{account_manager::AccountManager, client::ClientOptionsBuilder,
 
 #[tokio::main]
 async fn main() -> iota_wallet::Result<()> {
-    let mut manager = AccountManager::new().unwrap();
+    let mut manager = AccountManager::new().await.unwrap();
     manager.set_stronghold_password("password").await.unwrap();
 
     // first we'll create an example account and store it

--- a/examples/transfer.rs
+++ b/examples/transfer.rs
@@ -15,6 +15,8 @@ async fn main() -> iota_wallet::Result<()> {
     // we need to synchronize with the Tangle first
     let sync_accounts = manager.sync_accounts().await?;
     let sync_account = sync_accounts.first().unwrap();
+
+    let account = account.read().unwrap();
     sync_account
         .transfer(Transfer::new(account.latest_address().unwrap().address().clone(), 150))
         .await?;

--- a/examples/transfer.rs
+++ b/examples/transfer.rs
@@ -16,7 +16,6 @@ async fn main() -> iota_wallet::Result<()> {
     let sync_accounts = manager.sync_accounts().await?;
     let sync_account = sync_accounts.first().unwrap();
 
-    let account = account.read().unwrap();
     sync_account
         .transfer(Transfer::new(account.latest_address().unwrap().address().clone(), 150))
         .await?;

--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -573,7 +573,7 @@ mod tests {
         #[test]
         fn set_alias() {
             let manager = crate::test_utils::get_account_manager();
-            let mut manager = manager.lock().unwrap();
+            let manager = manager.lock().unwrap();
 
             let updated_alias = "updated alias";
             let client_options = ClientOptionsBuilder::node("https://nodes.devnet.iota.org:443")
@@ -592,8 +592,6 @@ mod tests {
                     account_handle.set_alias(updated_alias).await;
                     account_handle.id().await
                 };
-
-                manager.stop_background_sync().await.unwrap();
 
                 let account_in_storage = manager
                     .get_account(&account_id)

--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -150,7 +150,7 @@ impl AccountInitialiser {
 
     /// Initialises the account.
     pub async fn initialise(self) -> crate::Result<AccountHandle> {
-        let mut accounts = self.accounts.write().unwrap();
+        let mut accounts = self.accounts.write().await;
 
         let alias = self.alias.unwrap_or_else(|| format!("Account {}", accounts.len()));
         let signer_type = self
@@ -593,10 +593,11 @@ mod tests {
                     account_handle.id().await
                 };
 
-                manager.stop_background_sync().unwrap();
+                manager.stop_background_sync().await.unwrap();
 
                 let account_in_storage = manager
                     .get_account(&account_id)
+                    .await
                     .expect("failed to get account from storage");
                 let account_in_storage = account_in_storage.read().await;
                 assert_eq!(

--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -25,7 +25,7 @@ use std::{
 
 mod sync;
 pub(crate) use sync::{repost_message, RepostAction};
-pub use sync::{AccountSynchronizer, SyncedAccount, TransferMetadata};
+pub use sync::{AccountSynchronizer, SyncedAccount};
 
 type AddressesLock = Arc<Mutex<Vec<IotaAddress>>>;
 type AccountAddressesLock = Arc<Mutex<HashMap<AccountIdentifier, AddressesLock>>>;

--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -168,8 +168,8 @@ impl AccountInitialiser {
             }
         }
 
-        if let Some(latest_account) = accounts.values().last() {
-            let latest_account = latest_account.read().unwrap();
+        if let Some(latest_account_handle) = accounts.values().last() {
+            let latest_account = latest_account_handle.read().unwrap();
             if latest_account.messages().is_empty() && latest_account.total_balance() == 0 {
                 return Err(crate::WalletError::LatestAccountIsEmpty);
             }
@@ -450,7 +450,7 @@ impl Account {
     ///     .create_account(client_options)
     ///     .initialise()
     ///     .expect("failed to add account");
-    /// let account = account.read().unwrap();
+    /// let account = account_handle.read().unwrap();
     /// account.list_messages(10, 5, Some(MessageType::Received));
     /// ```
     pub fn list_messages(&self, count: usize, from: usize, message_type: Option<MessageType>) -> Vec<&Message> {
@@ -580,16 +580,14 @@ mod tests {
                 .build();
 
             let account_id = {
-                let account = manager
+                let account_handle = manager
                     .create_account(client_options)
                     .alias("alias")
                     .initialise()
                     .expect("failed to add account");
-                let mut account = account.write().unwrap();
 
-                account.set_alias(updated_alias);
-                let id = account.id().clone();
-                id
+                account_handle.set_alias(updated_alias);
+                account_handle.id()
             };
 
             manager.stop_background_sync().unwrap();

--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -273,8 +273,7 @@ macro_rules! guard_field_getters {
             $(
                 #[$attr]
                 pub fn $x(&self) -> $ret {
-                    let account = self.read().unwrap();
-                    account.$x().clone()
+                    self.0.read().unwrap().$x().clone()
                 }
             )*
         }
@@ -316,40 +315,36 @@ impl AccountHandle {
 
     /// Bridge to [Account#latest_address](struct.Account.html#method.latest_address).
     pub fn latest_address(&self) -> Option<Address> {
-        let account = self.0.read().unwrap();
-        account.latest_address().cloned()
+        self.0.read().unwrap().latest_address().cloned()
     }
 
     /// Bridge to [Account#total_balance](struct.Account.html#method.total_balance).
     pub fn total_balance(&self) -> u64 {
-        let account = self.0.read().unwrap();
-        account.total_balance()
+        self.0.read().unwrap().total_balance()
     }
 
     /// Bridge to [Account#available_balance](struct.Account.html#method.available_balance).
     pub fn available_balance(&self) -> u64 {
-        let account = self.0.read().unwrap();
-        account.available_balance()
+        self.0.read().unwrap().available_balance()
     }
 
     /// Bridge to [Account#set_alias](struct.Account.html#method.set_alias).
     pub fn set_alias(&self, alias: impl AsRef<str>) {
-        let mut account = self.0.write().unwrap();
-        account.set_alias(alias);
+        self.0.write().unwrap().set_alias(alias);
     }
 
     /// Bridge to [Account#set_client_options](struct.Account.html#method.set_client_options).
     pub fn set_client_options(&self, options: ClientOptions) {
-        let mut account = self.0.write().unwrap();
-        account.set_client_options(options);
+        self.0.write().unwrap().set_client_options(options);
     }
 
     /// Bridge to [Account#list_messages](struct.Account.html#method.list_messages).
     /// This method clones the account's messages so when querying a large list of messages
     /// prefer using the `read` method to access the account instance.
     pub fn list_messages(&self, count: usize, from: usize, message_type: Option<MessageType>) -> Vec<Message> {
-        let account = self.0.read().unwrap();
-        account
+        self.0
+            .read()
+            .unwrap()
             .list_messages(count, from, message_type)
             .into_iter()
             .cloned()
@@ -360,14 +355,18 @@ impl AccountHandle {
     /// This method clones the account's addresses so when querying a large list of addresses
     /// prefer using the `read` method to access the account instance.
     pub fn list_addresses(&self, unspent: bool) -> Vec<Address> {
-        let account = self.0.read().unwrap();
-        account.list_addresses(unspent).into_iter().cloned().collect()
+        self.0
+            .read()
+            .unwrap()
+            .list_addresses(unspent)
+            .into_iter()
+            .cloned()
+            .collect()
     }
 
     /// Bridge to [Account#get_message](struct.Account.html#method.get_message).
     pub fn get_message(&self, message_id: &MessageId) -> Option<Message> {
-        let account = self.0.read().unwrap();
-        account.get_message(message_id).cloned()
+        self.0.read().unwrap().get_message(message_id).cloned()
     }
 }
 

--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -445,21 +445,25 @@ impl Account {
     /// use iota_wallet::{account_manager::AccountManager, client::ClientOptionsBuilder, message::MessageType};
     /// # use rand::{thread_rng, Rng};
     ///
-    /// # let storage_path: String = thread_rng().gen_ascii_chars().take(10).collect();
-    /// # let storage_path = std::path::PathBuf::from(format!("./example-database/{}", storage_path));
-    /// // gets 10 received messages, skipping the first 5 most recent messages.
-    /// let client_options = ClientOptionsBuilder::node("https://nodes.devnet.iota.org:443")
-    ///     .expect("invalid node URL")
-    ///     .build();
-    /// let mut manager = AccountManager::new().unwrap();
-    /// # let mut manager = AccountManager::with_storage_path(storage_path).unwrap();
-    /// manager.set_stronghold_password("password").unwrap();
-    /// let account = manager
-    ///     .create_account(client_options)
-    ///     .initialise()
-    ///     .expect("failed to add account");
-    /// let account = account_handle.read().await;
-    /// account.list_messages(10, 5, Some(MessageType::Received));
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     # let storage_path: String = thread_rng().gen_ascii_chars().take(10).collect();
+    ///     # let storage_path = std::path::PathBuf::from(format!("./example-database/{}", storage_path));
+    ///     // gets 10 received messages, skipping the first 5 most recent messages.
+    ///     let client_options = ClientOptionsBuilder::node("https://nodes.devnet.iota.org:443")
+    ///         .expect("invalid node URL")
+    ///         .build();
+    ///     let mut manager = AccountManager::new().await.unwrap();
+    ///     # let mut manager = AccountManager::with_storage_path(storage_path).await.unwrap();
+    ///     manager.set_stronghold_password("password").await.unwrap();
+    ///     let account_handle = manager
+    ///         .create_account(client_options)
+    ///         .initialise()
+    ///         .await
+    ///         .expect("failed to add account");
+    ///     let account = account_handle.read().await;
+    ///     account.list_messages(10, 5, Some(MessageType::Received));
+    /// }
     /// ```
     pub fn list_messages(&self, count: usize, from: usize, message_type: Option<MessageType>) -> Vec<&Message> {
         let mut messages: Vec<&Message> = vec![];

--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -148,7 +148,7 @@ impl AccountInitialiser {
     }
 
     /// Initialises the account.
-    pub fn initialise(self) -> crate::Result<AccountGuard> {
+    pub fn initialise(self) -> crate::Result<AccountHandle> {
         let mut accounts = self.accounts.write().unwrap();
 
         let alias = self.alias.unwrap_or_else(|| format!("Account {}", accounts.len()));
@@ -195,7 +195,7 @@ impl AccountInitialiser {
             account.into()
         } else {
             let account_id = account.id().clone();
-            let guard: AccountGuard = account.into();
+            let guard: AccountHandle = account.into();
             accounts.insert(account_id, guard.clone());
             guard
         };
@@ -252,15 +252,15 @@ pub struct Account {
 
 /// A thread guard over an account.
 #[derive(Debug, Clone)]
-pub struct AccountGuard(Arc<RwLock<Account>>);
+pub struct AccountHandle(Arc<RwLock<Account>>);
 
-impl From<Account> for AccountGuard {
+impl From<Account> for AccountHandle {
     fn from(account: Account) -> Self {
         Self(Arc::new(RwLock::new(account)))
     }
 }
 
-impl Deref for AccountGuard {
+impl Deref for AccountHandle {
     type Target = RwLock<Account>;
     fn deref(&self) -> &Self::Target {
         &self.0.deref()
@@ -282,7 +282,7 @@ macro_rules! guard_field_getters {
 }
 
 guard_field_getters!(
-    AccountGuard,
+    AccountHandle,
     #[doc = "Bridge to [Account#id](struct.Account.html#method.id)."] => id => AccountIdentifier,
     #[doc = "Bridge to [Account#signer_type](struct.Account.html#method.signer_type)."] => signer_type => SignerType,
     #[doc = "Bridge to [Account#index](struct.Account.html#method.index)."] => index => usize,
@@ -295,7 +295,7 @@ guard_field_getters!(
     #[doc = "Bridge to [Account#client_options](struct.Account.html#method.client_options)."] => client_options => ClientOptions
 );
 
-impl AccountGuard {
+impl AccountHandle {
     /// Returns the builder to setup the process to synchronize this account with the Tangle.
     pub fn sync(&self) -> AccountSynchronizer {
         AccountSynchronizer::new(self.clone())

--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -401,15 +401,6 @@ pub struct SyncedAccount {
     addresses: Vec<Address>,
 }
 
-/// Transfer response metadata.
-#[derive(Debug)]
-pub struct TransferMetadata {
-    /// The transfer message.
-    pub message: Message,
-    /// The transfer source account with new message and addresses attached.
-    pub account: AccountGuard,
-}
-
 impl SyncedAccount {
     /// Selects input addresses for a value transaction.
     /// The method ensures that the recipient address doesn’t match any of the selected inputs or the remainder address.
@@ -460,7 +451,7 @@ impl SyncedAccount {
     }
 
     /// Send messages.
-    pub async fn transfer(&self, transfer_obj: Transfer) -> crate::Result<TransferMetadata> {
+    pub async fn transfer(&self, transfer_obj: Transfer) -> crate::Result<Message> {
         // validate the transfer
         if transfer_obj.amount == 0 {
             return Err(crate::WalletError::ZeroAmount);
@@ -717,10 +708,7 @@ impl SyncedAccount {
         // ignore errors because we fallback to the polling system
         let _ = crate::monitor::monitor_confirmation_state_change(self.account.clone(), &message_id);
 
-        Ok(TransferMetadata {
-            message,
-            account: self.account.clone(),
-        })
+        Ok(message)
     }
 
     /// Retry message.

--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -71,7 +71,7 @@ async fn sync_addresses(
         for (iota_address_index, iota_address_internal, iota_address) in &generated_iota_addresses {
             futures_.push(async move {
                 let client = crate::client::get_client(account.client_options());
-                let client = client.read().unwrap();
+                let client = client.read().await;
 
                 let address_outputs = client.get_address().outputs(&iota_address).await?;
                 let balance = client.get_address().balance(&iota_address).await?;
@@ -157,7 +157,7 @@ async fn sync_messages(
             let client_options = client_options.clone();
             async move {
                 let client = crate::client::get_client(&client_options);
-                let client = client.read().unwrap();
+                let client = client.read().await;
 
                 let address_outputs = client.get_address().outputs(address.address()).await?;
                 let balance = client.get_address().balance(address.address()).await?;
@@ -215,7 +215,7 @@ async fn update_account_messages<'a>(
         .filter(|message| message.confirmed().is_none())
         .collect();
 
-    let client = client.read().unwrap();
+    let client = client.read().await;
 
     for message in unconfirmed_messages.iter_mut() {
         let metadata = client.get_message().metadata(message.id()).await?;
@@ -528,7 +528,7 @@ impl SyncedAccount {
         let account_ = self.account_handle.read().await;
 
         let client = crate::client::get_client(account_.client_options());
-        let client = client.read().unwrap();
+        let client = client.read().await;
 
         if let RemainderValueStrategy::AccountAddress(ref remainder_target_address) =
             transfer_obj.remainder_value_strategy
@@ -778,7 +778,7 @@ pub(crate) async fn repost_message(
             }
 
             let client = crate::client::get_client(account.client_options());
-            let client = client.read().unwrap();
+            let client = client.read().await;
 
             let (id, message) = match action {
                 RepostAction::Promote => {

--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -837,25 +837,23 @@ mod tests {
     rusty_fork_test! {
         #[test]
         fn account_sync() {
-            crate::block_on(async move {
-                let manager = crate::test_utils::get_account_manager();
-                let manager = manager.lock().unwrap();
+            let manager = crate::test_utils::get_account_manager();
+            let manager = manager.lock().unwrap();
 
-                let client_options = ClientOptionsBuilder::node("https://nodes.devnet.iota.org:443")
-                    .unwrap()
-                    .build();
-                crate::block_on(async move {
-                    let account = manager
+            let client_options = ClientOptionsBuilder::node("https://nodes.devnet.iota.org:443")
+                .unwrap()
+                .build();
+            crate::block_on(async move {
+                let account = manager
                     .create_account(client_options)
                     .alias("alias")
                     .initialise()
                     .await
                     .unwrap();
-                });
-
-                // let synced_accounts = account.sync().execute().await.unwrap();
-                // TODO improve test when the node API is ready to use
             });
+
+            // let synced_accounts = account.sync().execute().await.unwrap();
+            // TODO improve test when the node API is ready to use
         }
     }
 }

--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -816,6 +816,8 @@ mod tests {
         fn account_sync() {
             crate::block_on(async move {
                 let manager = crate::test_utils::get_account_manager();
+                let manager = manager.lock().unwrap();
+
                 let client_options = ClientOptionsBuilder::node("https://nodes.devnet.iota.org:443")
                     .unwrap()
                     .build();

--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -439,7 +439,7 @@ impl SyncedAccount {
         &self,
         locked_addresses: &'a mut MutexGuard<'_, Vec<IotaAddress>>,
         threshold: u64,
-        account: &'a mut Account,
+        account: &'a Account,
         address: &'a IotaAddress,
     ) -> crate::Result<(Vec<input_selection::Input>, Option<input_selection::Input>)> {
         let mut available_addresses: Vec<input_selection::Input> = account
@@ -526,7 +526,7 @@ impl SyncedAccount {
             }
         }
 
-        let mut account_ = self.account.write().unwrap();
+        let account_ = self.account.read().unwrap();
 
         let client = crate::client::get_client(account_.client_options());
         let client = client.read().unwrap();
@@ -547,7 +547,7 @@ impl SyncedAccount {
         let (input_addresses, remainder_address) = self.select_inputs(
             &mut locked_addresses,
             transfer_obj.amount,
-            &mut account_,
+            &account_,
             &transfer_obj.address,
         )?;
 
@@ -623,6 +623,9 @@ impl SyncedAccount {
                 current_output_sum += *utxo.amount();
             }
         }
+
+        drop(account_);
+        let mut account_ = self.account.write().unwrap();
 
         // if there's remainder value, we check the strategy defined in the transfer
         let mut remainder_value_deposit_address = None;

--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    account::{get_account_addresses_lock, Account, AccountGuard},
+    account::{get_account_addresses_lock, Account, AccountHandle},
     address::{Address, AddressBuilder, AddressOutput, IotaAddress},
     client::get_client,
     message::{Message, RemainderValueStrategy, Transfer},
@@ -292,7 +292,7 @@ async fn perform_sync(mut account: &mut Account, address_index: usize, gap_limit
 
 /// Account sync helper.
 pub struct AccountSynchronizer {
-    account: AccountGuard,
+    account: AccountHandle,
     address_index: usize,
     gap_limit: usize,
     skip_persistance: bool,
@@ -300,7 +300,7 @@ pub struct AccountSynchronizer {
 
 impl AccountSynchronizer {
     /// Initialises a new instance of the sync helper.
-    pub(super) fn new(account: AccountGuard) -> Self {
+    pub(super) fn new(account: AccountHandle) -> Self {
         let address_index = {
             let account_ = account.read().unwrap();
             account_.addresses().len()
@@ -391,7 +391,7 @@ impl AccountSynchronizer {
     }
 }
 
-fn serialize_as_id<S>(x: &AccountGuard, s: S) -> Result<S::Ok, S::Error>
+fn serialize_as_id<S>(x: &AccountHandle, s: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {
@@ -405,7 +405,7 @@ pub struct SyncedAccount {
     /// The associated account identifier.
     #[serde(rename = "accountId", serialize_with = "serialize_as_id")]
     #[getset(get = "pub")]
-    account: AccountGuard,
+    account: AccountHandle,
     /// The account's deposit address.
     #[serde(rename = "depositAddress")]
     #[getset(get = "pub")]
@@ -758,7 +758,7 @@ pub(crate) enum RepostAction {
 }
 
 pub(crate) async fn repost_message(
-    account: AccountGuard,
+    account: AccountHandle,
     message_id: &MessageId,
     action: RepostAction,
 ) -> crate::Result<Message> {

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -329,10 +329,12 @@ impl AccountManager {
     /// Gets the account associated with the given alias (case insensitive).
     pub fn get_account_by_alias<S: Into<String>>(&self, alias: S) -> Option<AccountHandle> {
         let alias = alias.into().to_lowercase();
-        self.get_accounts().into_iter().find(|acc| {
-            let acc = acc.read().unwrap();
-            acc.alias().to_lowercase() == alias
-        })
+        self.accounts
+            .read()
+            .unwrap()
+            .values()
+            .find(|a| a.alias().to_lowercase().chars().zip(alias.chars()).all(|(x, y)| x == y))
+            .cloned()
     }
 
     /// Gets all accounts from storage.

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -530,7 +530,8 @@ async fn sync_accounts<'a>(
                 Ok(vec![])
             }
         }
-        None => Ok(vec![]), // None => discover_accounts(accounts.clone(), &storage_path, &ClientOptions::default(), None).await,
+        None => Ok(vec![]), /* None => discover_accounts(accounts.clone(), &storage_path, &ClientOptions::default(),
+                             * None).await, */
     };
 
     if let Ok(discovered_accounts) = discovered_accounts_res {

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -337,8 +337,8 @@ impl AccountManager {
     }
 
     /// Gets the account associated with the given alias (case insensitive).
-    pub async fn get_account_by_alias<S: Into<String>>(&self, alias: S) -> Option<AccountHandle> {
-        let alias = alias.into().to_lowercase();
+    pub async fn get_account_by_alias<S: AsRef<str>>(&self, alias: S) -> Option<AccountHandle> {
+        let alias = alias.as_ref().to_lowercase();
         for account_handle in self.accounts.read().await.values() {
             let account = account_handle.read().await;
             if account

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     account::{
-        account_id_to_stronghold_record_id, repost_message, AccountGuard, AccountIdentifier, AccountInitialiser,
+        account_id_to_stronghold_record_id, repost_message, AccountHandle, AccountIdentifier, AccountInitialiser,
         RepostAction, SyncedAccount,
     },
     client::ClientOptions,
@@ -35,7 +35,7 @@ use stronghold::Stronghold;
 /// The default storage path.
 pub const DEFAULT_STORAGE_PATH: &str = "./example-database";
 
-pub(crate) type AccountStore = Arc<RwLock<HashMap<AccountIdentifier, AccountGuard>>>;
+pub(crate) type AccountStore = Arc<RwLock<HashMap<AccountIdentifier, AccountHandle>>>;
 
 /// The account manager.
 ///
@@ -330,7 +330,7 @@ impl AccountManager {
     }
 
     /// Gets the account associated with the given identifier.
-    pub fn get_account(&self, account_id: &AccountIdentifier) -> crate::Result<AccountGuard> {
+    pub fn get_account(&self, account_id: &AccountIdentifier) -> crate::Result<AccountHandle> {
         let accounts = self.accounts.read().unwrap();
         accounts
             .get(account_id)
@@ -339,7 +339,7 @@ impl AccountManager {
     }
 
     /// Gets the account associated with the given alias (case insensitive).
-    pub fn get_account_by_alias<S: Into<String>>(&self, alias: S) -> Option<AccountGuard> {
+    pub fn get_account_by_alias<S: Into<String>>(&self, alias: S) -> Option<AccountHandle> {
         let alias = alias.into().to_lowercase();
         self.get_accounts().into_iter().find(|acc| {
             let acc = acc.read().unwrap();
@@ -348,7 +348,7 @@ impl AccountManager {
     }
 
     /// Gets all accounts from storage.
-    pub fn get_accounts(&self) -> Vec<AccountGuard> {
+    pub fn get_accounts(&self) -> Vec<AccountHandle> {
         let accounts = self.accounts.read().unwrap();
         accounts.values().cloned().collect()
     }
@@ -475,7 +475,7 @@ async fn discover_accounts(
     storage_path: &PathBuf,
     client_options: &ClientOptions,
     signer_type: Option<SignerType>,
-) -> crate::Result<Vec<(AccountGuard, SyncedAccount)>> {
+) -> crate::Result<Vec<(AccountHandle, SyncedAccount)>> {
     let mut synced_accounts = vec![];
     loop {
         let mut account_initialiser =

--- a/src/actor/message.rs
+++ b/src/actor/message.rs
@@ -12,7 +12,7 @@ use serde::{ser::Serializer, Deserialize, Serialize};
 use tokio::sync::mpsc::UnboundedSender;
 
 /// An account to create.
-#[derive(Clone, Debug, Deserialize, Default)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct AccountToCreate {
     /// The node options.
     #[serde(rename = "clientOptions")]

--- a/src/actor/mod.rs
+++ b/src/actor/mod.rs
@@ -161,7 +161,7 @@ impl WalletMessageHandler {
         account_id: &AccountIdentifier,
         method: &AccountMethod,
     ) -> Result<ResponseType> {
-        let account_handle = self.account_manager.get_account(account_id)?;
+        let account_handle = self.account_manager.get_account(account_id).await?;
 
         match method {
             AccountMethod::GenerateAddress => {
@@ -257,13 +257,13 @@ impl WalletMessageHandler {
     }
 
     async fn get_account(&self, account_id: &AccountIdentifier) -> Result<ResponseType> {
-        let account_handle = self.account_manager.get_account(&account_id)?;
+        let account_handle = self.account_manager.get_account(&account_id).await?;
         let account = account_handle.read().await;
         Ok(ResponseType::ReadAccount(account.clone()))
     }
 
     async fn get_accounts(&self) -> Result<ResponseType> {
-        let accounts = self.account_manager.get_accounts();
+        let accounts = self.account_manager.get_accounts().await;
         let mut accounts_ = Vec::new();
         for account_handle in accounts {
             accounts_.push(account_handle.read().await.clone());
@@ -277,7 +277,7 @@ impl WalletMessageHandler {
     }
 
     async fn send_transfer(&self, account_id: &AccountIdentifier, transfer: &Transfer) -> Result<ResponseType> {
-        let account = self.account_manager.get_account(account_id)?;
+        let account = self.account_manager.get_account(account_id).await?;
         let synced = account.sync().await.execute().await?;
         let message = synced.transfer(transfer.clone()).await?;
         Ok(ResponseType::SentTransfer(message))

--- a/src/actor/mod.rs
+++ b/src/actor/mod.rs
@@ -157,8 +157,7 @@ impl WalletMessageHandler {
 
         match method {
             AccountMethod::GenerateAddress => {
-                let mut account_ = account.write().unwrap();
-                let address = account_.generate_address()?;
+                let address = account.generate_address()?;
                 Ok(ResponseType::GeneratedAddress(address))
             }
             AccountMethod::ListMessages {

--- a/src/actor/mod.rs
+++ b/src/actor/mod.rs
@@ -269,7 +269,7 @@ impl WalletMessageHandler {
     async fn send_transfer(&self, account_id: &AccountIdentifier, transfer: &Transfer) -> Result<ResponseType> {
         let account = self.account_manager.get_account(account_id)?;
         let synced = account.sync().execute().await?;
-        let message = synced.transfer(transfer.clone()).await?.message;
+        let message = synced.transfer(transfer.clone()).await?;
         Ok(ResponseType::SentTransfer(message))
     }
 
@@ -282,8 +282,7 @@ impl WalletMessageHandler {
         let message = self
             .account_manager
             .internal_transfer(from_account_id, to_account_id, amount)
-            .await?
-            .message;
+            .await?;
         Ok(ResponseType::SentTransfer(message))
     }
 }

--- a/src/actor/mod.rs
+++ b/src/actor/mod.rs
@@ -153,7 +153,9 @@ impl WalletMessageHandler {
         account_id: &AccountIdentifier,
         method: &AccountMethod,
     ) -> Result<ResponseType> {
-        let mut account = self.account_manager.get_account(account_id)?;
+        let account = self.account_manager.get_account(account_id)?;
+        let mut account = account.write().unwrap();
+
         match method {
             AccountMethod::GenerateAddress => {
                 let address = account.generate_address()?;
@@ -231,7 +233,8 @@ impl WalletMessageHandler {
 
     fn get_account(&self, account_id: &AccountIdentifier) -> Result<ResponseType> {
         let account = self.account_manager.get_account(&account_id)?;
-        Ok(ResponseType::ReadAccount(account))
+        let account = account.read().unwrap();
+        Ok(ResponseType::ReadAccount(account.clone()))
     }
 
     fn get_accounts(&self) -> Result<ResponseType> {
@@ -245,7 +248,9 @@ impl WalletMessageHandler {
     }
 
     async fn send_transfer(&self, account_id: &AccountIdentifier, transfer: &Transfer) -> Result<ResponseType> {
-        let mut account = self.account_manager.get_account(account_id)?;
+        let account = self.account_manager.get_account(account_id)?;
+        let mut account = account.write().unwrap();
+
         let synced = account.sync().execute().await?;
         let message = synced.transfer(transfer.clone()).await?.message;
         Ok(ResponseType::SentTransfer(message))

--- a/src/actor/mod.rs
+++ b/src/actor/mod.rs
@@ -11,6 +11,7 @@ use futures::{Future, FutureExt};
 use iota::message::prelude::MessageId;
 use std::{
     any::Any,
+    borrow::Cow,
     convert::TryInto,
     panic::{catch_unwind, AssertUnwindSafe},
     path::PathBuf,
@@ -26,9 +27,7 @@ pub struct WalletMessageHandler {
 }
 
 fn panic_to_response_message(panic: Box<dyn Any>) -> Result<ResponseType> {
-    let msg = if let Some(message) = panic.downcast_ref::<String>() {
-        format!("Internal error: {}", message)
-    } else if let Some(message) = panic.downcast_ref::<&str>() {
+    let msg = if let Some(message) = panic.downcast_ref::<Cow<'_, str>>() {
         format!("Internal error: {}", message)
     } else {
         "Internal error".to_string()

--- a/src/client.rs
+++ b/src/client.rs
@@ -6,11 +6,12 @@ pub use iota::client::builder::Network;
 use iota::client::{BrokerOptions, Client, ClientBuilder};
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
+use tokio::sync::RwLock;
 use url::Url;
 
 use std::{
     collections::HashMap,
-    sync::{Arc, Mutex, RwLock},
+    sync::{Arc, Mutex},
 };
 
 type ClientInstanceMap = Arc<Mutex<HashMap<ClientOptions, Arc<RwLock<Client>>>>>;

--- a/src/client.rs
+++ b/src/client.rs
@@ -243,7 +243,7 @@ impl ClientOptionsBuilder {
 }
 
 /// The client options type.
-#[derive(Default, Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash, Getters)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash, Getters)]
 #[getset(get = "pub(crate)")]
 pub struct ClientOptions {
     node: Option<Url>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,13 +35,10 @@ use once_cell::sync::OnceCell;
 use std::{
     collections::HashMap,
     path::PathBuf,
-    sync::{Arc, Mutex, RwLock},
+    sync::{Arc, Mutex},
 };
 use stronghold::Stronghold;
 use tokio::runtime::Runtime;
-
-/// A thread guard over an account.
-pub type AccountGuard = Arc<RwLock<account::Account>>;
 
 static STRONGHOLD_INSTANCE: OnceCell<Arc<Mutex<HashMap<PathBuf, Stronghold>>>> = OnceCell::new();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,13 +169,15 @@ mod test_utils {
     static MANAGER_INSTANCE: OnceCell<Mutex<AccountManager>> = OnceCell::new();
     pub fn get_account_manager() -> &'static Mutex<AccountManager> {
         MANAGER_INSTANCE.get_or_init(|| {
-            let storage_path: String = thread_rng().gen_ascii_chars().take(10).collect();
-            let storage_path = PathBuf::from(format!("./example-database/{}", storage_path));
+            crate::block_on(async move {
+                let storage_path: String = thread_rng().gen_ascii_chars().take(10).collect();
+                let storage_path = PathBuf::from(format!("./example-database/{}", storage_path));
 
-            let mut manager = AccountManager::with_storage_path(storage_path).unwrap();
-            manager.set_polling_interval(Duration::from_secs(4));
-            manager.set_stronghold_password("password").unwrap();
-            Mutex::new(manager)
+                let mut manager = AccountManager::with_storage_path(storage_path).unwrap();
+                manager.set_polling_interval(Duration::from_secs(4));
+                manager.set_stronghold_password("password").await.unwrap();
+                Mutex::new(manager)
+            })
         })
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,7 +177,8 @@ mod test_utils {
     static MANAGER_INSTANCE: OnceCell<Mutex<AccountManager>> = OnceCell::new();
     pub fn get_account_manager() -> &'static Mutex<AccountManager> {
         MANAGER_INSTANCE.get_or_init(|| {
-            crate::block_on(async move {
+            let mut runtime = tokio::runtime::Runtime::new().unwrap();
+            runtime.block_on(async move {
                 let storage_path: String = thread_rng().gen_ascii_chars().take(10).collect();
                 let storage_path = PathBuf::from(format!("./example-database/{}", storage_path));
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,10 +35,13 @@ use once_cell::sync::OnceCell;
 use std::{
     collections::HashMap,
     path::PathBuf,
-    sync::{Arc, Mutex},
+    sync::{Arc, Mutex, RwLock},
 };
 use stronghold::Stronghold;
 use tokio::runtime::Runtime;
+
+/// A thread guard over an account.
+pub type AccountGuard = Arc<RwLock<account::Account>>;
 
 static STRONGHOLD_INSTANCE: OnceCell<Arc<Mutex<HashMap<PathBuf, Stronghold>>>> = OnceCell::new();
 

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -76,10 +76,11 @@ pub fn monitor_address_balance(account: AccountGuard, address: &IotaAddress) -> 
         let account_ = account.read().unwrap();
         account_.client_options().clone()
     };
+    let client_options_ = client_options.clone();
     let address = address.clone();
 
     subscribe_to_topic(
-        &client_options.clone(),
+        &client_options_,
         format!("addresses/{}/outputs", address.to_bech32()),
         move |topic_event| {
             let topic_event = topic_event.clone();

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    account::AccountGuard,
+    account::AccountHandle,
     address::{AddressOutput, IotaAddress},
     client::ClientOptions,
     message::{Message, MessageType},
@@ -42,7 +42,7 @@ struct AddressOutputPayloadAddress {
 }
 
 /// Unsubscribe from all topics associated with the account.
-pub fn unsubscribe(account: AccountGuard) -> crate::Result<()> {
+pub fn unsubscribe(account: AccountHandle) -> crate::Result<()> {
     let account_ = account.read().unwrap();
     let client = crate::client::get_client(account_.client_options());
     let mut client = client.write().unwrap();
@@ -62,7 +62,7 @@ fn subscribe_to_topic<C: Fn(&TopicEvent) + Send + Sync + 'static>(
 }
 
 /// Monitor account addresses for balance changes.
-pub fn monitor_account_addresses_balance(account: AccountGuard) -> crate::Result<()> {
+pub fn monitor_account_addresses_balance(account: AccountHandle) -> crate::Result<()> {
     let account_ = account.read().unwrap();
     for address in account_.addresses() {
         monitor_address_balance(account.clone(), address.address())?;
@@ -71,7 +71,7 @@ pub fn monitor_account_addresses_balance(account: AccountGuard) -> crate::Result
 }
 
 /// Monitor address for balance changes.
-pub fn monitor_address_balance(account: AccountGuard, address: &IotaAddress) -> crate::Result<()> {
+pub fn monitor_address_balance(account: AccountHandle, address: &IotaAddress) -> crate::Result<()> {
     let client_options = {
         let account_ = account.read().unwrap();
         account_.client_options().clone()
@@ -101,7 +101,7 @@ pub fn monitor_address_balance(account: AccountGuard, address: &IotaAddress) -> 
 
 async fn process_output(
     payload: String,
-    account: AccountGuard,
+    account: AccountHandle,
     address: IotaAddress,
     client_options: ClientOptions,
 ) -> crate::Result<()> {
@@ -156,7 +156,7 @@ async fn process_output(
 }
 
 /// Monitor the account's unconfirmed messages for confirmation state change.
-pub fn monitor_unconfirmed_messages(account: AccountGuard) -> crate::Result<()> {
+pub fn monitor_unconfirmed_messages(account: AccountHandle) -> crate::Result<()> {
     let account_ = account.read().unwrap();
     for message in account_.list_messages(0, 0, Some(MessageType::Unconfirmed)) {
         monitor_confirmation_state_change(account.clone(), message.id())?;
@@ -165,7 +165,7 @@ pub fn monitor_unconfirmed_messages(account: AccountGuard) -> crate::Result<()> 
 }
 
 /// Monitor message for confirmation state.
-pub fn monitor_confirmation_state_change(account: AccountGuard, message_id: &MessageId) -> crate::Result<()> {
+pub fn monitor_confirmation_state_change(account: AccountHandle, message_id: &MessageId) -> crate::Result<()> {
     let (message, client_options) = {
         let account_ = account.read().unwrap();
         let message = account_
@@ -191,7 +191,7 @@ pub fn monitor_confirmation_state_change(account: AccountGuard, message_id: &Mes
 
 fn process_metadata(
     payload: String,
-    account: AccountGuard,
+    account: AccountHandle,
     message_id: MessageId,
     message: &Message,
 ) -> crate::Result<()> {

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -128,14 +128,12 @@ async fn process_output(
 
     let mut account = account.write().unwrap();
     let account_id = account.id().clone();
-
     let message_id_ = *message_id;
-    {
-        let addresses = account.addresses_mut();
-        let address_to_update = addresses.iter_mut().find(|a| a.address() == &address).unwrap();
-        address_to_update.handle_new_output(address_output);
-        crate::event::emit_balance_change(&account_id, &address_to_update, *address_to_update.balance());
-    }
+
+    let addresses = account.addresses_mut();
+    let address_to_update = addresses.iter_mut().find(|a| a.address() == &address).unwrap();
+    address_to_update.handle_new_output(address_output);
+    crate::event::emit_balance_change(&account_id, &address_to_update, *address_to_update.balance());
 
     match account.messages_mut().iter().position(|m| m.id() == &message_id_) {
         Some(message_index) => {
@@ -201,11 +199,10 @@ fn process_metadata(
         let confirmed = inclusion_state == "included";
         if message.confirmed().is_none() || confirmed != message.confirmed().unwrap() {
             let mut account = account.write().unwrap();
-            {
-                let messages = account.messages_mut();
-                let message = messages.iter_mut().find(|m| m.id() == &message_id).unwrap();
-                message.set_confirmed(Some(confirmed));
-            }
+
+            let messages = account.messages_mut();
+            let account_message = messages.iter_mut().find(|m| m.id() == &message_id).unwrap();
+            account_message.set_confirmed(Some(confirmed));
 
             crate::event::emit_confirmation_state_change(account.id(), &message, confirmed);
         }

--- a/src/signing/stronghold.rs
+++ b/src/signing/stronghold.rs
@@ -61,12 +61,13 @@ impl super::Signer for StrongholdSigner {
             })
             .collect::<Vec<stronghold::AddressIndexRecorder>>();
         crate::with_stronghold_from_path(account.storage_path(), |stronghold| {
-            stronghold.get_transaction_unlock_blocks(
-                &account_id_to_stronghold_record_id(account.id())?,
-                &essence,
-                &mut inputs,
-            )
+            stronghold
+                .get_transaction_unlock_blocks(
+                    &account_id_to_stronghold_record_id(account.id())?,
+                    &essence,
+                    &mut inputs,
+                )
+                .map_err(|e| e.into())
         })
-        .map_err(|e| e.into())
     }
 }

--- a/src/signing/stronghold.rs
+++ b/src/signing/stronghold.rs
@@ -67,7 +67,7 @@ impl super::Signer for StrongholdSigner {
                     &essence,
                     &mut inputs,
                 )
-                .map_err(|e| e.into())
+                .map_err(Into::into)
         })
     }
 }

--- a/src/storage/stronghold.rs
+++ b/src/storage/stronghold.rs
@@ -86,7 +86,7 @@ impl StorageAdapter for StrongholdStorageAdapter {
         let (_, index) = crate::with_stronghold_from_path(&self.path, |stronghold| get_account_index(&stronghold))?;
         for (_, record_id) in index {
             let account = crate::with_stronghold_from_path(&self.path, |stronghold| {
-                stronghold.record_read(&record_id).map_err(|e| e.into())
+                stronghold.record_read(&record_id).map_err(Into::into)
             })?;
             accounts.push(account);
         }

--- a/src/storage/stronghold.rs
+++ b/src/storage/stronghold.rs
@@ -85,8 +85,9 @@ impl StorageAdapter for StrongholdStorageAdapter {
         let mut accounts = vec![];
         let (_, index) = crate::with_stronghold_from_path(&self.path, |stronghold| get_account_index(&stronghold))?;
         for (_, record_id) in index {
-            let account =
-                crate::with_stronghold_from_path(&self.path, |stronghold| stronghold.record_read(&record_id))?;
+            let account = crate::with_stronghold_from_path(&self.path, |stronghold| {
+                stronghold.record_read(&record_id).map_err(|e| e.into())
+            })?;
             accounts.push(account);
         }
         Ok(accounts)


### PR DESCRIPTION
# Description of change

Instead of loading the account from storage and saving on each operation, we'll keep the account references stored on the AccountManager struct, wrapped on Arc<RwLock<>> for thread safety. This prevents race conditions between e.g. the polling system and the transfer API, where account data can be lost. 

## Type of change

- Refactor

## How the change has been tested

Unit tests + faucet.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked that new and existing unit tests pass locally with my changes
