### PR TITLE
fix(bindings): remainderValueStrategy is optional

### DIFF
--- a/bindings/node/native/src/classes/synced_account/mod.rs
+++ b/bindings/node/native/src/classes/synced_account/mod.rs
@@ -28,20 +28,11 @@ struct IndexationDto {
     data: Option<Vec<u8>>,
 }
 
-#[derive(Deserialize)]
+#[derive(Default, Deserialize)]
 struct TransferOptions {
-    #[serde(rename = "remainderValueStrategy")]
+    #[serde(rename = "remainderValueStrategy", default)]
     remainder_value_strategy: RemainderValueStrategy,
     indexation: Option<IndexationDto>,
-}
-
-impl Default for TransferOptions {
-    fn default() -> Self {
-        Self {
-            remainder_value_strategy: RemainderValueStrategy::ChangeAddress,
-            indexation: None,
-        }
-    }
 }
 
 declare_types! {

--- a/src/message.rs
+++ b/src/message.rs
@@ -27,6 +27,12 @@ pub enum RemainderValueStrategy {
     AccountAddress(IotaAddress),
 }
 
+impl Default for RemainderValueStrategy {
+    fn default() -> Self {
+        Self::ChangeAddress
+    }
+}
+
 /// A transfer to make a transaction.
 #[derive(Debug, Clone, Deserialize)]
 pub struct TransferBuilder {


### PR DESCRIPTION
# Description of change

The transfer's remainder_value_strategy field is now optional on the Node.js binding. 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Faucet.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
