### PR TITLE
refactor(storage): new stronghold filename, add timestamp to backup name, closes #185

### DIFF
--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -33,7 +33,7 @@ pub fn set_adapter<P: AsRef<Path>, S: StorageAdapter + Sync + Send + 'static>(st
 }
 
 pub(crate) fn stronghold_snapshot_filename() -> &'static str {
-    "snapshot"
+    "wallet.stronghold"
 }
 
 /// gets the storage adapter


### PR DESCRIPTION
# Description of change

- Change stronghold filename from "snapshot" to "wallet.stronghold" (BREAKING CHANGE)
- Change backup so all files has a prefix of `$DATETIME-wallet-$ORIGINAL_FILE_NAME`

## Links to any relevant issues

#185 

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

Not tested yet since it needs the stronghold refactor.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
