### PR TITLE
fix(account): persist to storage after every mutable operation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,11 +4,6 @@ version = "0.1.0"
 authors = ["Lucas Nogueira <lucas.nogueira@iota.org>"]
 edition = "2018"
 
-[package.metadata.cargo-udeps.ignore]
-# ignore sled since it's enabled only when not(any(feature = "stronghold-storage", feature = "sqlite-storage"))
-# and we can't specify that on the dependency section
-development = ["sled"]
-
 [dependencies]
 thiserror = "1.0"
 chrono = { version = "0.4", features = ["serde"] }

--- a/bindings/nodejs/README.md
+++ b/bindings/nodejs/README.md
@@ -85,11 +85,12 @@ Supported event names:
 
 Creates a new instance of the AccountManager.
 
-| Param         | Type                     | Default                             | Description                                    |
-| ------------- | ------------------------ | ----------------------------------- | ---------------------------------------------- |
-| [options]     | <code>object</code>      | <code>undefined</code>              | The options to configure the account manager   |
-| [storagePath] | <code>string</code>      | <code>undefined</code>              | The path where the database file will be saved |
-| [storageType] | <code>StorageType</code> | <code>StorageType.Stronghold</code> | The storage implementation to use              |
+| Param             | Type                     | Default                             | Description                                      |
+| -------------     | ------------------------ | ----------------------------------- | ----------------------------------------------   |
+| [options]         | <code>object</code>      | <code>undefined</code>              | The options to configure the account manager     |
+| [storagePath]     | <code>string</code>      | <code>undefined</code>              | The path where the database file will be saved   |
+| [storageType]     | <code>StorageType</code> | <code>StorageType.Stronghold</code> | The storage implementation to use                |
+| [storagePassword] | <code>string</code>      | <code>undefined</code>              | The storage password to encrypt/decrypt accounts |
 
 - StorageType
   

