### PR TITLE
feat(storage): add encryption on the account JSONs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ futures = "0.3"
 backtrace = "0.3"
 async-trait = "0.1"
 log = "0.4"
-iota-crypto = { git = "https://github.com/iotaledger/crypto.rs", rev = "b7148617a87ea03a0653d5784b87644e1167a8c2", features = ["random", "sha", "pbkdf", "hmac", "sha", "bip39", "bip39-en"] }
 
 # env mnemonic
 bee-signing-ext = { git = "https://github.com/wusyong/bee-p.git", branch = "sign-ext", version = "^0.1.0-alpha" }
@@ -41,6 +40,11 @@ tiny-bip39 = "0.7"
 iota-stronghold = { git = "https://github.com/iotaledger/stronghold.rs", rev = "e221dcb31519960e60982012da3c2ac154d989e1", optional = true }
 riker = { version = "0.4", optional = true }
 riker-patterns = { version = "0.4", optional = true }
+
+[dependencies.iota-crypto]
+git = "https://github.com/iotaledger/crypto.rs"
+rev = "c2514969c3f6693b86425ec84bada84b3ebea645"
+features = ["random", "sha", "pbkdf", "hmac", "sha", "bip39", "bip39-en", "chacha"]
 
 [dev-dependencies]
 tokio = { version = "0.2", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ riker-patterns = { version = "0.4", optional = true }
 [dependencies.iota-crypto]
 git = "https://github.com/iotaledger/crypto.rs"
 rev = "c2514969c3f6693b86425ec84bada84b3ebea645"
-features = ["random", "sha", "pbkdf", "hmac", "sha", "bip39", "bip39-en", "chacha"]
+features = ["random", "sha", "pbkdf", "hmac", "bip39", "bip39-en", "chacha"]
 
 [dev-dependencies]
 tokio = { version = "0.2", features = ["full"] }

--- a/bindings/node/README.md
+++ b/bindings/node/README.md
@@ -101,13 +101,21 @@ One of the default storage implementations provided by the wallet library.
 | Stronghold | Storage using Stronghold        |
 
 
+#### setStoragePassword(password): void
+
+Sets the password used for encrypting the storage.
+
+| Param    | Type                | Default                | Description          |
+| -------- | ------------------- | ---------------------- | -------------------- |
+| password | <code>string</code> | <code>undefined</code> | The storage password |
+
 #### setStrongholdPassword(password): void
 
 Sets the stronghold password and initialises it.
 
-| Param    | Type                | Default                | Description                      |
-| -------- | ------------------- | ---------------------- | -------------------------------- |
-| password | <code>string</code> | <code>undefined</code> | The stronghold snapshot password |
+| Param    | Type                | Default                | Description             |
+| -------- | ------------------- | ---------------------- | ----------------------- |
+| password | <code>string</code> | <code>undefined</code> | The stronghold password |
 
 #### generateMnemonic(): string
 

--- a/bindings/node/lib/index.d.ts
+++ b/bindings/node/lib/index.d.ts
@@ -133,6 +133,7 @@ export declare interface ManagerOptions {
 
 export declare class AccountManager {
   constructor(options: ManagerOptions)
+  setStoragePassword(password: string): void
   setStrongholdPassword(password: string): void
   generateMnemonic(): string
   storeMnemonic(signerType: SignerType, mnemonic?: string): void

--- a/bindings/node/native/src/classes/account_manager/mod.rs
+++ b/bindings/node/native/src/classes/account_manager/mod.rs
@@ -103,6 +103,20 @@ declare_types! {
             Ok(cx.undefined().upcast())
         }
 
+        method setStoragePassword(mut cx) {
+            let password = cx.argument::<JsString>(0)?.value();
+            {
+                let this = cx.this();
+                let guard = cx.lock();
+                let ref_ = &this.borrow(&guard).0;
+                crate::block_on(async move {
+                    let mut manager = ref_.write().await;
+                    manager.set_storage_password(password).await
+                }).expect("error setting storage password");
+            }
+            Ok(cx.undefined().upcast())
+        }
+
         method setStrongholdPassword(mut cx) {
             let password = cx.argument::<JsString>(0)?.value();
             {

--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -345,16 +345,10 @@ impl AccountHandle {
 }
 
 impl Account {
-    pub(crate) async fn save(&mut self) -> crate::Result<()> {
+    pub(crate) async fn save(&mut self, encryption_key: &Option<[u8; 32]>) -> crate::Result<()> {
         if self.has_pending_changes && !self.skip_persistance {
             let storage_path = self.storage_path.clone();
-            let account_id = self.id().clone();
-            let data = serde_json::to_string(&self)?;
-            crate::storage::get(&storage_path)?
-                .lock()
-                .await
-                .set(&account_id, data)
-                .await?;
+            crate::storage::save_account(&storage_path, &self, encryption_key).await?;
             self.has_pending_changes = false;
         }
         Ok(())

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -327,7 +327,7 @@ impl AccountManager {
             let account = serde_json::from_str::<Account>(&decrypted)?;
             accounts.insert(account.id().clone(), account.into());
         }
-        self.encrypted_accounts = Vec::new();
+        self.encrypted_accounts.clear();
 
         Ok(())
     }

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -85,6 +85,7 @@ pub struct AccountManagerBuilder {
     polling_interval: Duration,
     skip_polling: bool,
     default_storage: Option<DefaultStorage>,
+    storage_encryption_key: Option<[u8; 32]>,
 }
 
 impl Default for AccountManagerBuilder {
@@ -101,6 +102,7 @@ impl Default for AccountManagerBuilder {
             polling_interval: Duration::from_millis(30_000),
             skip_polling: false,
             default_storage,
+            storage_encryption_key: None,
         }
     }
 }
@@ -146,6 +148,11 @@ impl AccountManagerBuilder {
 
     pub(crate) fn skip_polling(mut self) -> Self {
         self.skip_polling = true;
+        self
+    }
+
+    pub(crate) fn with_storage_encryption_key(mut self, key: Option<[u8; 32]>) -> Self {
+        self.storage_encryption_key = key;
         self
     }
 
@@ -204,7 +211,7 @@ impl AccountManagerBuilder {
             stop_polling_sender: None,
             polling_handle: None,
             generated_mnemonic: None,
-            storage_encryption_key: Arc::new(Mutex::new(None)),
+            storage_encryption_key: Arc::new(Mutex::new(self.storage_encryption_key)),
             encypted_accounts: Vec::new(),
         };
 
@@ -662,6 +669,7 @@ impl AccountManager {
                 let mut stronghold_manager = Self::builder()
                     .with_storage_path(&source)
                     .with_storage(DefaultStorage::Stronghold)
+                    .with_storage_encryption_key(self.storage_encryption_key.lock().await.clone())
                     .skip_polling()
                     .finish()
                     .await?;

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -669,7 +669,7 @@ impl AccountManager {
                 let mut stronghold_manager = Self::builder()
                     .with_storage_path(&source)
                     .with_storage(DefaultStorage::Stronghold)
-                    .with_storage_encryption_key(self.storage_encryption_key.lock().await.clone())
+                    .with_storage_encryption_key(*self.storage_encryption_key.lock().await)
                     .skip_polling()
                     .finish()
                     .await?;

--- a/src/actor/message.rs
+++ b/src/actor/message.rs
@@ -121,6 +121,8 @@ pub enum MessageType {
         #[cfg(any(feature = "stronghold", feature = "stronghold-storage"))]
         password: String,
     },
+    /// Sets the password used to encrypt/decrypt the storage.
+    SetStoragePassword(String),
     /// Set stronghold snapshot password.
     #[cfg(any(feature = "stronghold", feature = "stronghold-storage"))]
     SetStrongholdPassword(String),
@@ -184,25 +186,28 @@ impl Serialize for MessageType {
                 #[cfg(any(feature = "stronghold", feature = "stronghold-storage"))]
                     password: _,
             } => serializer.serialize_unit_variant("MessageType", 8, "RestoreBackup"),
+            MessageType::SetStoragePassword(_) => {
+                serializer.serialize_unit_variant("MessageType", 9, "SetStoragePassword")
+            }
             #[cfg(any(feature = "stronghold", feature = "stronghold-storage"))]
             MessageType::SetStrongholdPassword(_) => {
-                serializer.serialize_unit_variant("MessageType", 9, "SetStrongholdPassword")
+                serializer.serialize_unit_variant("MessageType", 10, "SetStrongholdPassword")
             }
             MessageType::SendTransfer {
                 account_id: _,
                 transfer: _,
-            } => serializer.serialize_unit_variant("MessageType", 10, "SendTransfer"),
+            } => serializer.serialize_unit_variant("MessageType", 11, "SendTransfer"),
             MessageType::InternalTransfer {
                 from_account_id: _,
                 to_account_id: _,
                 amount: _,
-            } => serializer.serialize_unit_variant("MessageType", 11, "InternalTransfer"),
-            MessageType::GenerateMnemonic => serializer.serialize_unit_variant("MessageType", 12, "GenerateMnemonic"),
-            MessageType::VerifyMnemonic(_) => serializer.serialize_unit_variant("MessageType", 13, "GenerateMnemonic"),
+            } => serializer.serialize_unit_variant("MessageType", 12, "InternalTransfer"),
+            MessageType::GenerateMnemonic => serializer.serialize_unit_variant("MessageTpe", 13, "GenerateMnemonic"),
+            MessageType::VerifyMnemonic(_) => serializer.serialize_unit_variant("MessageType", 14, "GenerateMnemonic"),
             MessageType::StoreMnemonic {
                 signer_type: _,
                 mnemonic: _,
-            } => serializer.serialize_unit_variant("MessageType", 14, "StoreMnemonic"),
+            } => serializer.serialize_unit_variant("MessageType", 15, "StoreMnemonic"),
         }
     }
 }
@@ -268,6 +273,8 @@ pub enum ResponseType {
     /// ImportAccounts response.
     #[cfg(any(feature = "stronghold-storage", feature = "sqlite-storage"))]
     BackupRestored,
+    /// SetStoragePassword response.
+    StoragePasswordSet,
     /// SetStrongholdPassword response.
     #[cfg(any(feature = "stronghold", feature = "stronghold-storage"))]
     StrongholdPasswordSet,

--- a/src/actor/message.rs
+++ b/src/actor/message.rs
@@ -202,8 +202,8 @@ impl Serialize for MessageType {
                 to_account_id: _,
                 amount: _,
             } => serializer.serialize_unit_variant("MessageType", 12, "InternalTransfer"),
-            MessageType::GenerateMnemonic => serializer.serialize_unit_variant("MessageTpe", 13, "GenerateMnemonic"),
-            MessageType::VerifyMnemonic(_) => serializer.serialize_unit_variant("MessageType", 14, "GenerateMnemonic"),
+            MessageType::GenerateMnemonic => serializer.serialize_unit_variant("MessageType", 13, "GenerateMnemonic"),
+            MessageType::VerifyMnemonic(_) => serializer.serialize_unit_variant("MessageType", 14, "VerifyMnemonic"),
             MessageType::StoreMnemonic {
                 signer_type: _,
                 mnemonic: _,

--- a/src/actor/mod.rs
+++ b/src/actor/mod.rs
@@ -101,6 +101,9 @@ impl WalletMessageHandler {
             MessageType::RestoreBackup { backup_path } => {
                 convert_async_panics(|| async { self.restore_backup(backup_path).await }).await
             }
+            MessageType::SetStoragePassword(password) => {
+                convert_async_panics(|| async { self.set_storage_password(password).await }).await
+            }
             #[cfg(any(feature = "stronghold", feature = "stronghold-storage"))]
             MessageType::SetStrongholdPassword(password) => {
                 convert_async_panics(|| async { self.set_stronghold_password(password).await }).await
@@ -292,6 +295,11 @@ impl WalletMessageHandler {
             accounts_.push(account_handle.read().await.clone());
         }
         Ok(ResponseType::ReadAccounts(accounts_))
+    }
+
+    async fn set_storage_password(&mut self, password: &str) -> Result<ResponseType> {
+        self.account_manager.set_storage_password(password).await?;
+        Ok(ResponseType::StoragePasswordSet)
     }
 
     #[cfg(feature = "stronghold")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,6 +184,9 @@ pub enum Error {
         "storage adapter not set for path `{0}`; please use the method `with_storage` on the AccountManager builder"
     )]
     StorageAdapterNotSet(PathBuf),
+    /// error decrypting stored account using provided encryptionKey
+    #[error("failed to decrypt account")]
+    AccountDecrypt,
 }
 
 impl From<iota::message::Error> for Error {
@@ -303,6 +306,8 @@ mod test_utils {
 
         #[cfg(any(feature = "stronghold", feature = "stronghold-storage"))]
         manager.set_stronghold_password("password").await.unwrap();
+
+        manager.set_storage_password("password").await.unwrap();
 
         manager.store_mnemonic(signer_type(), None).await.unwrap();
         manager

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -116,6 +116,7 @@ impl serde::Serialize for crate::Error {
             Self::StorageAdapterNotDefined => serialize_variant(self, serializer, "StorageAdapterNotDefined"),
             Self::StorageExists => serialize_variant(self, serializer, "StorageExists"),
             Self::StorageAdapterNotSet(_) => serialize_variant(self, serializer, "StorageAdapterNotSet"),
+            Self::AccountDecrypt => serialize_variant(self, serializer, "AccountDecrypt"),
         }
     }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -10,11 +10,13 @@ pub mod sqlite;
 pub mod stronghold;
 
 use crate::account::{Account, AccountIdentifier};
+use crypto::ciphers::chacha::xchacha20poly1305;
 use once_cell::sync::OnceCell;
 use tokio::sync::Mutex as AsyncMutex;
 
 use std::{
     collections::HashMap,
+    io::{Read, Write},
     path::{Path, PathBuf},
     sync::{Arc, Mutex, RwLock},
 };
@@ -60,26 +62,115 @@ pub trait StorageAdapter {
     async fn remove(&self, account_id: &AccountIdentifier) -> crate::Result<()>;
 }
 
-pub(crate) fn parse_accounts(storage_path: &PathBuf, accounts: &[String]) -> crate::Result<Vec<Account>> {
+fn encrypt_account_json<O: Write>(account: &[u8], key: &[u8; 32], output: &mut O) -> crate::Result<()> {
+    let mut nonce = [0; xchacha20poly1305::XCHACHA20POLY1305_NONCE_SIZE];
+    crypto::rand::fill(&mut nonce)?;
+
+    let mut tag = [0; xchacha20poly1305::XCHACHA20POLY1305_TAG_SIZE];
+    let mut ct = vec![0; account.len()];
+    xchacha20poly1305::encrypt(&mut ct, &mut tag, account, key, &nonce, &[])?;
+
+    output.write_all(&nonce)?;
+    output.write_all(&tag)?;
+    output.write_all(&ct)?;
+
+    Ok(())
+}
+
+pub(crate) fn decrypt_account_json(account: &str, key: &[u8; 32]) -> crate::Result<String> {
+    let account: Vec<u8> = serde_json::from_str(&account)?;
+    let mut account: &[u8] = &account;
+
+    let mut nonce = [0; xchacha20poly1305::XCHACHA20POLY1305_NONCE_SIZE];
+    account.read_exact(&mut nonce)?;
+
+    let mut tag = [0; xchacha20poly1305::XCHACHA20POLY1305_TAG_SIZE];
+    account.read_exact(&mut tag)?;
+
+    let mut ct = Vec::new();
+    account.read_to_end(&mut ct)?;
+
+    let mut pt = vec![0; ct.len()];
+    xchacha20poly1305::decrypt(&mut pt, &ct, key, &tag, &nonce, &[])?;
+
+    Ok(String::from_utf8_lossy(&pt).to_string())
+}
+
+pub(crate) enum ParsedAccount {
+    Account(Account),
+    EncryptedAccount(String),
+}
+
+pub(crate) fn get_account_string_to_save(
+    account: &Account,
+    encryption_key: &Option<[u8; 32]>,
+) -> crate::Result<String> {
+    let json = serde_json::to_string(&account)?;
+    let data = if let Some(key) = encryption_key {
+        let mut output = Vec::new();
+        encrypt_account_json(json.as_bytes(), key, &mut output)?;
+        serde_json::to_string(&output)?
+    } else {
+        json
+    };
+    Ok(data)
+}
+
+pub(crate) async fn save_account(
+    storage_path: &PathBuf,
+    account: &Account,
+    encryption_key: &Option<[u8; 32]>,
+) -> crate::Result<()> {
+    crate::storage::get(&storage_path)?
+        .lock()
+        .await
+        .set(account.id(), get_account_string_to_save(account, encryption_key)?)
+        .await?;
+    Ok(())
+}
+
+pub(crate) fn parse_accounts(
+    storage_path: &PathBuf,
+    accounts: &[String],
+    encryption_key: &Option<[u8; 32]>,
+) -> crate::Result<Vec<ParsedAccount>> {
     let mut err = None;
-    let accounts: Vec<Option<Account>> = accounts
+    let accounts: Vec<Option<ParsedAccount>> = accounts
         .iter()
-        .map(|account| match serde_json::from_str::<Account>(&account) {
-            Ok(mut acc) => {
-                acc.set_storage_path(storage_path.clone());
-                Some(acc)
-            }
-            Err(e) => {
-                err = Some(e);
+        .map(|account| {
+            let account_json = if account.starts_with('{') {
+                Some(account.to_string())
+            } else if let Some(key) = encryption_key {
+                if let Ok(json) = decrypt_account_json(account, key) {
+                    Some(json)
+                } else {
+                    err = Some(crate::Error::AccountDecrypt);
+                    return None;
+                }
+            } else {
                 None
+            };
+            if let Some(json) = account_json {
+                match serde_json::from_str::<Account>(&json) {
+                    Ok(mut acc) => {
+                        acc.set_storage_path(storage_path.clone());
+                        Some(ParsedAccount::Account(acc))
+                    }
+                    Err(e) => {
+                        err = Some(e.into());
+                        None
+                    }
+                }
+            } else {
+                Some(ParsedAccount::EncryptedAccount(account.to_string()))
             }
         })
         .collect();
 
     if let Some(err) = err {
-        Err(err.into())
+        Err(err)
     } else {
-        let accounts = accounts.iter().map(|account| account.clone().unwrap()).collect();
+        let accounts = accounts.into_iter().map(|account| account.unwrap()).collect();
         Ok(accounts)
     }
 }


### PR DESCRIPTION
# Description of change

Add optional account JSON encryption accessible through `AccountManager::set_storage_password`. 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Unit tests, faucet.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
