### PR TITLE
fix(address): `get_new_address` checking if the address list is empty

### DIFF
--- a/src/address.rs
+++ b/src/address.rs
@@ -289,7 +289,16 @@ pub(crate) async fn get_iota_address(
 /// Gets an unused public address for the given account.
 pub(crate) async fn get_new_address(account: &Account, metadata: GenerateAddressMetadata) -> crate::Result<Address> {
     let key_index = account.addresses().iter().filter(|a| !a.internal()).count();
-    let bech32_hrp = account.addresses().first().unwrap().address().hrp().to_string();
+    let bech32_hrp = match account.addresses().first() {
+        Some(address) => address.address().hrp().to_string(),
+        None => {
+            crate::client::get_client(account.client_options())
+                .read()
+                .await
+                .get_network_info()
+                .bech32_hrp
+        }
+    };
     let iota_address = get_iota_address(&account, key_index, false, bech32_hrp, metadata).await?;
     let address = Address {
         address: iota_address,


### PR DESCRIPTION
# Description of change

Fixes an issue with `get_new_address` (called by `Account#generate_address`) when the address list is empty.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

CLI wallet.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have checked that new and existing unit tests pass locally with my changes
