### PR TITLE
refactor(address): follow spec on `list addresses` APIs, closes #167

### DIFF
--- a/bindings/node/README.md
+++ b/bindings/node/README.md
@@ -305,14 +305,16 @@ Returns the account's messages.
 
 Message object: { confirmed: boolean, broadcasted: boolean, incoming: boolean, value: number }
 
-#### listAddresses([unspent])
+#### listAddresses()
 Returns the account's addresses.
 
-| Param     | Type                 | Default           | Description                 |
-| --------- | -------------------- | ----------------- | --------------------------- |
-| [unspent] | <code>boolean</code> | <code>null</code> | The `unspent` status filter |
-
 Address object: { address: string, balance: number, keyIndex: number }
+
+#### listSpentAddresses()
+Returns the account's spent addresses.
+
+#### listUnspentAddresses()
+Returns the account's unspent addresses.
 
 #### sync([options])
 

--- a/examples/account_operations.rs
+++ b/examples/account_operations.rs
@@ -21,10 +21,12 @@ async fn main() -> iota_wallet::Result<()> {
 
     // update alias
     account.set_alias("the new alias").await;
-    // list unspent addresses
-    let _ = account.list_addresses(false);
-    // list spent addresses
-    let _ = account.list_addresses(true);
+    // get unspent addresses
+    let _ = account.list_unspent_addresses();
+    // get spent addresses
+    let _ = account.list_spent_addresses();
+    // get all addresses
+    let _ = account.addresses();
 
     // generate a new unused address
     let _ = account.generate_address().await?;

--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -325,14 +325,27 @@ impl AccountHandle {
             .collect()
     }
 
-    /// Bridge to [Account#list_addresses](struct.Account.html#method.list_addresses).
+    /// Bridge to [Account#list_spent_addresses](struct.Account.html#method.list_spent_addresses).
     /// This method clones the account's addresses so when querying a large list of addresses
     /// prefer using the `read` method to access the account instance.
-    pub async fn list_addresses(&self, unspent: bool) -> Vec<Address> {
+    pub async fn list_spent_addresses(&self) -> Vec<Address> {
         self.inner
             .read()
             .await
-            .list_addresses(unspent)
+            .list_spent_addresses()
+            .into_iter()
+            .cloned()
+            .collect()
+    }
+
+    /// Bridge to [Account#list_unspent_addresses](struct.Account.html#method.list_unspent_addresses).
+    /// This method clones the account's addresses so when querying a large list of addresses
+    /// prefer using the `read` method to access the account instance.
+    pub async fn list_unspent_addresses(&self) -> Vec<Address> {
+        self.inner
+            .read()
+            .await
+            .list_unspent_addresses()
             .into_iter()
             .cloned()
             .collect()
@@ -478,13 +491,19 @@ impl Account {
         }
     }
 
-    /// Gets the addresses linked to this account.
-    ///
-    /// * `unspent` - Whether it should get only unspent addresses or not.
-    pub fn list_addresses(&self, unspent: bool) -> Vec<&Address> {
+    /// Gets the spent addresses.
+    pub fn list_spent_addresses(&self) -> Vec<&Address> {
         self.addresses
             .iter()
-            .filter(|address| crate::address::is_unspent(&self, address.address()) == unspent)
+            .filter(|address| !crate::address::is_unspent(&self, address.address()))
+            .collect()
+    }
+
+    /// Gets the spent addresses.
+    pub fn list_unspent_addresses(&self) -> Vec<&Address> {
+        self.addresses
+            .iter()
+            .filter(|address| crate::address::is_unspent(&self, address.address()))
             .collect()
     }
 

--- a/src/actor/message.rs
+++ b/src/actor/message.rs
@@ -52,11 +52,11 @@ pub enum AccountMethod {
         from: usize,
     },
     /// List addresses.
-    ListAddresses {
-        /// Address unspent filter.
-        #[serde(default)]
-        unspent: bool,
-    },
+    ListAddresses,
+    /// List spent addresses.
+    ListSpentAddresses,
+    /// List unspent addresses.
+    ListUnspentAddresses,
     /// Get available balance.
     GetAvailableBalance,
     /// Get total balance.
@@ -251,7 +251,7 @@ pub enum ResponseType {
     ReadAccounts(Vec<Account>),
     /// ListMessages response.
     Messages(Vec<WalletMessage>),
-    /// ListAddresses response.
+    /// ListAddresses/ListSpentAddresses/ListUnspentAddresses response.
     Addresses(Vec<Address>),
     /// GenerateAddress response.
     GeneratedAddress(Address),

--- a/src/actor/mod.rs
+++ b/src/actor/mod.rs
@@ -208,9 +208,16 @@ impl WalletMessageHandler {
                     .collect();
                 Ok(ResponseType::Messages(messages))
             }
-            AccountMethod::ListAddresses { unspent } => {
-                let account = account_handle.read().await;
-                let addresses = account.list_addresses(*unspent).into_iter().cloned().collect();
+            AccountMethod::ListAddresses => {
+                let addresses = account_handle.addresses().await;
+                Ok(ResponseType::Addresses(addresses))
+            }
+            AccountMethod::ListSpentAddresses => {
+                let addresses = account_handle.list_spent_addresses().await;
+                Ok(ResponseType::Addresses(addresses))
+            }
+            AccountMethod::ListUnspentAddresses => {
+                let addresses = account_handle.list_unspent_addresses().await;
                 Ok(ResponseType::Addresses(addresses))
             }
             AccountMethod::GetAvailableBalance => {


### PR DESCRIPTION
# Description of change

Split `list_addresses(unspent: bool)` API into `list_addresses`, `list_unspent_addresses`, `list_spent_addresses`. 

## Links to any relevant issues

#167

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked that new and existing unit tests pass locally with my changes
