### PR TITLE
fix(tests): increase `action_keeps_password` password clear interval

### DIFF
--- a/src/stronghold.rs
+++ b/src/stronghold.rs
@@ -645,14 +645,14 @@ mod tests {
         fn action_keeps_password() {
             let runtime = tokio::runtime::Runtime::new().unwrap();
             runtime.block_on(async {
-                let interval = Duration::from_millis(500);
+                let interval = Duration::from_secs(1);
                 super::set_password_clear_interval(interval).await;
                 let snapshot_path: String = thread_rng().sample_iter(&Alphanumeric).take(10).collect();
                 std::fs::create_dir_all("./test-storage").unwrap();
                 let snapshot_path = PathBuf::from(format!("./test-storage/{}.stronghold", snapshot_path));
                 super::load_snapshot(&snapshot_path, &[0; 32]).await.unwrap();
 
-                for i in 1..5 {
+                for i in 1..6 {
                     super::store_account(
                         &snapshot_path,
                         &AccountIdentifier::Id(format!("actionkeepspassword{}", i)),
@@ -660,7 +660,7 @@ mod tests {
                     )
                     .await
                     .unwrap();
-                    std::thread::sleep(interval / 2);
+                    std::thread::sleep(interval / 4);
                 }
 
                 let id = AccountIdentifier::Id("actionkeepspassword1".to_string());


### PR DESCRIPTION
# Description of change

Trying to fix the `action_keeps_password` password timeout on slow devices. 

## Type of change

- Test fix
