### PR TITLE
fix: Validate BIP-39 mnemonic when loading from env var

### DIFF
--- a/src/signing/env_mnemonic.rs
+++ b/src/signing/env_mnemonic.rs
@@ -62,8 +62,10 @@ pub struct EnvMnemonicSigner;
 impl EnvMnemonicSigner {
     fn get_seed(&self) -> ed25519::Ed25519Seed {
         let _ = dotenv::dotenv();
+        let mnemonic = env::var(MNEMONIC_ENV_KEY).expect("must set the IOTA_WALLET_MNEMONIC environment variable");
+        bip39::Mnemonic::validate(mnemonic.as_str(), bip39::Language::English).expect("invalid BIP-39 mnemonic");
         mnemonic_to_ed25_seed(
-            env::var(MNEMONIC_ENV_KEY).expect("must set the IOTA_WALLET_MNEMONIC environment variable"),
+            mnemonic,
             env::var(MNEMONIC_PASSWORD_ENV_KEY).unwrap_or_else(|_| "password".to_string()),
         )
     }


### PR DESCRIPTION
# Description of change

The BIP-39 mnemonic does not seem to be validated when loaded from the `IOTA_WALLET_MNEMONIC` environment variable. This can cause addresses to be generated incorrectly (see https://github.com/iotaledger/cli-wallet/issues/25#issuecomment-748481363)

## Links to any relevant issues

iotaledger/cli-wallet#25

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested by using a mnemonic containing `brackets` (invalid) instead of `bracket` (valid)

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