--- a/bindings/nodejs/lib/index.d.ts
+++ b/bindings/nodejs/lib/index.d.ts
@@ -129,6 +129,7 @@ export declare enum StorageType {
 export declare interface ManagerOptions {
   storagePath?: string
   storageType?: StorageType
+  storagePassword?: string
 }
 
 export declare class AccountManager {

--- a/bindings/nodejs/native/src/classes/account/mod.rs
+++ b/bindings/nodejs/native/src/classes/account/mod.rs
@@ -181,7 +181,7 @@ declare_types! {
                 let id = &this.borrow(&guard).0;
                 crate::block_on(async move {
                     let account_handle = crate::get_account(id).await;
-                    account_handle.set_alias(alias).await;
+                    account_handle.set_alias(alias).await.expect("failed to update account alias");
                 });
             }
             Ok(cx.undefined().upcast())
@@ -196,7 +196,7 @@ declare_types! {
                 let id = &this.borrow(&guard).0;
                 crate::block_on(async move {
                     let account_handle = crate::get_account(id).await;
-                    account_handle.set_client_options(client_options).await;
+                    account_handle.set_client_options(client_options).await.expect("failed to update client options");
                 });
             }
             Ok(cx.undefined().upcast())

--- a/examples/account_operations.rs
+++ b/examples/account_operations.rs
@@ -20,7 +20,7 @@ async fn main() -> iota_wallet::Result<()> {
         .await?;
 
     // update alias
-    account.set_alias("the new alias").await;
+    account.set_alias("the new alias").await?;
     // get unspent addresses
     let _ = account.list_unspent_addresses();
     // get spent addresses

--- a/examples/custom_storage.rs
+++ b/examples/custom_storage.rs
@@ -2,83 +2,81 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /// ! An example of using a custom storage adapter (in this case, using sled).
-
-#[cfg(not(any(feature = "sqlite-storage", feature = "stronghold-storage")))]
 use iota_wallet::{
-    account::AccountIdentifier, account_manager::AccountManager, client::ClientOptionsBuilder, signing::SignerType,
+    account::AccountIdentifier,
+    account_manager::{AccountManager, ManagerStorage},
+    client::ClientOptionsBuilder,
+    signing::SignerType,
     storage::StorageAdapter,
 };
 
-#[cfg(any(feature = "sqlite-storage", feature = "stronghold-storage"))]
-fn main() {
-    panic!("can't run custom adapter example with `sqlite-storage` or `stronghold-storage` features; use `--no-default-features` to run")
+struct MyStorage {
+    db: sled::Db,
 }
 
-#[cfg(not(any(feature = "sqlite-storage", feature = "stronghold-storage")))]
+impl MyStorage {
+    pub fn new<P: AsRef<std::path::Path>>(path: P) -> anyhow::Result<Self> {
+        let instance = Self { db: sled::open(path)? };
+        Ok(instance)
+    }
+}
+
+fn account_id_value(account_id: &AccountIdentifier) -> iota_wallet::Result<String> {
+    match account_id {
+        AccountIdentifier::Id(val) => Ok(val.to_string()),
+        _ => Err(iota_wallet::Error::Storage(
+            "Unexpected AccountIdentifier type".to_string(),
+        )),
+    }
+}
+
+#[async_trait::async_trait]
+impl StorageAdapter for MyStorage {
+    async fn get(&self, account_id: &AccountIdentifier) -> iota_wallet::Result<String> {
+        match self.db.get(account_id_value(account_id)?) {
+            Ok(Some(value)) => Ok(String::from_utf8(value.to_vec()).unwrap()),
+            Ok(None) => Err(iota_wallet::Error::AccountNotFound),
+            Err(e) => Err(iota_wallet::Error::Storage(format!(
+                "operational problem encountered: {}",
+                e
+            ))),
+        }
+    }
+
+    async fn get_all(&self) -> iota_wallet::Result<std::vec::Vec<String>> {
+        let mut accounts = vec![];
+        for tuple in self.db.iter() {
+            let (_, value) = tuple.unwrap();
+            accounts.push(String::from_utf8(value.to_vec()).unwrap());
+        }
+        Ok(accounts)
+    }
+
+    async fn set(&self, account_id: &AccountIdentifier, account: String) -> iota_wallet::Result<()> {
+        self.db
+            .insert(account_id_value(account_id)?, account.as_bytes())
+            .map_err(|e| iota_wallet::Error::Storage(e.to_string()))?;
+        Ok(())
+    }
+
+    async fn remove(&self, account_id: &AccountIdentifier) -> iota_wallet::Result<()> {
+        self.db
+            .remove(account_id_value(account_id)?)
+            .map_err(|e| iota_wallet::Error::Storage(e.to_string()))?;
+        Ok(())
+    }
+}
+
 #[tokio::main]
 async fn main() -> iota_wallet::Result<()> {
-    struct MyStorage {
-        db: sled::Db,
-    }
-
-    impl MyStorage {
-        pub fn new<P: AsRef<std::path::Path>>(path: P) -> anyhow::Result<Self> {
-            let instance = Self { db: sled::open(path)? };
-            Ok(instance)
-        }
-    }
-
-    fn account_id_value(account_id: &AccountIdentifier) -> iota_wallet::Result<String> {
-        match account_id {
-            AccountIdentifier::Id(val) => Ok(val.to_string()),
-            _ => Err(iota_wallet::Error::Storage(
-                "Unexpected AccountIdentifier type".to_string(),
-            )),
-        }
-    }
-
-    #[async_trait::async_trait]
-    impl StorageAdapter for MyStorage {
-        async fn get(&self, account_id: &AccountIdentifier) -> iota_wallet::Result<String> {
-            match self.db.get(account_id_value(account_id)?) {
-                Ok(Some(value)) => Ok(String::from_utf8(value.to_vec()).unwrap()),
-                Ok(None) => Err(iota_wallet::Error::AccountNotFound),
-                Err(e) => Err(iota_wallet::Error::Storage(format!(
-                    "operational problem encountered: {}",
-                    e
-                ))),
-            }
-        }
-
-        async fn get_all(&self) -> iota_wallet::Result<std::vec::Vec<String>> {
-            let mut accounts = vec![];
-            for tuple in self.db.iter() {
-                let (_, value) = tuple.unwrap();
-                accounts.push(String::from_utf8(value.to_vec()).unwrap());
-            }
-            Ok(accounts)
-        }
-
-        async fn set(&self, account_id: &AccountIdentifier, account: String) -> iota_wallet::Result<()> {
-            self.db
-                .insert(account_id_value(account_id)?, account.as_bytes())
-                .map_err(|e| iota_wallet::Error::Storage(e.to_string()))?;
-            Ok(())
-        }
-
-        async fn remove(&self, account_id: &AccountIdentifier) -> iota_wallet::Result<()> {
-            self.db
-                .remove(account_id_value(account_id)?)
-                .map_err(|e| iota_wallet::Error::Storage(e.to_string()))?;
-            Ok(())
-        }
-    }
-
     let mut manager = AccountManager::builder()
         .with_storage(
             "./test-storage/sled",
-            MyStorage::new("./test-storage/sled").map_err(|e| iota_wallet::Error::Storage(e.to_string()))?,
-        )
+            ManagerStorage::Custom(Box::new(
+                MyStorage::new("./test-storage/sled").map_err(|e| iota_wallet::Error::Storage(e.to_string()))?,
+            )),
+            None,
+        )?
         .finish()
         .await
         .unwrap();

--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -363,7 +363,8 @@ impl Account {
     pub(crate) async fn save(&mut self) -> crate::Result<()> {
         if !self.skip_persistance {
             let storage_path = self.storage_path.clone();
-            crate::storage::get(&storage_path)?
+            crate::storage::get(&storage_path)
+                .await?
                 .lock()
                 .await
                 .set(&self.id, serde_json::to_string(&self)?)

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -547,7 +547,7 @@ impl AccountManager {
                     .skip_polling()
                     .finish()
                     .await?;
-                let stronghold_storage = crate::storage::get(&self.storage_path).await?;
+                let stronghold_storage = crate::storage::get(&self.storage_folder.join(STRONGHOLD_FILENAME)).await?;
                 let stronghold_storage = stronghold_storage.lock().await;
 
                 for (account_id, account_handle) in &*self.accounts.read().await {

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -33,7 +33,7 @@ use serde::Deserialize;
 use tokio::{
     sync::{
         broadcast::{channel as broadcast_channel, Receiver as BroadcastReceiver, Sender as BroadcastSender},
-        Mutex, RwLock,
+        RwLock,
     },
     time::interval,
 };
@@ -49,60 +49,66 @@ pub const SQLITE_FILENAME: &str = "wallet.db";
 
 pub(crate) type AccountStore = Arc<RwLock<HashMap<AccountIdentifier, AccountHandle>>>;
 
-/// The storages used by default.
-#[derive(Deserialize, PartialEq)]
+/// The storage used by the manager.
+#[derive(Deserialize)]
 #[serde(tag = "type", content = "data")]
-pub enum DefaultStorage {
+pub enum ManagerStorage {
     /// Stronghold storage.
     #[cfg(any(feature = "stronghold", feature = "stronghold-storage"))]
     Stronghold,
     /// Sqlite storage.
     #[cfg(feature = "sqlite-storage")]
     Sqlite,
+    /// Custom storage.
+    #[serde(skip)]
+    Custom(Box<dyn StorageAdapter + Send + Sync + 'static>),
 }
 
 #[cfg(any(feature = "stronghold", feature = "stronghold-storage", feature = "sqlite-storage"))]
-fn storage_file_path(storage: &Option<DefaultStorage>, storage_path: &PathBuf) -> PathBuf {
+fn storage_file_path(storage: &Option<ManagerStorage>, storage_path: &PathBuf) -> PathBuf {
     if storage_path.is_file() || storage_path.extension().is_some() || storage.is_none() {
         storage_path.clone()
     } else {
-        #[cfg(any(feature = "stronghold", feature = "stronghold-storage"))]
-        if storage == &Some(DefaultStorage::Stronghold) {
-            return storage_path.join(STRONGHOLD_FILENAME);
+        match storage {
+            #[cfg(any(feature = "stronghold", feature = "stronghold-storage"))]
+            Some(ManagerStorage::Stronghold) => storage_path.join(STRONGHOLD_FILENAME),
+            #[cfg(feature = "sqlite-storage")]
+            Some(ManagerStorage::Sqlite) => storage_path.join(SQLITE_FILENAME),
+            _ => storage_path.clone(),
         }
-        #[cfg(feature = "sqlite-storage")]
-        if storage == &Some(DefaultStorage::Sqlite) {
-            return storage_path.join(SQLITE_FILENAME);
-        }
-        storage_path.clone()
     }
+}
+
+fn storage_password_to_encryption_key(password: &str) -> crate::Result<[u8; 32]> {
+    let mut dk = [0; 64];
+    crypto::kdfs::pbkdf::PBKDF2_HMAC_SHA512(password.as_bytes(), b"wallet.rs::storage", 100, &mut dk)?;
+    let key: [u8; 32] = dk[0..32][..].try_into().unwrap();
+    Ok(key)
 }
 
 /// Account manager builder.
 pub struct AccountManagerBuilder {
     storage_path: PathBuf,
-    initialised_storage: bool,
+    storage: Option<ManagerStorage>,
     polling_interval: Duration,
     skip_polling: bool,
-    default_storage: Option<DefaultStorage>,
     storage_encryption_key: Option<[u8; 32]>,
 }
 
 impl Default for AccountManagerBuilder {
     fn default() -> Self {
         #[allow(unused_variables)]
-        let default_storage: Option<DefaultStorage> = None;
+        let default_storage: Option<ManagerStorage> = None;
         #[cfg(all(feature = "stronghold-storage", not(feature = "sqlite-storage")))]
-        let default_storage = Some(DefaultStorage::Stronghold);
+        let default_storage = Some(ManagerStorage::Stronghold);
         #[cfg(all(feature = "sqlite-storage", not(feature = "stronghold-storage")))]
-        let default_storage = Some(DefaultStorage::Sqlite);
+        let default_storage = Some(ManagerStorage::Sqlite);
 
         Self {
             storage_path: PathBuf::from(DEFAULT_STORAGE_FOLDER),
-            initialised_storage: false,
+            storage: default_storage,
             polling_interval: Duration::from_millis(30_000),
             skip_polling: false,
-            default_storage,
             storage_encryption_key: None,
         }
     }
@@ -114,30 +120,24 @@ impl AccountManagerBuilder {
         Default::default()
     }
 
-    /// Use the specified storage folder when initialising the default storage adapter.
-    #[cfg(any(feature = "stronghold-storage", feature = "sqlite-storage"))]
-    pub fn with_storage_path(mut self, storage_path: impl AsRef<Path>) -> Self {
-        self.storage_path = storage_path.as_ref().to_path_buf();
-        self
-    }
-
-    /// Sets the default storage to be used.
-    #[cfg(any(feature = "sqlite-storage", feature = "stronghold-storage"))]
-    pub fn with_storage(mut self, storage: DefaultStorage) -> Self {
-        self.default_storage = Some(storage);
-        self
-    }
-
-    /// Sets a custom storage adapter to be used.
-    #[cfg(not(any(feature = "sqlite-storage", feature = "stronghold-storage")))]
-    pub fn with_storage<S: StorageAdapter + Sync + Send + 'static>(
+    /// Sets the storage to be used.
+    pub fn with_storage(
         mut self,
         storage_path: impl AsRef<Path>,
-        adapter: S,
-    ) -> Self {
-        crate::storage::set_adapter(&storage_path, adapter);
+        storage: ManagerStorage,
+        password: Option<&str>,
+    ) -> crate::Result<Self> {
         self.storage_path = storage_path.as_ref().to_path_buf();
-        self.initialised_storage = true;
+        self.storage = Some(storage);
+        self.storage_encryption_key = match password {
+            Some(p) => Some(storage_password_to_encryption_key(p)?),
+            None => None,
+        };
+        Ok(self)
+    }
+
+    pub(crate) fn with_storage_encryption_key(mut self, key: Option<[u8; 32]>) -> Self {
+        self.storage_encryption_key = key;
         self
     }
 
@@ -152,43 +152,30 @@ impl AccountManagerBuilder {
         self
     }
 
-    pub(crate) fn with_storage_encryption_key(mut self, key: Option<[u8; 32]>) -> Self {
-        self.storage_encryption_key = key;
-        self
-    }
-
     /// Builds the manager.
     pub async fn finish(self) -> crate::Result<AccountManager> {
-        if !self.initialised_storage {
-            #[cfg(any(feature = "stronghold-storage", feature = "sqlite-storage"))]
-            {
-                match &self.default_storage {
-                    Some(storage) => match storage {
-                        #[cfg(any(feature = "stronghold", feature = "stronghold-storage"))]
-                        DefaultStorage::Stronghold => {
-                            let path = storage_file_path(&self.default_storage, &self.storage_path);
-                            let storage = crate::storage::stronghold::StrongholdStorageAdapter::new(&path)?;
-                            crate::storage::set_adapter(&path, storage);
-                        }
-                        #[cfg(feature = "sqlite-storage")]
-                        DefaultStorage::Sqlite => {
-                            let path = storage_file_path(&self.default_storage, &self.storage_path);
-                            let storage = crate::storage::sqlite::SqliteStorageAdapter::new(&path, "accounts")?;
-                            crate::storage::set_adapter(&path, storage);
-                        }
-                    },
-                    None => {
-                        return Err(crate::Error::StorageAdapterNotDefined);
+        let (storage, storage_file_path): (Box<dyn StorageAdapter + Send + Sync>, PathBuf) =
+            if let Some(storage) = self.storage {
+                match storage {
+                    #[cfg(any(feature = "stronghold", feature = "stronghold-storage"))]
+                    ManagerStorage::Stronghold => {
+                        let path = storage_file_path(&Some(ManagerStorage::Stronghold), &self.storage_path);
+                        let storage = crate::storage::stronghold::StrongholdStorageAdapter::new(&path)?;
+                        (Box::new(storage) as Box<dyn StorageAdapter + Send + Sync>, path)
                     }
-                };
-            }
-            #[cfg(not(any(feature = "stronghold-storage", feature = "sqlite-storage")))]
-            {
+                    #[cfg(feature = "sqlite-storage")]
+                    ManagerStorage::Sqlite => {
+                        let path = storage_file_path(&Some(ManagerStorage::Sqlite), &self.storage_path);
+                        let storage = crate::storage::sqlite::SqliteStorageAdapter::new(&path, "accounts")?;
+                        (Box::new(storage) as Box<dyn StorageAdapter + Send + Sync>, path)
+                    }
+                    ManagerStorage::Custom(storage) => (storage, self.storage_path.clone()),
+                }
+            } else {
                 return Err(crate::Error::StorageAdapterNotDefined);
-            }
-        }
+            };
 
-        let storage_file_path = storage_file_path(&self.default_storage, &self.storage_path);
+        crate::storage::set(&storage_file_path, self.storage_encryption_key, storage);
 
         // with one of the stronghold features, the accounts are loaded when the password is set
         #[cfg(any(feature = "stronghold", feature = "stronghold-storage"))]
@@ -212,7 +199,6 @@ impl AccountManagerBuilder {
             stop_polling_sender: None,
             polling_handle: None,
             generated_mnemonic: None,
-            storage_encryption_key: Arc::new(Mutex::new(self.storage_encryption_key)),
             encrypted_accounts: Vec::new(),
         };
 
@@ -237,7 +223,6 @@ pub struct AccountManager {
     stop_polling_sender: Option<BroadcastSender<()>>,
     polling_handle: Option<thread::JoinHandle<()>>,
     generated_mnemonic: Option<String>,
-    storage_encryption_key: Arc<Mutex<Option<[u8; 32]>>>,
     encrypted_accounts: Vec<String>,
 }
 
@@ -253,15 +238,11 @@ impl AccountManager {
         AccountManagerBuilder::new()
     }
 
-    async fn load_accounts(
-        storage_file_path: &PathBuf,
-        encryption_key: &Option<[u8; 32]>,
-    ) -> crate::Result<(AccountStore, Vec<String>)> {
+    async fn load_accounts(storage_file_path: &PathBuf) -> crate::Result<(AccountStore, Vec<String>)> {
         let mut encrypted_accounts = Vec::new();
         let mut parsed_accounts = HashMap::new();
 
         let accounts = crate::storage::get(&storage_file_path)?.lock().await.get_all().await?;
-        let accounts = crate::storage::parse_accounts(&storage_file_path, &accounts, encryption_key)?;
         for parsed_account in accounts {
             match parsed_account {
                 crate::storage::ParsedAccount::Account(account) => {
@@ -316,11 +297,12 @@ impl AccountManager {
     }
 
     /// Sets the password for the stored accounts.
-    pub async fn set_storage_password<P: AsRef<str>>(&mut self, key: P) -> crate::Result<()> {
-        let mut dk = [0; 64];
-        crypto::kdfs::pbkdf::PBKDF2_HMAC_SHA512(key.as_ref().as_bytes(), b"wallet.rs::storage", 100, &mut dk)?;
-        let key: [u8; 32] = dk[0..32][..].try_into().unwrap();
-        *self.storage_encryption_key.lock().await = Some(key);
+    pub async fn set_storage_password<P: AsRef<str>>(&mut self, password: P) -> crate::Result<()> {
+        let key = storage_password_to_encryption_key(password.as_ref())?;
+        // safe to unwrap because the storage is always defined at this point
+        crate::storage::set_encryption_key(&self.storage_path, key)
+            .await
+            .unwrap();
 
         let mut accounts = self.accounts.write().await;
         for encrypted_account in &self.encrypted_accounts {
@@ -348,8 +330,7 @@ impl AccountManager {
 
         // let is_empty = self.accounts.read().await.is_empty();
         if self.accounts.read().await.is_empty() {
-            let (accounts, encrypted_accounts) =
-                Self::load_accounts(&self.storage_path, &*self.storage_encryption_key.lock().await).await?;
+            let (accounts, encrypted_accounts) = Self::load_accounts(&self.storage_path).await?;
             self.encrypted_accounts = encrypted_accounts;
             let mut accounts_store = self.accounts.write().await;
             for (id, account) in &*accounts.read().await {
@@ -369,7 +350,6 @@ impl AccountManager {
     ) {
         let storage_file_path = self.storage_path.clone();
         let accounts = self.accounts.clone();
-        let storage_encryption_key = self.storage_encryption_key.clone();
 
         let handle = thread::spawn(move || {
             let runtime = tokio::runtime::Builder::new_current_thread()
@@ -402,25 +382,12 @@ impl AccountManager {
                                     // when the error is dropped, the on_error event will be triggered
                                 }
                             }
-
-                            {
-                                let encryption_key = &*storage_encryption_key.lock().await;
-                                for account_handle in accounts.read().await.values() {
-                                    let _ = account_handle.write().await.save(&encryption_key).await;
-                                }
-                            }
                         } => {}
                         _ = stop.recv() => {
-                            let encryption_key = &*storage_encryption_key.lock().await;
-                            // before stopping the polling loop, we save the accounts
-                            for account_handle in accounts.read().await.values() {
-                                let _ = account_handle.write().await.save(&encryption_key).await;
-                            }
                             break;
                         }
                     }
                 }
-                println!("DONE");
             });
         });
         self.polling_handle = Some(handle);
@@ -540,13 +507,6 @@ impl AccountManager {
             return Err(crate::Error::InvalidBackupDestination);
         }
 
-        {
-            let encryption_key = &*self.storage_encryption_key.lock().await;
-            for account_handle in self.accounts.read().await.values() {
-                account_handle.write().await.save(&encryption_key).await?;
-            }
-        }
-
         #[allow(unused_variables)]
         let (storage_path, backup_entire_directory) = (
             &self.storage_path,
@@ -563,18 +523,24 @@ impl AccountManager {
             let storage_id = crate::storage::get(&&self.storage_path)?.lock().await.id();
             // if we're actually using the SQLite storage adapter
             let storage_path = if storage_id == crate::storage::sqlite::STORAGE_ID {
-                let stronghold_storage = crate::storage::stronghold::StrongholdStorageAdapter::new(
-                    &self.storage_folder.join(STRONGHOLD_FILENAME),
-                )
-                .unwrap();
+                // create a account manager to setup the stronghold storage for the backup
+                let _ = Self::builder()
+                    .with_storage(
+                        &self.storage_folder.join(STRONGHOLD_FILENAME),
+                        ManagerStorage::Stronghold,
+                        None,
+                    )
+                    .unwrap() // safe to unwrap - password is None
+                    .with_storage_encryption_key(crate::storage::get(&self.storage_path)?.lock().await.encryption_key)
+                    .skip_polling()
+                    .finish()
+                    .await?;
+                let stronghold_storage = crate::storage::get(&self.storage_path)?;
+                let stronghold_storage = stronghold_storage.lock().await;
 
-                let encryption_key = &*self.storage_encryption_key.lock().await;
                 for (account_id, account_handle) in &*self.accounts.read().await {
                     stronghold_storage
-                        .set(
-                            account_id,
-                            crate::storage::get_account_string_to_save(&*account_handle.read().await, &encryption_key)?,
-                        )
+                        .set(account_id, serde_json::to_string(&*account_handle.read().await)?)
                         .await?;
                 }
                 self.storage_folder.join(STRONGHOLD_FILENAME)
@@ -660,9 +626,9 @@ impl AccountManager {
             #[cfg(any(feature = "stronghold", feature = "stronghold-storage"))]
             {
                 let mut stronghold_manager = Self::builder()
-                    .with_storage_path(&source)
-                    .with_storage(DefaultStorage::Stronghold)
-                    .with_storage_encryption_key(*self.storage_encryption_key.lock().await)
+                    .with_storage(&source, ManagerStorage::Stronghold, None)
+                    .unwrap() // safe to unwrap - password is None
+                    .with_storage_encryption_key(crate::storage::get(&self.storage_path)?.lock().await.encryption_key)
                     .skip_polling()
                     .finish()
                     .await?;
@@ -1049,7 +1015,6 @@ mod tests {
             .initialise()
             .await
             .expect("failed to add account");
-        account_handle.write().await.save(&None).await.unwrap();
 
         manager
             .remove_account(account_handle.read().await.id())


### PR DESCRIPTION
# Description of change

We can't rely on the AccountManager's drop to save the account, so this PR changes account persistance to save on every mutable operation. 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

CLI Wallet.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
