### PR TITLE
fix(manager); add password parameter to the import_accounts method, closes #183

### DIFF
--- a/bindings/node/README.md
+++ b/bindings/node/README.md
@@ -150,9 +150,10 @@ Backups the database.
 
 Imports a database file.
 
-| Param  | Type                | Default                | Description                 |
-| ------ | ------------------- | ---------------------- | --------------------------- |
-| source | <code>string</code> | <code>undefined</code> | The path to the backup file |
+| Param    | Type                | Default                  | Description                    |
+| ------   | ------------------- | ----------------------   | ---------------------------    |
+| source   | <code>string</code> | <code>undefined</code>   | The path to the backup file    |
+| password | <code>string</code> | <code>undefined</code>   | The backup stronghold password |
 
 ### SyncedAccount
 

--- a/bindings/node/lib/index.d.ts
+++ b/bindings/node/lib/index.d.ts
@@ -142,7 +142,7 @@ export declare class AccountManager {
   syncAccounts(): Promise<SyncedAccount[]>
   internalTransfer(fromAccount: Account, toAccount: Account, amount: number): Promise<Message>
   backup(destination: string): string
-  importAccounts(source: string): void
+  importAccounts(source: string, password: string): void
 }
 
 export declare type Event = 'ErrorThrown' |

--- a/bindings/node/native/src/classes/account_manager/mod.rs
+++ b/bindings/node/native/src/classes/account_manager/mod.rs
@@ -294,12 +294,13 @@ declare_types! {
 
         method importAccounts(mut cx) {
             let source = cx.argument::<JsString>(0)?.value();
+            let password = cx.argument::<JsString>(1)?.value();
             {
                 let this = cx.this();
                 let guard = cx.lock();
                 let ref_ = &this.borrow(&guard).0;
                 let manager = ref_.read().unwrap();
-                crate::block_on(manager.import_accounts(source)).expect("error importing accounts");
+                crate::block_on(manager.import_accounts(source, password)).expect("error importing accounts");
             };
             Ok(cx.undefined().upcast())
         }

--- a/examples/backup_and_restore.rs
+++ b/examples/backup_and_restore.rs
@@ -24,7 +24,7 @@ async fn main() -> iota_wallet::Result<()> {
     manager.remove_account(&id).await?;
 
     // import the accounts from the backup and assert that it's the same
-    manager.import_accounts(backup_path).await?;
+    manager.import_accounts(backup_path, "password").await?;
     let imported_account_handle = manager.get_account(&id).await?;
 
     let account = account_handle.read().await;

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -328,10 +328,10 @@ impl AccountManager {
     }
 
     /// Import backed up accounts.
-    pub async fn import_accounts<P: AsRef<Path>>(&self, source: P) -> crate::Result<()> {
+    pub async fn import_accounts<S: AsRef<Path>, P: AsRef<str>>(&self, source: S, password: P) -> crate::Result<()> {
         let backup_stronghold_path = source.as_ref().join(crate::storage::stronghold_snapshot_filename());
         let backup_stronghold =
-            stronghold::Stronghold::new(&backup_stronghold_path, false, "password".to_string(), None)?;
+            stronghold::Stronghold::new(&backup_stronghold_path, false, password.as_ref().to_string(), None)?;
         crate::init_stronghold(&source.as_ref().to_path_buf(), backup_stronghold);
 
         let backup_storage = crate::storage::get_adapter_from_path(&source)?;

--- a/src/actor/message.rs
+++ b/src/actor/message.rs
@@ -106,7 +106,14 @@ pub enum MessageType {
     /// Backup storage.
     Backup(String),
     /// Import accounts from storage.
-    RestoreBackup(String),
+    RestoreBackup {
+        /// The path to the backed up storage.
+        #[serde(rename = "backupPath")]
+        backup_path: String,
+        /// The backup stronghold password.
+        #[cfg(feature = "stronghold")]
+        password: String,
+    },
     /// Set stronghold snapshot password.
     SetStrongholdPassword(String),
     /// Send funds.
@@ -150,7 +157,10 @@ impl Serialize for MessageType {
                 message_id: _,
             } => serializer.serialize_unit_variant("MessageType", 6, "Reattach"),
             MessageType::Backup(_) => serializer.serialize_unit_variant("MessageType", 7, "Backup"),
-            MessageType::RestoreBackup(_) => serializer.serialize_unit_variant("MessageType", 8, "RestoreBackup"),
+            MessageType::RestoreBackup {
+                backup_path: _,
+                password: _,
+            } => serializer.serialize_unit_variant("MessageType", 8, "RestoreBackup"),
             MessageType::SetStrongholdPassword(_) => {
                 serializer.serialize_unit_variant("MessageType", 9, "SetStrongholdPassword")
             }

--- a/src/actor/mod.rs
+++ b/src/actor/mod.rs
@@ -88,8 +88,8 @@ impl WalletMessageHandler {
                 convert_async_panics(|| async { self.reattach(account_id, message_id).await }).await
             }
             MessageType::Backup(destination_path) => convert_panics(|| self.backup(destination_path)),
-            MessageType::RestoreBackup(backup_path) => {
-                convert_async_panics(|| async { self.restore_backup(backup_path).await }).await
+            MessageType::RestoreBackup { backup_path, password } => {
+                convert_async_panics(|| async { self.restore_backup(backup_path, password).await }).await
             }
             MessageType::SetStrongholdPassword(password) => {
                 convert_async_panics(|| async { self.set_stronghold_password(password).await }).await
@@ -121,8 +121,8 @@ impl WalletMessageHandler {
         Ok(ResponseType::BackupSuccessful)
     }
 
-    async fn restore_backup(&self, backup_path: &str) -> Result<ResponseType> {
-        self.account_manager.import_accounts(backup_path).await?;
+    async fn restore_backup(&self, backup_path: &str, password: &str) -> Result<ResponseType> {
+        self.account_manager.import_accounts(backup_path, password).await?;
         Ok(ResponseType::BackupRestored)
     }
 


### PR DESCRIPTION
## Description

Currently the import_accounts API has a fixed password. This PR changes it to be a parameter instead.

## Links to any relevant issues

#183 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Didn't test it yet since this API needs the stronghold refactor.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked that new and existing unit tests pass locally with my changes
