### PR TITLE
feat(errors): rename to `Error`, remove anyhow calls

### DIFF
--- a/bindings/node/native/src/classes/account/sync.rs
+++ b/bindings/node/native/src/classes/account/sync.rs
@@ -3,7 +3,7 @@
 
 use iota_wallet::{
     account::{AccountIdentifier, SyncedAccount},
-    WalletError,
+    Error,
 };
 use neon::prelude::*;
 use serde::Deserialize;
@@ -25,7 +25,7 @@ pub struct SyncTask {
 
 impl Task for SyncTask {
     type Output = SyncedAccount;
-    type Error = WalletError;
+    type Error = Error;
     type JsEvent = JsValue;
 
     fn perform(&self) -> Result<Self::Output, Self::Error> {

--- a/bindings/node/native/src/classes/account_manager/internal_transfer.rs
+++ b/bindings/node/native/src/classes/account_manager/internal_transfer.rs
@@ -3,7 +3,7 @@
 
 use std::sync::{Arc, RwLock};
 
-use iota_wallet::{account::AccountIdentifier, account_manager::AccountManager, message::Message, WalletError};
+use iota_wallet::{account::AccountIdentifier, account_manager::AccountManager, message::Message, Error};
 use neon::prelude::*;
 
 pub struct InternalTransferTask {
@@ -15,7 +15,7 @@ pub struct InternalTransferTask {
 
 impl Task for InternalTransferTask {
     type Output = Message;
-    type Error = WalletError;
+    type Error = Error;
     type JsEvent = JsValue;
 
     fn perform(&self) -> Result<Self::Output, Self::Error> {

--- a/bindings/node/native/src/classes/account_manager/sync.rs
+++ b/bindings/node/native/src/classes/account_manager/sync.rs
@@ -3,7 +3,7 @@
 
 use std::sync::{Arc, RwLock};
 
-use iota_wallet::{account::SyncedAccount, account_manager::AccountManager, WalletError};
+use iota_wallet::{account::SyncedAccount, account_manager::AccountManager, Error};
 use neon::prelude::*;
 
 pub struct SyncTask {
@@ -12,7 +12,7 @@ pub struct SyncTask {
 
 impl Task for SyncTask {
     type Output = Vec<SyncedAccount>;
-    type Error = WalletError;
+    type Error = Error;
     type JsEvent = JsArray;
 
     fn perform(&self) -> Result<Self::Output, Self::Error> {

--- a/bindings/node/native/src/classes/synced_account/repost.rs
+++ b/bindings/node/native/src/classes/synced_account/repost.rs
@@ -3,7 +3,7 @@
 
 use iota_wallet::{
     message::{Message, MessageId},
-    WalletError,
+    Error,
 };
 use neon::prelude::*;
 
@@ -21,7 +21,7 @@ pub struct RepostTask {
 
 impl Task for RepostTask {
     type Output = Message;
-    type Error = WalletError;
+    type Error = Error;
     type JsEvent = JsValue;
 
     fn perform(&self) -> Result<Self::Output, Self::Error> {

--- a/bindings/node/native/src/classes/synced_account/send.rs
+++ b/bindings/node/native/src/classes/synced_account/send.rs
@@ -3,7 +3,7 @@
 
 use iota_wallet::{
     message::{Message, Transfer},
-    WalletError,
+    Error,
 };
 use neon::prelude::*;
 
@@ -14,7 +14,7 @@ pub struct SendTask {
 
 impl Task for SendTask {
     type Output = Message;
-    type Error = WalletError;
+    type Error = Error;
     type JsEvent = JsValue;
 
     fn perform(&self) -> Result<Self::Output, Self::Error> {

--- a/src/account/sync/input_selection.rs
+++ b/src/account/sync/input_selection.rs
@@ -13,7 +13,7 @@ pub struct Input {
 
 pub fn select_input(target: u64, available_utxos: &mut [Input]) -> crate::Result<Vec<Input>> {
     if target > available_utxos.iter().fold(0, |acc, address| acc + address.balance) {
-        return Err(crate::WalletError::InsufficientFunds);
+        return Err(crate::Error::InsufficientFunds);
     }
 
     available_utxos.sort_by(|a, b| b.balance.cmp(&a.balance));

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -171,16 +171,20 @@ impl AccountManager {
                                 let storage_path_ = storage_path.clone();
                                 let accounts_ = accounts.clone();
 
-                                if let Err(panic) = AssertUnwindSafe(poll(accounts_.clone(), storage_path_, is_monitoring_disabled))
+                                if let Err(error) = AssertUnwindSafe(poll(accounts_.clone(), storage_path_, is_monitoring_disabled))
                                     .catch_unwind()
                                     .await {
-                                    let msg = if let Some(message) = panic.downcast_ref::<Cow<'_, str>>() {
-                                        format!("Internal error: {}", message)
-                                    } else {
-                                        "Internal error".to_string()
-                                    };
-                                    let _error = crate::WalletError::UnknownError(msg);
-                                    // when the error is dropped, the on_error event will be triggered
+                                        if let Some(error) = error.downcast_ref::<crate::Error>() {
+                                            // when the error is dropped, the on_error event will be triggered
+                                        } else {
+                                            let msg = if let Some(message) = error.downcast_ref::<Cow<'_, str>>() {
+                                                format!("Internal error: {}", message)
+                                            } else {
+                                                "Internal error".to_string()
+                                            };
+                                            let _error = crate::Error::Panic(msg);
+                                            // when the error is dropped, the on_error event will be triggered
+                                        }
                                 }
 
                                 let accounts_ = accounts_.read().await;
@@ -209,11 +213,11 @@ impl AccountManager {
         let mut accounts = self.accounts.write().await;
 
         {
-            let account_handle = accounts.get(&account_id).ok_or(crate::WalletError::AccountNotFound)?;
+            let account_handle = accounts.get(&account_id).ok_or(crate::Error::AccountNotFound)?;
             let account = account_handle.read().await;
 
             if !(account.messages().is_empty() && account.total_balance() == 0) {
-                return Err(crate::WalletError::MessageNotEmpty);
+                return Err(crate::Error::MessageNotEmpty);
             }
         }
 
@@ -222,7 +226,7 @@ impl AccountManager {
         if let Err(e) = crate::storage::with_adapter(&self.storage_path, |storage| storage.remove(&account_id)) {
             match e {
                 // if we got an "AccountNotFound" error, that means we didn't save the cached account yet
-                crate::WalletError::AccountNotFound => {}
+                crate::Error::AccountNotFound => {}
                 _ => return Err(e),
             }
         }
@@ -248,7 +252,7 @@ impl AccountManager {
             .read()
             .await
             .latest_address()
-            .ok_or_else(|| anyhow::anyhow!("destination account address list empty"))?
+            .ok_or(crate::Error::TransferDestinationEmpty)?
             .clone();
 
         let from_synchronized = self.get_account(from_account_id).await?.sync().await.execute().await?;
@@ -271,7 +275,7 @@ impl AccountManager {
             }
             Ok(backup_path)
         } else {
-            Err(crate::WalletError::StorageDoesntExist)
+            Err(crate::Error::StorageDoesntExist)
         }
     }
 
@@ -300,7 +304,7 @@ impl AccountManager {
             })
         });
         if let Some(imported_account) = already_imported_account {
-            return Err(crate::WalletError::AccountAlreadyImported {
+            return Err(crate::Error::AccountAlreadyImported {
                 alias: imported_account.alias().to_string(),
             });
         }
@@ -331,10 +335,7 @@ impl AccountManager {
     /// Gets the account associated with the given identifier.
     pub async fn get_account(&self, account_id: &AccountIdentifier) -> crate::Result<AccountHandle> {
         let accounts = self.accounts.read().await;
-        accounts
-            .get(account_id)
-            .cloned()
-            .ok_or(crate::WalletError::AccountNotFound)
+        accounts.get(account_id).cloned().ok_or(crate::Error::AccountNotFound)
     }
 
     /// Gets the account associated with the given alias (case insensitive).

--- a/src/actor/message.rs
+++ b/src/actor/message.rs
@@ -6,7 +6,7 @@ use crate::{
     address::Address,
     client::ClientOptions,
     message::{Message as WalletMessage, MessageType as WalletMessageType, Transfer},
-    WalletError,
+    Error,
 };
 use serde::{ser::Serializer, Deserialize, Serialize};
 use tokio::sync::mpsc::UnboundedSender;
@@ -229,7 +229,7 @@ pub enum ResponseType {
     /// SendTransfer and InternalTransfer response.
     SentTransfer(WalletMessage),
     /// An error occurred.
-    Error(WalletError),
+    Error(Error),
     /// A panic occurred.
     Panic(String),
 }

--- a/src/actor/mod.rs
+++ b/src/actor/mod.rs
@@ -136,7 +136,7 @@ impl WalletMessageHandler {
         let parsed_message_id = MessageId::new(
             message_id.as_bytes()[..]
                 .try_into()
-                .map_err(|_| anyhow::anyhow!("invalid message id length"))?,
+                .map_err(|_| crate::Error::InvalidMessageId)?,
         );
         self.account_manager.reattach(account_id, &parsed_message_id).await?;
         Ok(ResponseType::Reattached(message_id.to_string()))
@@ -231,11 +231,7 @@ impl WalletMessageHandler {
             builder = builder.alias(alias);
         }
         if let Some(created_at) = &account.created_at {
-            builder = builder.created_at(
-                created_at
-                    .parse::<DateTime<Utc>>()
-                    .map_err(|e| anyhow::anyhow!(e.to_string()))?,
-            );
+            builder = builder.created_at(created_at.parse::<DateTime<Utc>>()?);
         }
 
         match builder.initialise().await {

--- a/src/address.rs
+++ b/src/address.rs
@@ -57,19 +57,19 @@ impl AddressOutput {
 }
 
 impl TryFrom<OutputMetadata> for AddressOutput {
-    type Error = crate::WalletError;
+    type Error = crate::Error;
 
     fn try_from(output: OutputMetadata) -> crate::Result<Self> {
         let output = Self {
             transaction_id: TransactionId::new(
                 output.transaction_id[..]
                     .try_into()
-                    .map_err(|_| anyhow::anyhow!("invalid transaction id length"))?,
+                    .map_err(|_| crate::Error::InvalidTransactionId)?,
             ),
             message_id: MessageId::new(
                 output.message_id[..]
                     .try_into()
-                    .map_err(|_| anyhow::anyhow!("invalid message id length"))?,
+                    .map_err(|_| crate::Error::InvalidMessageId)?,
             ),
             index: output.output_index,
             amount: output.amount,
@@ -127,21 +127,21 @@ impl AddressBuilder {
 
     /// Builds the address.
     pub fn build(self) -> crate::Result<Address> {
-        let iota_address = self
-            .address
-            .ok_or_else(|| anyhow::anyhow!("the `address` field is required"))?;
+        let iota_address = self.address.ok_or(crate::Error::AddressBuildRequiredField(
+            crate::AddressBuildRequiredField::Address,
+        ))?;
         let address = Address {
             address: iota_address,
-            balance: self
-                .balance
-                .ok_or_else(|| anyhow::anyhow!("the `balance` field is required"))?,
-            key_index: self
-                .key_index
-                .ok_or_else(|| anyhow::anyhow!("the `key_index` field is required"))?,
+            balance: self.balance.ok_or(crate::Error::AddressBuildRequiredField(
+                crate::AddressBuildRequiredField::Balance,
+            ))?,
+            key_index: self.key_index.ok_or(crate::Error::AddressBuildRequiredField(
+                crate::AddressBuildRequiredField::KeyIndex,
+            ))?,
             internal: self.internal,
-            outputs: self
-                .outputs
-                .ok_or_else(|| anyhow::anyhow!("the `outputs` field is required"))?,
+            outputs: self.outputs.ok_or(crate::Error::AddressBuildRequiredField(
+                crate::AddressBuildRequiredField::Outputs,
+            ))?,
         };
         Ok(address)
     }
@@ -233,7 +233,7 @@ pub fn parse(address: String) -> crate::Result<IotaAddress> {
     let iota_address = IotaAddress::Ed25519(Ed25519Address::new(
         address_ed25519[1..]
             .try_into()
-            .map_err(|_| crate::WalletError::InvalidAddressLength)?,
+            .map_err(|_| crate::Error::InvalidAddressLength)?,
     ));
     Ok(iota_address)
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -186,7 +186,7 @@ impl MultiNodeClientOptionsBuilder {
             None => 0,
         };
         if node_len == 0 {
-            return Err(crate::WalletError::EmptyNodeList);
+            return Err(crate::Error::EmptyNodeList);
         }
         let options = ClientOptions {
             node: None,

--- a/src/event.rs
+++ b/src/event.rs
@@ -76,7 +76,7 @@ struct BalanceEventHandler {
 
 struct ErrorHandler {
     /// The on error callback.
-    on_error: Box<dyn Fn(&crate::WalletError) + Send>,
+    on_error: Box<dyn Fn(&crate::Error) + Send>,
 }
 
 #[derive(PartialEq)]
@@ -218,7 +218,7 @@ pub fn on_broadcast<F: Fn(&TransactionEvent<'_>) + Send + 'static>(cb: F) {
     add_transaction_listener(TransactionEventType::Broadcast, cb);
 }
 
-pub(crate) fn emit_error(error: &crate::WalletError) {
+pub(crate) fn emit_error(error: &crate::Error) {
     let listeners = error_listeners()
         .lock()
         .expect("Failed to lock error_listeners: emit_error()");
@@ -228,7 +228,7 @@ pub(crate) fn emit_error(error: &crate::WalletError) {
 }
 
 /// Listen to errors.
-pub fn on_error<F: Fn(&crate::WalletError) + Send + 'static>(cb: F) {
+pub fn on_error<F: Fn(&crate::Error) + Send + 'static>(cb: F) {
     let mut l = error_listeners()
         .lock()
         .expect("Failed to lock error_listeners: on_error()");
@@ -246,7 +246,7 @@ mod tests {
     use rusty_fork::rusty_fork_test;
 
     fn _create_and_drop_error() {
-        let _ = crate::WalletError::GenericError(anyhow::anyhow!("generic error"));
+        let _ = crate::Error::AccountNotFound;
     }
 
     // have to fork this test so other errors dropped doesn't affect it
@@ -254,7 +254,7 @@ mod tests {
         #[test]
         fn error_events() {
             on_error(|error| {
-                assert!(matches!(error, crate::WalletError::GenericError(_)));
+                assert!(matches!(error, crate::Error::AccountNotFound));
             });
             _create_and_drop_error();
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ pub mod signing;
 pub mod storage;
 
 /// The wallet Result type.
-pub type Result<T> = std::result::Result<T, WalletError>;
+pub type Result<T> = std::result::Result<T, Error>;
 pub use chrono::prelude::{DateTime, Utc};
 use once_cell::sync::OnceCell;
 use std::{
@@ -45,13 +45,10 @@ static RUNTIME: OnceCell<Mutex<Runtime>> = OnceCell::new();
 
 /// The wallet error type.
 #[derive(Debug, thiserror::Error)]
-pub enum WalletError {
-    /// Unknown error.
-    #[error("`{0}`")]
-    UnknownError(String),
+pub enum Error {
     /// Generic error.
     #[error("{0}")]
-    GenericError(#[from] anyhow::Error),
+    GenericError(#[from] anyhow::Error), // TODO remove this with stronghold update
     /// IO error.
     #[error("`{0}`")]
     IoError(#[from] std::io::Error),
@@ -89,9 +86,6 @@ pub enum WalletError {
     /// Address length invalid.
     #[error("unexpected address length")]
     InvalidAddressLength,
-    /// Transaction id length response invalid.
-    #[error("unexpected transaction_id length")]
-    InvalidTransactionIdLength,
     /// Message id length response invalid.
     #[error("unexpected message_id length")]
     InvalidMessageIdLength,
@@ -126,9 +120,91 @@ pub enum WalletError {
     /// the address must belong to the account.
     #[error("the remainder value address doesn't belong to the account")]
     InvalidRemainderValueAddress,
+    /// Storage access error.
+    #[error("error accessing storage: {0}")]
+    Storage(String),
+    /// Panic error.
+    #[error("a panic happened: {0}")]
+    Panic(String),
+    /// Error on `internal_transfer` when the destination account address list is empty
+    #[error("destination account has no addresses")]
+    TransferDestinationEmpty,
+    /// Invalid message identifier.
+    #[error("invalid message id received by node")]
+    InvalidMessageId,
+    /// Invalid transaction identifier.
+    #[error("invalid transaction id received by node")]
+    InvalidTransactionId,
+    /// Address build error: required field not filled.
+    #[error("address build error, field `{0}` is required")]
+    AddressBuildRequiredField(AddressBuildRequiredField),
+    /// Account initialisation error: required field not filled.
+    #[error("account initialisation error, field `{0}` is required")]
+    AccountInitialiseRequiredField(AccountInitialiseRequiredField),
+    /// Error that happens when the stronghold snapshot wasn't loaded.
+    /// The snapshot is loaded through the
+    /// [AccountManager#set_stronghold_password](struct.AccountManager.html#method.set_stronghold_password).
+    #[error("stronghold not loaded")]
+    StrongholdNotLoaded,
+    /// Invalid hex string.
+    #[error("invalid hex string received: {0}")]
+    Hex(#[from] hex::FromHexError),
+    /// Error from bee_message crate.
+    #[error("{0}")]
+    BeeMessage(iota::message::Error),
+    /// Transaction output amount can't be zero.
+    #[error("transaction output amount can't be zero")]
+    OutputAmountIsZero,
+    /// invalid BIP32 derivation path.
+    #[error("invalid BIP32 derivation path: {0}")]
+    InvalidDerivationPath(String),
+    /// Failed to generate private key from BIP32 path.
+    #[error("failed to generate private key from derivation path")]
+    FailedToGeneratePrivateKey(bee_signing_ext::binary::BIP32Path),
+    /// Failed to parse date string.
+    #[error("error parsing date: {0}")]
+    ParseDate(#[from] chrono::ParseError),
 }
 
-impl Drop for WalletError {
+impl From<iota::message::Error> for Error {
+    fn from(error: iota::message::Error) -> Self {
+        Self::BeeMessage(error)
+    }
+}
+
+/// Each of the account initialisation required fields.
+#[derive(Debug)]
+pub enum AccountInitialiseRequiredField {
+    /// `signer_type` field.
+    SignerType,
+}
+
+impl std::fmt::Display for AccountInitialiseRequiredField {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", format!("{:?}", self).to_lowercase())
+    }
+}
+
+/// Each of the address builder required fields.
+#[derive(Debug)]
+pub enum AddressBuildRequiredField {
+    /// address field.
+    Address,
+    /// balance field.
+    Balance,
+    /// key_index field.
+    KeyIndex,
+    /// outputs field.
+    Outputs,
+}
+
+impl std::fmt::Display for AddressBuildRequiredField {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", format!("{:?}", self).to_lowercase())
+    }
+}
+
+impl Drop for Error {
     fn drop(&mut self) {
         event::emit_error(self);
     }
@@ -152,7 +228,7 @@ pub(crate) fn with_stronghold_from_path<T, F: FnOnce(&Stronghold) -> crate::Resu
     if let Some(stronghold) = stronghold_map.get(path) {
         cb(stronghold)
     } else {
-        Err(anyhow::anyhow!("should initialize stronghold instance before using it").into())
+        Err(Error::StrongholdNotLoaded)
     }
 }
 
@@ -211,7 +287,7 @@ mod test_utils {
 
     impl PowProvider for NoopNonceProvider {
         type Builder = NoopNonceProviderBuilder;
-        type Error = crate::WalletError;
+        type Error = crate::Error;
 
         fn nonce(&self, bytes: &[u8], target_score: f64) -> std::result::Result<u64, Self::Error> {
             Ok(0)

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -101,8 +101,8 @@ async fn process_output(
 ) -> crate::Result<()> {
     let output: AddressOutputPayload = serde_json::from_str(&payload)?;
     let metadata = OutputMetadata {
-        message_id: hex::decode(output.message_id).map_err(|e| anyhow::anyhow!(e.to_string()))?,
-        transaction_id: hex::decode(output.transaction_id).map_err(|e| anyhow::anyhow!(e.to_string()))?,
+        message_id: hex::decode(output.message_id)?,
+        transaction_id: hex::decode(output.transaction_id)?,
         output_index: output.output_index,
         is_spent: output.is_spent,
         amount: output.output.amount,

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -91,53 +91,62 @@ pub(crate) mod message_id_serde {
     }
 }
 
-impl serde::Serialize for crate::WalletError {
+impl serde::Serialize for crate::Error {
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
         fn serialize_variant<S: Serializer>(
+            error: &crate::Error,
             serializer: S,
             variant_name: &str,
-            message: Option<&str>,
         ) -> std::result::Result<S::Ok, S::Error> {
-            let mut state = serializer.serialize_struct("WalletError", 2)?;
+            let mut state = serializer.serialize_struct("Error", 2)?;
             state.serialize_field("type", variant_name)?;
-            state.serialize_field("error", &message)?;
+            state.serialize_field("error", &error.to_string())?;
             state.end()
         }
+
         match self {
-            Self::UnknownError(error) => serialize_variant(serializer, "UnknownError", Some(error)),
-            Self::GenericError(error) => serialize_variant(serializer, "GenericError", Some(&error.to_string())),
-            Self::IoError(error) => serialize_variant(serializer, "IoError", Some(&error.to_string())),
-            Self::JsonError(error) => serialize_variant(serializer, "JsonError", Some(&error.to_string())),
-            Self::StrongholdError(error) => serialize_variant(serializer, "StrongholdError", Some(&error.to_string())),
-            Self::ClientError(error) => serialize_variant(serializer, "ClientError", Some(&error.to_string())),
-            Self::SqliteError(error) => serialize_variant(serializer, "SqliteError", Some(&error.to_string())),
-            Self::UrlError(error) => serialize_variant(serializer, "UrlError", Some(&error.to_string())),
-            Self::UnexpectedResponse(error) => serialize_variant(serializer, "UnexpectedResponse", Some(&error)),
-            Self::MessageAboveMaxDepth => serialize_variant(serializer, "MessageAboveMaxDepth", None),
-            Self::MessageAlreadyConfirmed => serialize_variant(serializer, "MessageAlreadyConfirmed", None),
-            Self::MessageNotFound => serialize_variant(serializer, "MessageNotFound", None),
-            Self::EmptyNodeList => serialize_variant(serializer, "EmptyNodeList", None),
-            Self::InvalidAddressLength => serialize_variant(serializer, "InvalidAddressLength", None),
-            Self::InvalidTransactionIdLength => {
-                serializer.serialize_newtype_variant("WalletError", 14, "InvalidTransactionIdLength", "")
+            Self::GenericError(error) => serialize_variant(self, serializer, "GenericError"),
+            Self::IoError(error) => serialize_variant(self, serializer, "IoError"),
+            Self::JsonError(error) => serialize_variant(self, serializer, "JsonError"),
+            Self::StrongholdError(error) => serialize_variant(self, serializer, "StrongholdError"),
+            Self::ClientError(error) => serialize_variant(self, serializer, "ClientError"),
+            Self::SqliteError(error) => serialize_variant(self, serializer, "SqliteError"),
+            Self::UrlError(error) => serialize_variant(self, serializer, "UrlError"),
+            Self::UnexpectedResponse(error) => serialize_variant(self, serializer, "UnexpectedResponse"),
+            Self::MessageAboveMaxDepth => serialize_variant(self, serializer, "MessageAboveMaxDepth"),
+            Self::MessageAlreadyConfirmed => serialize_variant(self, serializer, "MessageAlreadyConfirmed"),
+            Self::MessageNotFound => serialize_variant(self, serializer, "MessageNotFound"),
+            Self::EmptyNodeList => serialize_variant(self, serializer, "EmptyNodeList"),
+            Self::InvalidAddressLength => serialize_variant(self, serializer, "InvalidAddressLength"),
+            Self::InvalidMessageIdLength => serialize_variant(self, serializer, "InvalidMessageIdLength"),
+            Self::Bech32Error(error) => serialize_variant(self, serializer, "Bech32Error"),
+            Self::AccountAlreadyImported { alias } => serialize_variant(self, serializer, "AccountAlreadyImported"),
+            Self::StorageDoesntExist => serialize_variant(self, serializer, "StorageDoesntExist"),
+            Self::InsufficientFunds => serialize_variant(self, serializer, "InsufficientFunds"),
+            Self::MessageNotEmpty => serialize_variant(self, serializer, "MessageNotEmpty"),
+            Self::LatestAccountIsEmpty => serialize_variant(self, serializer, "LatestAccountIsEmpty"),
+            Self::ZeroAmount => serialize_variant(self, serializer, "ZeroAmount"),
+            Self::AccountNotFound => serialize_variant(self, serializer, "AccountNotFound"),
+            Self::InvalidRemainderValueAddress => serialize_variant(self, serializer, "InvalidRemainderValueAddress"),
+            Self::Storage(error) => serialize_variant(self, serializer, "Storage"),
+            Self::Panic(error) => serialize_variant(self, serializer, "Panic"),
+            Self::TransferDestinationEmpty => serialize_variant(self, serializer, "TransferDestinationEmpty"),
+            Self::InvalidMessageId => serialize_variant(self, serializer, "InvalidMessageId"),
+            Self::InvalidTransactionId => serialize_variant(self, serializer, "InvalidTransactionId"),
+            Self::AddressBuildRequiredField(field) => serialize_variant(self, serializer, "AddressBuildRequiredField"),
+            Self::AccountInitialiseRequiredField(field) => {
+                serialize_variant(self, serializer, "AccountInitialiseRequiredField")
             }
-            Self::InvalidMessageIdLength => serialize_variant(serializer, "InvalidMessageIdLength", None),
-            Self::Bech32Error(error) => serialize_variant(serializer, "Bech32Error", Some(&error.to_string())),
-            Self::AccountAlreadyImported { alias } => serialize_variant(
-                serializer,
-                "AccountAlreadyImported",
-                Some(&format!("account {} already imported", alias)),
-            ),
-            Self::StorageDoesntExist => serialize_variant(serializer, "StorageDoesntExist", None),
-            Self::InsufficientFunds => serialize_variant(serializer, "InsufficientFunds", None),
-            Self::MessageNotEmpty => serialize_variant(serializer, "MessageNotEmpty", None),
-            Self::LatestAccountIsEmpty => serialize_variant(serializer, "LatestAccountIsEmpty", None),
-            Self::ZeroAmount => serialize_variant(serializer, "ZeroAmount", None),
-            Self::AccountNotFound => serialize_variant(serializer, "AccountNotFound", None),
-            Self::InvalidRemainderValueAddress => serialize_variant(serializer, "InvalidRemainderValueAddress", None),
+            Self::StrongholdNotLoaded => serialize_variant(self, serializer, "StrongholdNotLoaded"),
+            Self::Hex(error) => serialize_variant(self, serializer, "Hex"),
+            Self::BeeMessage(error) => serialize_variant(self, serializer, "BeeMessage"),
+            Self::OutputAmountIsZero => serialize_variant(self, serializer, "OutputAmountIsZero"),
+            Self::InvalidDerivationPath(path) => serialize_variant(self, serializer, "InvalidDerivationPath"),
+            Self::FailedToGeneratePrivateKey(path) => serialize_variant(self, serializer, "FailedToGeneratePrivateKey"),
+            Self::ParseDate(error) => serialize_variant(self, serializer, "ParseDate"),
         }
     }
 }

--- a/src/signing/env_mnemonic.rs
+++ b/src/signing/env_mnemonic.rs
@@ -68,11 +68,10 @@ impl EnvMnemonicSigner {
 
     fn get_private_key(&self, derivation_path: String) -> crate::Result<ed25519::Ed25519PrivateKey> {
         let seed = self.get_seed();
-        Ok(ed25519::Ed25519PrivateKey::generate_from_seed(
-            &seed,
-            &BIP32Path::from_str(&derivation_path).map_err(|e| anyhow::anyhow!(e.to_string()))?,
-        )
-        .map_err(|e| anyhow::anyhow!(e.to_string()))?)
+        let derivation_path = BIP32Path::from_str(&derivation_path)
+            .map_err(|_| crate::Error::InvalidDerivationPath(derivation_path.clone()))?;
+        Ok(ed25519::Ed25519PrivateKey::generate_from_seed(&seed, &derivation_path)
+            .map_err(|_| crate::Error::FailedToGeneratePrivateKey(derivation_path))?)
     }
 }
 
@@ -129,14 +128,11 @@ impl super::Signer for EnvMnemonicSigner {
             // Check if current path is same as previous path
             // If so, add a reference unlock block
             if let Some(block_index) = signature_indexes.get(&recorder.address_index) {
-                unlock_blocks.push(UnlockBlock::Reference(
-                    ReferenceUnlock::new(*block_index as u16)
-                        .map_err(|e| anyhow::anyhow!("failed to create reference unlock block"))?,
-                ));
+                unlock_blocks.push(UnlockBlock::Reference(ReferenceUnlock::new(*block_index as u16)?));
             } else {
                 // If not, we should create a signature unlock block
                 let private_key = ed25519::Ed25519PrivateKey::generate_from_seed(&seed, &recorder.address_path)
-                    .map_err(|_| anyhow::anyhow!("invalid parameter: seed inputs"))?;
+                    .map_err(|_| crate::Error::FailedToGeneratePrivateKey(recorder.address_path.clone()))?;
                 let public_key = private_key.generate_public_key().to_bytes();
                 // The block should sign the entire transaction essence part of the transaction payload
                 let signature = Box::new(private_key.sign(&serialized_essence).to_bytes());

--- a/src/storage/sqlite.rs
+++ b/src/storage/sqlite.rs
@@ -67,7 +67,7 @@ impl StorageAdapter for SqliteStorageAdapter {
         let account = results
             .first()
             .map(|val| val.as_ref().unwrap().to_string())
-            .ok_or(crate::WalletError::AccountNotFound)?;
+            .ok_or(crate::Error::AccountNotFound)?;
         Ok(account)
     }
 
@@ -84,7 +84,7 @@ impl StorageAdapter for SqliteStorageAdapter {
     fn set(&self, account_id: &AccountIdentifier, account: String) -> crate::Result<()> {
         let id = match account_id {
             AccountIdentifier::Id(id) => id,
-            _ => return Err(anyhow::anyhow!("only Id is supported").into()),
+            _ => return Err(crate::Error::Storage("only Id is supported".into())),
         };
         let connection = self.connection.lock().expect("failed to get connection lock");
         let result = connection
@@ -92,7 +92,7 @@ impl StorageAdapter for SqliteStorageAdapter {
                 &format!("INSERT OR REPLACE INTO {} VALUES (?1, ?2, ?3)", self.table_name),
                 params![id, account, Utc::now().timestamp()],
             )
-            .map_err(|_| anyhow::anyhow!("failed to insert data"))?;
+            .map_err(|_| crate::Error::Storage("failed to insert data".into()))?;
         Ok(())
     }
 
@@ -115,7 +115,7 @@ impl StorageAdapter for SqliteStorageAdapter {
         let connection = self.connection.lock().expect("failed to get connection lock");
         let result = connection
             .execute(&sql, params)
-            .map_err(|_| anyhow::anyhow!("failed to delete data"))?;
+            .map_err(|_| crate::Error::Storage("failed to delete data".into()))?;
         Ok(())
     }
 }

--- a/src/storage/stronghold.rs
+++ b/src/storage/stronghold.rs
@@ -73,10 +73,10 @@ impl StorageAdapter for StrongholdStorageAdapter {
     fn get(&self, account_id: &AccountIdentifier) -> crate::Result<String> {
         let account = crate::with_stronghold_from_path(&self.path, |stronghold| {
             let (_, index) = get_account_index(&stronghold)?;
-            let stronghold_id = get_from_index(&index, &account_id).ok_or(crate::WalletError::AccountNotFound)?;
+            let stronghold_id = get_from_index(&index, &account_id).ok_or(crate::Error::AccountNotFound)?;
             stronghold
                 .record_read(&stronghold_id)
-                .map_err(crate::WalletError::GenericError)
+                .map_err(crate::Error::GenericError)
         })?;
         Ok(account)
     }
@@ -128,7 +128,7 @@ impl StorageAdapter for StrongholdStorageAdapter {
     fn remove(&self, account_id: &AccountIdentifier) -> crate::Result<()> {
         let res: crate::Result<()> = crate::with_stronghold_from_path(&self.path, |stronghold| {
             let (index_record_id, index) = get_account_index(&stronghold)?;
-            let stronghold_id = get_from_index(&index, &account_id).ok_or(crate::WalletError::AccountNotFound)?;
+            let stronghold_id = get_from_index(&index, &account_id).ok_or(crate::Error::AccountNotFound)?;
 
             stronghold.record_remove(stronghold_id)?;
 
@@ -145,7 +145,7 @@ impl StorageAdapter for StrongholdStorageAdapter {
                     &serde_json::to_string(&new_index)?,
                     RecordHint::new(ACCOUNT_ID_INDEX_HINT).unwrap(),
                 )
-                .map_err(crate::WalletError::GenericError)?;
+                .map_err(crate::Error::GenericError)?;
             Ok(())
         });
         res?;


### PR DESCRIPTION
# Description of change

Renames the lib's error struct to `Error` and removes anyhow calls, adding explicit error kinds for each possible scenario. 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
