### PR TITLE
fix(account): update addresses bech32 hrp on `set_client_options`

### DIFF
--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -435,7 +435,7 @@ impl Account {
             .get_network_info()
             .bech32_hrp;
         for address in &mut self.addresses {
-            address.set_bec32_hrp(bech32_hrp.to_string());
+            address.set_bech32_hrp(bech32_hrp.to_string());
         }
 
         self.save().await

--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -428,6 +428,16 @@ impl Account {
     /// Updates the account's client options.
     pub async fn set_client_options(&mut self, options: ClientOptions) -> crate::Result<()> {
         self.client_options = options;
+
+        let bech32_hrp = crate::client::get_client(&self.client_options)
+            .read()
+            .await
+            .get_network_info()
+            .bech32_hrp;
+        for address in &mut self.addresses {
+            address.set_bec32_hrp(bech32_hrp.to_string());
+        }
+
         self.save().await
     }
 

--- a/src/address.rs
+++ b/src/address.rs
@@ -148,10 +148,9 @@ impl AddressBuilder {
 }
 
 /// An address and its network type.
-#[derive(Debug, Clone, PartialEq, Eq, Getters)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AddressWrapper {
     inner: IotaAddress,
-    #[getset(get = "pub(crate)")]
     hrp: String,
 }
 
@@ -254,6 +253,10 @@ impl Address {
             .iter()
             .fold(0, |acc, o| acc + *o.amount())
     }
+
+    pub(crate) fn set_bec32_hrp(&mut self, hrp: String) {
+        self.address.hrp = hrp;
+    }
 }
 
 /// Parses a bech32 address string.
@@ -289,7 +292,7 @@ pub(crate) async fn get_iota_address(
 /// Gets an unused public address for the given account.
 pub(crate) async fn get_new_address(account: &Account, metadata: GenerateAddressMetadata) -> crate::Result<Address> {
     let key_index = account.addresses().iter().filter(|a| !a.internal()).count();
-    let bech32_hrp = account.addresses().first().unwrap().address().hrp().to_string();
+    let bech32_hrp = account.addresses().first().unwrap().address().hrp.to_string();
     let iota_address = get_iota_address(&account, key_index, false, bech32_hrp, metadata).await?;
     let address = Address {
         address: iota_address,
@@ -308,8 +311,7 @@ pub(crate) async fn get_new_change_address(
     metadata: GenerateAddressMetadata,
 ) -> crate::Result<Address> {
     let key_index = *address.key_index();
-    let iota_address =
-        get_iota_address(&account, key_index, true, address.address().hrp().to_string(), metadata).await?;
+    let iota_address = get_iota_address(&account, key_index, true, address.address().hrp.to_string(), metadata).await?;
     let address = Address {
         address: iota_address,
         balance: 0,

--- a/src/address.rs
+++ b/src/address.rs
@@ -254,7 +254,7 @@ impl Address {
             .fold(0, |acc, o| acc + *o.amount())
     }
 
-    pub(crate) fn set_bec32_hrp(&mut self, hrp: String) {
+    pub(crate) fn set_bech32_hrp(&mut self, hrp: String) {
         self.address.hrp = hrp;
     }
 }


### PR DESCRIPTION
# Description of change

When the node settings change, we must update the addresses hrp to properly encode them.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
