### PR TITLE
feat(account): expose `skip_persistance` on create_account, closes #182

### DIFF
--- a/bindings/node/README.md
+++ b/bindings/node/README.md
@@ -136,14 +136,15 @@ Saves the mnemonic using the given signer provider.
 
 Creates a new account.
 
-| Param                 | Type                                         | Default                           | Description                                              |
-| --------------------- | -------------------------------------------- | --------------------------------- | -------------------------------------------------------- |
-| account               | <code>object</code>                          | <code>{}</code>                   | The account to be created                                |
-| account.clientOptions | <code>[ClientOptions](#clientoptions)</code> | <code>undefined</code>            | The node configuration                                   |
-| [account.mnemonic]    | <code>string</code>                          | <code>undefined</code>            | The account BIP39 mnemonic                               |
-| [account.alias]       | <code>string</code>                          | <code>Account ${index + 1}</code> | The account alias                                        |
-| [account.createdAt]   | <code>string</code>                          | the current date and time         | The ISO 8601 date string of the account creation         |
-| [account.signerType]  | <code>number</code>                          | 1 = Stronghold                    | The account signer type. 1 = Stronghold, 2 = EnvMnemonic |
+| Param                     | Type                                         | Default                           | Description                                              |
+| ------------------------- | -------------------------------------------- | --------------------------------- | -------------------------------------------------------- |
+| account                   | <code>object</code>                          | <code>{}</code>                   | The account to be created                                |
+| account.clientOptions     | <code>[ClientOptions](#clientoptions)</code> | <code>undefined</code>            | The node configuration                                   |
+| [account.mnemonic]        | <code>string</code>                          | <code>undefined</code>            | The account BIP39 mnemonic                               |
+| [account.alias]           | <code>string</code>                          | <code>Account ${index + 1}</code> | The account alias                                        |
+| [account.createdAt]       | <code>string</code>                          | the current date and time         | The ISO 8601 date string of the account creation         |
+| [account.signerType]      | <code>number</code>                          | 1 = Stronghold                    | The account signer type. 1 = Stronghold, 2 = EnvMnemonic |
+| [account.skipPersistance] | <code>boolean</code>                         | false                             | Skip saving the account to the storage                   |
 
 #### getAccount(accountId)
 

--- a/bindings/node/lib/index.d.ts
+++ b/bindings/node/lib/index.d.ts
@@ -119,6 +119,7 @@ export declare interface AccountToCreate {
   alias?: string;
   createdAt?: string;
   signerType?: SignerType;
+  skipPersistance?: boolean;
 }
 
 export declare enum StorageType {

--- a/bindings/node/native/src/classes/account_manager/mod.rs
+++ b/bindings/node/native/src/classes/account_manager/mod.rs
@@ -41,6 +41,8 @@ pub struct AccountToCreate {
     pub created_at: Option<String>,
     #[serde(rename = "signerType", default)]
     pub signer_type: AccountSignerType,
+    #[serde(rename = "skipPersistance", default)]
+    pub skip_persistance: bool,
 }
 
 fn js_value_to_account_id(
@@ -191,6 +193,10 @@ declare_types! {
                         .expect("invalid account created at format"),
                     );
                 }
+                if account_to_create.skip_persistance {
+                    builder = builder.skip_persistance();
+                }
+
                 crate::block_on(builder.initialise()).expect("error creating account")
             };
 

--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -115,7 +115,8 @@ impl AccountInitialiser {
         self
     }
 
-    pub(crate) fn skip_persistance(mut self) -> Self {
+    /// Skips storing the account to the database.
+    pub fn skip_persistance(mut self) -> Self {
         self.skip_persistance = true;
         self
     }

--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -343,7 +343,8 @@ impl AccountSynchronizer {
         self
     }
 
-    /// Skip write to the database.
+    /// Skip saving new messages and addresses on the account object.
+    /// The found data is returned on the `execute` call but won't be persisted on the database.
     pub fn skip_persistance(mut self) -> Self {
         self.skip_persistance = true;
         self


### PR DESCRIPTION
# Description of change

Allows an account to be created without persisting to the database. 

## Links to any relevant issues

#182 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Faucet.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked that new and existing unit tests pass locally with my changes
