### PR TITLE
Setting OPENSSL_ROOT_DIR on macOS is no longer necessary

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -72,11 +72,6 @@ jobs:
         restore-keys: |
           ${{ matrix.os }}-stable-cargo-build-node-target-${{ hashFiles('**/Cargo.toml') }}
 
-    # paho.mqtt requires openssl and OPENSSL_ROOT_DIR on macOS
-    - name: Set OpenSSL location (macOS)
-      if: matrix.os == 'macos-latest'
-      run: echo "OPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1)" >> $GITHUB_ENV
-
     # paho.mqtt requires openssl and OPENSSL_DIR on Windows
     - name: Install OpenSSL (Windows)
       if: matrix.os == 'windows-latest'

--- a/README.md
+++ b/README.md
@@ -51,10 +51,7 @@ $ set OPENSSL_DIR="C:\Program Files\OpenSSL-Win64"
 `cmake` and `openssl` can be installed with `Homebrew`:
 
 ```
-$ brew install cmake
-$ brew install openssl@1.1
-# you may want to add this to your .zshrc or .bashrc since you'll need it to compile the crate
-$ OPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1)
+$ brew install cmake openssl@1.1
 ```
 
 ### Linux


### PR DESCRIPTION
# Description of change

With the update to `paho-mqtt` 0.9, setting `OPENSSL_ROOT_DIR` is no longer necessary on macOS as `openssl-sys` will automatically detect the path of OpenSSL when installed with Homebrew

## Links to any relevant issues

N/A

## Type of change

- CI improvement
- Documentation Fix

## How the change has been tested

CI passes

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation