### PR TITLE
fix(stronghold): snapshot switch

### DIFF
--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -1120,17 +1120,20 @@ mod tests {
         };
 
         // get another manager instance so we can import the accounts to a different storage
+        #[allow(unused_mut)]
         let mut manager = crate::test_utils::get_account_manager().await;
 
-        // import the accounts from the backup and assert that it's the same
         #[cfg(all(
             not(feature = "sqlite-storage"),
             any(feature = "stronghold", feature = "stronghold-storage")
         ))]
-        {
-            std::fs::remove_file(manager.storage_path()).unwrap();
-            manager.import_accounts(backup_file_path, "password").await.unwrap();
-        }
+        std::fs::remove_file(manager.storage_path()).unwrap();
+
+        // import the accounts from the backup and assert that it's the same
+
+        #[cfg(any(feature = "stronghold", feature = "stronghold-storage"))]
+        manager.import_accounts(backup_file_path, "password").await.unwrap();
+
         #[cfg(not(any(feature = "stronghold", feature = "stronghold-storage")))]
         manager.import_accounts(backup_file_path).await.unwrap();
 

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -622,6 +622,11 @@ impl AccountManager {
             #[cfg(not(any(feature = "stronghold", feature = "stronghold-storage")))]
             return Err(crate::Error::InvalidBackupFile);
         } else {
+            #[cfg(any(feature = "stronghold", feature = "stronghold-storage"))]
+            {
+                // wait for stronghold to finish its tasks
+                let _ = crate::stronghold::actor_runtime().lock().await;
+            }
             fs::copy(source, &storage_file_path)?;
         }
 
@@ -632,9 +637,13 @@ impl AccountManager {
         }
 
         #[cfg(any(feature = "stronghold", feature = "stronghold-storage"))]
-        if let Err(e) = self.set_stronghold_password(stronghold_password).await {
-            fs::remove_file(&storage_file_path)?;
-            return Err(e);
+        {
+            // force stronghold to read the snapshot again, ignoring any previous cached value
+            crate::stronghold::unload_snapshot(&self.storage_path, false).await?;
+            if let Err(e) = self.set_stronghold_password(stronghold_password).await {
+                fs::remove_file(&storage_file_path)?;
+                return Err(e);
+            }
         }
 
         Ok(())
@@ -1111,11 +1120,14 @@ mod tests {
         };
 
         // get another manager instance so we can import the accounts to a different storage
-        let mut manager = crate::test_utils::get_empty_account_manager().await;
+        let mut manager = crate::test_utils::get_account_manager().await;
 
         // import the accounts from the backup and assert that it's the same
         #[cfg(any(feature = "stronghold", feature = "stronghold-storage"))]
-        manager.import_accounts(backup_file_path, "password").await.unwrap();
+        {
+            std::fs::remove_file(manager.storage_path()).unwrap();
+            manager.import_accounts(backup_file_path, "password").await.unwrap();
+        }
         #[cfg(not(any(feature = "stronghold", feature = "stronghold-storage")))]
         manager.import_accounts(backup_file_path).await.unwrap();
 

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -1123,7 +1123,10 @@ mod tests {
         let mut manager = crate::test_utils::get_account_manager().await;
 
         // import the accounts from the backup and assert that it's the same
-        #[cfg(any(feature = "stronghold", feature = "stronghold-storage"))]
+        #[cfg(all(
+            not(feature = "sqlite-storage"),
+            any(feature = "stronghold", feature = "stronghold-storage")
+        ))]
         {
             std::fs::remove_file(manager.storage_path()).unwrap();
             manager.import_accounts(backup_file_path, "password").await.unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -314,8 +314,6 @@ mod test_utils {
             .await
             .unwrap();
 
-        manager.set_storage_password("password").await.unwrap();
-
         #[cfg(not(any(feature = "stronghold", feature = "stronghold-storage")))]
         crate::signing::set_signer(signer_type(), TestSigner {}).await;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -299,16 +299,6 @@ mod test_utils {
     }
 
     pub async fn get_account_manager() -> AccountManager {
-        let mut manager = get_empty_account_manager().await;
-
-        #[cfg(any(feature = "stronghold", feature = "stronghold-storage"))]
-        manager.set_stronghold_password("password").await.unwrap();
-
-        manager.store_mnemonic(signer_type(), None).await.unwrap();
-        manager
-    }
-
-    pub async fn get_empty_account_manager() -> AccountManager {
         let storage_path = loop {
             let storage_path: String = thread_rng().sample_iter(&Alphanumeric).take(10).collect();
             let storage_path = PathBuf::from(format!("./test-storage/{}", storage_path));
@@ -317,16 +307,22 @@ mod test_utils {
             }
         };
 
-        let manager = AccountManager::builder()
+        let mut manager = AccountManager::builder()
             .with_storage_path(storage_path)
             .with_polling_interval(POLLING_INTERVAL)
             .finish()
             .await
             .unwrap();
 
-        let signer_type = signer_type();
+        manager.set_storage_password("password").await.unwrap();
+
         #[cfg(not(any(feature = "stronghold", feature = "stronghold-storage")))]
-        crate::signing::set_signer(signer_type.clone(), TestSigner {}).await;
+        crate::signing::set_signer(signer_type(), TestSigner {}).await;
+
+        #[cfg(any(feature = "stronghold", feature = "stronghold-storage"))]
+        manager.set_stronghold_password("password").await.unwrap();
+
+        manager.store_mnemonic(signer_type(), None).await.unwrap();
 
         manager
     }


### PR DESCRIPTION
# Description of change

Fixes stroghold's snapshot switch when loading multiple snapshots (previously overwriting the restored backup if a pending operation existed).

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

The unit tests.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
