### PR TITLE
feat(bindings): expose MessageType enum on nodejs, closes #168

### DIFF
--- a/bindings/node/lib/index.js
+++ b/bindings/node/lib/index.js
@@ -111,5 +111,12 @@ module.exports = {
   StorageType: {
     Sqlite: { type: 'Sqlite' },
     Stronghold: { type: 'Stronghold' }
+  },
+  MessageType: {
+    Received: 1,
+    Sent: 2,
+    Failed: 3,
+    Unconfirmed: 4,
+    Value: 5
   }
 }

--- a/bindings/node/tests/account.js
+++ b/bindings/node/tests/account.js
@@ -3,25 +3,24 @@
 
 async function run() {
   try {
-    const { AccountManager, SignerType } = require('../lib')
-    const manager = new AccountManager({
-      storagePath: './test-database'
-    })
-    manager.setStrongholdPassword('password')
-    manager.storeMnemonic(SignerType.Stronghold)
-
-    const account = manager.createAccount({
-      clientOptions: { node: 'http://localhost:14265' }
-    })
-    account.setAlias('banana')
-  } finally {
     const fs = require('fs')
-    try {
     fs.rmdirSync('./test-database', { recursive: true })
-    } catch (e) {
-      // ignore it
-    }
+  } catch (e) {
+    // ignore it
   }
+
+  const { AccountManager, SignerType, MessageType } = require('../lib')
+  const manager = new AccountManager({
+    storagePath: './test-database'
+  })
+  manager.setStrongholdPassword('password')
+  manager.storeMnemonic(SignerType.Stronghold)
+
+  const account = manager.createAccount({
+    clientOptions: { node: 'http://localhost:14265' }
+  })
+  console.log('messages', account.listMessages(0, 0, MessageType.Failed))
+  account.setAlias('new alias')
 }
 
 run()


### PR DESCRIPTION
# Description of change

Simplifies usage of the listMessages API on nodejs by returning the MessageType enum object. 

## Links to any relevant issues

#168

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Unit test.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
