### PR TITLE
chore(docs): document feature-specific APIs on docs.rs using `doc_cfg`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 authors = ["Lucas Nogueira <lucas.nogueira@iota.org>"]
 edition = "2018"
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 thiserror = "1.0"
 chrono = { version = "0.4", features = ["serde"] }

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ async fn main() -> iota_wallet::Result<()> {
 If you'd like to explore the implementation in more depth, the following command generates docs for the whole crate:
 
 ```
-cargo doc --document-private-items --no-deps --open
+RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features --document-private-items --no-deps --open
 ```
 
 ## Other Examples

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -40,11 +40,15 @@ use tokio::{
 
 /// The default storage folder.
 pub const DEFAULT_STORAGE_FOLDER: &str = "./storage";
+
 /// The default stronghold storage file name.
 #[cfg(any(feature = "stronghold", feature = "stronghold-storage"))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "stronghold", feature = "stronghold-storage"))))]
 pub const STRONGHOLD_FILENAME: &str = "wallet.stronghold";
+
 /// The default SQLite storage file name.
 #[cfg(feature = "sqlite-storage")]
+#[cfg_attr(docsrs, doc(cfg(feature = "sqlite-storage")))]
 pub const SQLITE_FILENAME: &str = "wallet.db";
 
 pub(crate) type AccountStore = Arc<RwLock<HashMap<AccountIdentifier, AccountHandle>>>;
@@ -55,9 +59,11 @@ pub(crate) type AccountStore = Arc<RwLock<HashMap<AccountIdentifier, AccountHand
 pub enum ManagerStorage {
     /// Stronghold storage.
     #[cfg(any(feature = "stronghold", feature = "stronghold-storage"))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "stronghold", feature = "stronghold-storage"))))]
     Stronghold,
     /// Sqlite storage.
     #[cfg(feature = "sqlite-storage")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "sqlite-storage")))]
     Sqlite,
     /// Custom storage.
     #[serde(skip)]
@@ -332,6 +338,7 @@ impl AccountManager {
 
     /// Sets the stronghold password.
     #[cfg(any(feature = "stronghold", feature = "stronghold-storage"))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "sqlite-storage", feature = "stronghold-storage"))))]
     pub async fn set_stronghold_password<P: AsRef<str>>(&mut self, password: P) -> crate::Result<()> {
         let mut dk = [0; 64];
         // safe to unwrap because rounds > 0
@@ -529,6 +536,7 @@ impl AccountManager {
 
     /// Backups the storage to the given destination
     #[cfg(any(feature = "stronghold-storage", feature = "sqlite-storage"))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "sqlite-storage", feature = "stronghold-storage"))))]
     pub async fn backup<P: AsRef<Path>>(&self, destination: P) -> crate::Result<PathBuf> {
         let destination = destination.as_ref().to_path_buf();
         if !(destination.is_dir() && destination.exists()) {
@@ -625,6 +633,7 @@ impl AccountManager {
 
     /// Import backed up accounts.
     #[cfg(any(feature = "stronghold-storage", feature = "sqlite-storage"))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "sqlite-storage", feature = "stronghold-storage"))))]
     pub async fn import_accounts<S: AsRef<Path>>(
         &mut self,
         source: S,

--- a/src/actor/message.rs
+++ b/src/actor/message.rs
@@ -111,21 +111,25 @@ pub enum MessageType {
     },
     /// Backup storage.
     #[cfg(any(feature = "stronghold-storage", feature = "sqlite-storage"))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "stronghold-storage", feature = "sqlite-storage"))))]
     Backup(String),
     /// Import accounts from storage.
     #[cfg(any(feature = "stronghold-storage", feature = "sqlite-storage"))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "stronghold-storage", feature = "sqlite-storage"))))]
     RestoreBackup {
         /// The path to the backed up storage.
         #[serde(rename = "backupPath")]
         backup_path: String,
         /// The backup stronghold password.
         #[cfg(any(feature = "stronghold", feature = "stronghold-storage"))]
+        #[cfg_attr(docsrs, doc(cfg(any(feature = "stronghold", feature = "stronghold-storage"))))]
         password: String,
     },
     /// Sets the password used to encrypt/decrypt the storage.
     SetStoragePassword(String),
     /// Set stronghold snapshot password.
     #[cfg(any(feature = "stronghold", feature = "stronghold-storage"))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "stronghold", feature = "stronghold-storage"))))]
     SetStrongholdPassword(String),
     /// Send funds.
     SendTransfer {
@@ -270,14 +274,17 @@ pub enum ResponseType {
     Reattached(String),
     /// Backup response.
     #[cfg(any(feature = "stronghold-storage", feature = "sqlite-storage"))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "stronghold-storage", feature = "sqlite-storage"))))]
     BackupSuccessful,
     /// ImportAccounts response.
     #[cfg(any(feature = "stronghold-storage", feature = "sqlite-storage"))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "stronghold-storage", feature = "sqlite-storage"))))]
     BackupRestored,
     /// SetStoragePassword response.
     StoragePasswordSet,
     /// SetStrongholdPassword response.
     #[cfg(any(feature = "stronghold", feature = "stronghold-storage"))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "stronghold", feature = "stronghold-storage"))))]
     StrongholdPasswordSet,
     /// SendTransfer and InternalTransfer response.
     SentTransfer(WalletMessage),

--- a/src/error.rs
+++ b/src/error.rs
@@ -47,6 +47,7 @@ pub enum Error {
     JsonError(#[from] serde_json::error::Error),
     /// stronghold client error.
     #[cfg(any(feature = "stronghold", feature = "stronghold-storage"))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "stronghold", feature = "stronghold-storage"))))]
     #[error("`{0}`")]
     StrongholdError(crate::stronghold::Error),
     /// iota.rs error.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 //! The IOTA Wallet Library
 
 #![warn(missing_docs, rust_2018_idioms)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 /// The account module.
 pub mod account;
@@ -28,10 +29,13 @@ pub mod signing;
 /// The storage module.
 pub mod storage;
 #[cfg(any(feature = "stronghold", feature = "stronghold-storage"))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "stronghold", feature = "stronghold-storage"))))]
 pub(crate) mod stronghold;
 
 pub use error::Error;
 
+#[cfg(any(feature = "stronghold", feature = "stronghold-storage"))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "stronghold", feature = "stronghold-storage"))))]
 pub use stronghold::set_password_clear_interval as set_stronghold_password_clear_interval;
 
 /// The wallet Result type.
@@ -59,6 +63,7 @@ where
 
 /// Access the stronghold's actor system.
 #[cfg(any(feature = "stronghold", feature = "stronghold-storage"))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "stronghold", feature = "stronghold-storage"))))]
 pub async fn with_actor_system<F: FnOnce(&riker::actors::ActorSystem)>(cb: F) {
     let runtime = self::stronghold::actor_runtime().lock().await;
     cb(&runtime.stronghold.system)

--- a/src/signing/mod.rs
+++ b/src/signing/mod.rs
@@ -27,6 +27,7 @@ static SIGNERS_INSTANCE: OnceCell<Signers> = OnceCell::new();
 pub enum SignerType {
     /// Stronghold signer.
     #[cfg(feature = "stronghold")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "stronghold")))]
     Stronghold,
     /// Custom signer with its identifier.
     Custom(String),

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -2,10 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #[cfg(feature = "sqlite-storage")]
+#[cfg_attr(docsrs, doc(cfg(feature = "sqlite-storage")))]
 /// Sqlite storage.
 pub mod sqlite;
 
 #[cfg(any(feature = "stronghold-storage", feature = "stronghold"))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "stronghold-storage", feature = "stronghold"))))]
 /// Stronghold storage.
 pub mod stronghold;
 


### PR DESCRIPTION
# Description of change

Changes the crate's generated docs to include manifest feature notes on stronghold/sqlite APIs (that needs cargo features enabled to be accessed).

https://doc.rust-lang.org/beta/unstable-book/language-features/doc-cfg.html

## Type of change

- Documentation Fix

## How the change has been tested

Running the doc generation command `$ RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features --document-private-items --no-deps --open`
