### PR TITLE
added nano s/x signer (for real device and simulator)

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,6 +35,12 @@ jobs:
       if: matrix.os == 'windows-latest'
       run: echo "CURRENT_DATE=$(Get-Date -Format "yyyy-MM-dd")" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
+    - name: Install required packages (Ubuntu)
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        sudo apt-get update
+        sudo apt-get install libudev-dev libusb-1.0-0-dev
+
     - name: Cache cargo registry
       uses: actions/cache@v2
       with:

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -26,6 +26,12 @@ jobs:
           toolchain: stable
           override: true
           components: clippy
+    
+    - name: Install required packages
+      run: |
+        sudo apt-get update
+        sudo apt-get install libudev-dev libusb-1.0-0-dev
+
     - uses: actions-rs/clippy-check@v1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,6 +24,11 @@ jobs:
           toolchain: stable
           override: true
 
+    - name: Install required packages (Ubuntu)
+      run: |
+        sudo apt-get update
+        sudo apt-get install libudev-dev libusb-1.0-0-dev
+
     - name: Run tests
       uses: actions-rs/cargo@v1
       with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,9 @@ riker = { version = "0.4", optional = true }
 blake2 = { version = "0.9", optional = true }
 slog = { version = "2.7", optional = true }
 
+# ledger hardware wallets
+ledger-iota = { git = "https://gitlab.com/ledger-iota-chrysalis/ledger-iota.rs", optional = true  }
+
 [dependencies.iota-crypto]
 git = "https://github.com/iotaledger/crypto.rs"
 rev = "c2514969c3f6693b86425ec84bada84b3ebea645"
@@ -50,3 +53,5 @@ default = ["stronghold", "stronghold-storage"]
 stronghold = ["iota-stronghold", "riker", "blake2", "slog"]
 stronghold-storage = ["iota-stronghold", "riker", "blake2", "slog"]
 sqlite-storage = ["rusqlite"]
+ledger-nano = ["ledger-iota"]
+ledger-nano-simulator = ["ledger-iota"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -146,6 +146,18 @@ pub enum Error {
     /// accounts)
     #[error("cannot use index identifier when two signer types are used")]
     CannotUseIndexIdentifier,
+    /// Ledger transport error
+    #[error("ledger transport error")]
+    LedgerMiscError,
+    /// Dongle Locked
+    #[error("ledger locked")]
+    LedgerDongleLocked,
+    /// Denied by User
+    #[error("denied by user")]
+    LedgerDeniedByUser,
+    /// Ledger Device not found
+    #[error("ledger device not found")]
+    LedgerDeviceNotFound,
 }
 
 impl Drop for Error {
@@ -225,6 +237,10 @@ impl serde::Serialize for Error {
             Self::AccountEncrypt(_) => serialize_variant(self, serializer, "AccountEncrypt"),
             Self::StorageIsEncrypted => serialize_variant(self, serializer, "StorageIsEncrypted"),
             Self::CannotUseIndexIdentifier => serialize_variant(self, serializer, "CannotUseIndexIdentifier"),
+            Self::LedgerMiscError => serialize_variant(self, serializer, "LedgerMiscError"),
+            Self::LedgerDongleLocked => serialize_variant(self, serializer, "LedgerDongleLocked"),
+            Self::LedgerDeniedByUser => serialize_variant(self, serializer, "LedgerDeniedByUser"),
+            Self::LedgerDeviceNotFound => serialize_variant(self, serializer, "LedgerDeviceNotFound"),
         }
     }
 }

--- a/src/signing/ledger.rs
+++ b/src/signing/ledger.rs
@@ -33,7 +33,7 @@ struct AddressIndexRecorder {
 // LedgerDeviceNotFound: No usable Ledger device was found
 // LedgerMiscError: Everything else.
 fn ledger_map_err(err: errors::APIError) -> crate::Error {
-    //println!("{}", err);
+    // println!("{}", err);
     match err {
         errors::APIError::SecurityStatusNotSatisfied => crate::Error::LedgerDongleLocked,
         errors::APIError::ConditionsOfUseNotSatisfied => crate::Error::LedgerDeniedByUser,

--- a/src/signing/ledger.rs
+++ b/src/signing/ledger.rs
@@ -6,8 +6,7 @@ use crate::account::Account;
 use iota::{common::packable::Packable, UnlockBlock};
 use std::path::PathBuf;
 
-use ledger_iota::api::errors;
-use ledger_iota::LedgerBIP32Index;
+use ledger_iota::{api::errors, LedgerBIP32Index};
 
 const HARDENED: u32 = 0x80000000;
 

--- a/src/signing/ledger.rs
+++ b/src/signing/ledger.rs
@@ -6,6 +6,9 @@ use crate::account::Account;
 use iota::{common::packable::Packable, UnlockBlock};
 use std::path::PathBuf;
 
+use ledger_iota::api::errors;
+use ledger_iota::LedgerBIP32Index;
+
 const HARDENED: u32 = 0x80000000;
 
 #[derive(Default)]
@@ -18,11 +21,10 @@ pub struct LedgerNanoSigner {
 struct AddressIndexRecorder {
     /// the input
     pub input: iota::Input,
-    /// bip32 index
-    pub bip32_index: u32,
-}
 
-use ledger_iota::api::errors;
+    /// bip32 index
+    pub bip32: LedgerBIP32Index,
+}
 
 // map most errors to a single error but there are some errors that
 // need special care.
@@ -31,6 +33,7 @@ use ledger_iota::api::errors;
 // LedgerDeviceNotFound: No usable Ledger device was found
 // LedgerMiscError: Everything else.
 fn ledger_map_err(err: errors::APIError) -> crate::Error {
+    //println!("{}", err);
     match err {
         errors::APIError::SecurityStatusNotSatisfied => crate::Error::LedgerDongleLocked,
         errors::APIError::ConditionsOfUseNotSatisfied => crate::Error::LedgerDeniedByUser,
@@ -49,7 +52,7 @@ impl super::Signer for LedgerNanoSigner {
         &mut self,
         account: &Account,
         address_index: usize,
-        _internal: bool,
+        internal: bool,
         meta: super::GenerateAddressMetadata,
     ) -> crate::Result<iota::Address> {
         // get ledger
@@ -59,7 +62,7 @@ impl super::Signer for LedgerNanoSigner {
         // if the wallet is not generating addresses for syncing, we assume it's a new receiving address that
         // needs to be shown to the user
         let address_bytes = ledger
-            .get_new_address(!meta.syncing, address_index as u32 | HARDENED)
+            .get_new_address(!meta.syncing, internal, address_index as u32 | HARDENED)
             .map_err(ledger_map_err)?;
 
         Ok(iota::Address::Ed25519(iota::Ed25519Address::new(address_bytes)))
@@ -78,41 +81,50 @@ impl super::Signer for LedgerNanoSigner {
 
         let input_len = inputs.len();
 
-        // gather input indices into vec
-        let mut address_index_recorders: Vec<AddressIndexRecorder> = Vec::new();
-
-        // on essence finalization, inputs are sorted lexically before they are packed into bytes
+        // on essence finalization, inputs are sorted lexically before they are packed into bytes.
         // we need the correct order of the bip32 indices before we can call PrepareSigning, but
-        // because we can't just get the inputs after sorting (because the fields are private),
-        // we need to sort it on our own too.
+        // because inputs of the essence don't have bip32 indices, we need to sort it on our own too.
+        let mut address_index_recorders: Vec<AddressIndexRecorder> = Vec::new();
         for input in inputs {
             address_index_recorders.push(AddressIndexRecorder {
                 input: input.input.clone(),
-                bip32_index: input.address_index as u32,
+                bip32: LedgerBIP32Index {
+                    bip32_index: input.address_index as u32 | HARDENED,
+                    bip32_change: if input.address_internal { 1 } else { 0 } | HARDENED,
+                },
             });
         }
         address_index_recorders.sort_by(|a, b| a.input.cmp(&b.input));
 
         // now extract the bip32 indices in the right order
-        let mut key_indices: Vec<u32> = Vec::new();
+        let mut input_bip32_indices: Vec<LedgerBIP32Index> = Vec::new();
         for recorder in address_index_recorders {
-            key_indices.push(recorder.bip32_index as u32 | HARDENED);
+            input_bip32_indices.push(recorder.bip32);
         }
 
         // figure out the remainder address and bip32 index (if there is one)
-        let (has_remainder, remainder_address, remainder_bip32): (bool, Option<&iota::Address>, u32) =
+        let (has_remainder, remainder_address, remainder_bip32): (bool, Option<&iota::Address>, LedgerBIP32Index) =
             match meta.remainder_deposit_address {
-                Some(a) => (true, Some(a.address().as_ref()), *a.key_index() as u32 | HARDENED),
-                None => (false, None, 0u32),
+                Some(a) => (
+                    true,
+                    Some(a.address().as_ref()),
+                    LedgerBIP32Index {
+                        bip32_index: *a.key_index() as u32 | HARDENED,
+                        bip32_change: if *a.internal() { 1 } else { 0 } | HARDENED,
+                    },
+                ),
+                None => (false, None, LedgerBIP32Index::default()),
             };
 
         let mut remainder_index = 0u16;
         if has_remainder {
             // find the index of the remainder in the essence
             // this has to be done because outputs in essences are sorted
-            // lexically and therefore the remainder is not always the last output
+            // lexically and therefore the remainder is not always the last output.
             // The index within the essence and the bip32 index will be validated
             // by the hardware wallet.
+            // The outputs in the essence already are sorted (done by `essence_builder.finish`)
+            // at this place, so we can rely on their order and don't have to sort it again.
             for output in essence.outputs().iter() {
                 match output {
                     iota::Output::SignatureLockedSingle(s) => {
@@ -139,7 +151,7 @@ impl super::Signer for LedgerNanoSigner {
         // prepare signing
         ledger
             .prepare_signing(
-                key_indices,
+                input_bip32_indices,
                 essence_bytes,
                 has_remainder,
                 remainder_index,
@@ -153,11 +165,12 @@ impl super::Signer for LedgerNanoSigner {
 
         // sign
         let signature_bytes = ledger.sign(input_len as u16).map_err(ledger_map_err)?;
-
+        let mut readable = &mut &*signature_bytes;
         // unpack signature to unlockblocks
         let mut unlock_blocks = Vec::new();
         for _ in 0..input_len {
-            unlock_blocks.push(UnlockBlock::unpack(&mut &signature_bytes[..])?);
+            let unlock_block = UnlockBlock::unpack(&mut readable)?;
+            unlock_blocks.push(unlock_block);
         }
         Ok(unlock_blocks)
     }

--- a/src/signing/ledger.rs
+++ b/src/signing/ledger.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::account::{Account};
-use crate::address::AddressWrapper;
 
 use iota::{common::packable::Packable, UnlockBlock};
 use std::{path::PathBuf};
@@ -81,9 +80,9 @@ impl super::Signer for LedgerNanoSigner {
         }
  
         // figure out the remainder address and bip32 index (if there is one)
-        let (has_remainder, remainder_address, remainder_bip32) : (bool, Option<&AddressWrapper>, u32) = match meta.remainder_deposit_address {
+        let (has_remainder, remainder_address, remainder_bip32) : (bool, Option<&iota::Address>, u32) = match meta.remainder_deposit_address {
             Some(a) => {
-                (true, Some(a.address()), *a.key_index() as u32 | HARDENED)
+                (true, Some(a.address().as_ref()), *a.key_index() as u32 | HARDENED)
             }
             None => {
                 (false, None, 0u32)

--- a/src/signing/ledger.rs
+++ b/src/signing/ledger.rs
@@ -45,13 +45,13 @@ impl super::Signer for LedgerNanoSigner {
     ) -> crate::Result<iota::Address> {
         // get ledger
         let ledger = ledger_iota::get_ledger(self.is_simulator, *account.index() as u32 | HARDENED)
-            .map_err(|e| ledger_map_err(e))?;
+            .map_err(ledger_map_err)?;
 
         // if the wallet is not generating addresses for syncing, we assume it's a new receiving address that
         // needs to be shown to the user
         let address_bytes = ledger
             .get_new_address(!meta.syncing, address_index as u32 | HARDENED)
-            .map_err(|e| ledger_map_err(e))?;
+            .map_err(ledger_map_err)?;
 
         Ok(iota::Address::Ed25519(iota::Ed25519Address::new(address_bytes)))
     }
@@ -65,7 +65,7 @@ impl super::Signer for LedgerNanoSigner {
     ) -> crate::Result<Vec<iota::UnlockBlock>> {
         // get ledger
         let ledger = ledger_iota::get_ledger(self.is_simulator, *account.index() as u32 | HARDENED)
-            .map_err(|e| ledger_map_err(e))?;
+            .map_err(ledger_map_err)?;
 
         // gather input indices into vec
         let mut key_indices: Vec<u32> = Vec::new();
@@ -120,14 +120,14 @@ impl super::Signer for LedgerNanoSigner {
                 remainder_index,
                 remainder_bip32,
             )
-            .map_err(|e| ledger_map_err(e))?;
+            .map_err(ledger_map_err)?;
 
         // show essence to user
         // if denied by user, it returns with `DeniedByUser` Error
-        ledger.user_confirm().map_err(|e| ledger_map_err(e))?;
+        ledger.user_confirm().map_err(ledger_map_err)?;
 
         // sign
-        let signature_bytes = ledger.sign(input_len as u16).map_err(|e| ledger_map_err(e))?;
+        let signature_bytes = ledger.sign(input_len as u16).map_err(ledger_map_err)?;
 
         // unpack signature to unlockblocks
         let mut unlock_blocks = Vec::new();

--- a/src/signing/ledger.rs
+++ b/src/signing/ledger.rs
@@ -1,0 +1,150 @@
+// Copyright 2020 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::account::{Account};
+use crate::address::AddressWrapper;
+
+use iota::{common::packable::Packable, UnlockBlock};
+use std::{path::PathBuf};
+
+const HARDENED : u32 = 0x80000000;
+
+#[derive(Default)]
+pub struct LedgerNanoSigner {
+    pub is_simulator: bool,
+}
+
+use ledger_iota::api::errors;
+
+// map most errors to a single error but there are some errors that
+// need special care.
+// LedgerDongleLocked: Ask the user to unlock the dongle
+// LedgerDeniedByUser: The user denied a signing
+// LedgerDeviceNotFound: No usable Ledger device was found
+// LedgerMiscError: Everything else.
+fn ledger_map_err(err: errors::APIError) -> crate::Error {
+    match err {
+        errors::APIError::SecurityStatusNotSatisfied => {
+            crate::Error::LedgerDongleLocked
+        }
+        errors::APIError::ConditionsOfUseNotSatisfied => {
+            crate::Error::LedgerDeniedByUser
+        }
+        errors::APIError::TransportError => {
+            crate::Error::LedgerDeviceNotFound
+        }
+        _ => {
+            crate::Error::LedgerMiscError 
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl super::Signer for LedgerNanoSigner {
+    async fn store_mnemonic(&mut self, _: &PathBuf, _mnemonic: String) -> crate::Result<()> {
+        Err(crate::Error::InvalidMnemonic(String::from("")))
+    }
+
+    async fn generate_address(
+        &mut self,
+        account: &Account,
+        address_index: usize,
+        _internal: bool,
+        meta: super::GenerateAddressMetadata, 
+    ) -> crate::Result<iota::Address> {
+        // get ledger
+        let ledger = ledger_iota::get_ledger(self.is_simulator, *account.index() as u32 | HARDENED).map_err(|e| ledger_map_err(e))?;
+
+        // if the wallet is not generating addresses for syncing, we assume it's a new receiving address that 
+        // needs to be shown to the user
+        let address_bytes = ledger.get_new_address(!meta.syncing, address_index as u32 | HARDENED)
+            .map_err(|e| ledger_map_err(e))?;
+
+        Ok(iota::Address::Ed25519(iota::Ed25519Address::new(address_bytes)))
+    }
+
+    async fn sign_message<'a>(
+        &mut self,
+        account: &Account,
+        essence: &iota::TransactionPayloadEssence,
+        inputs: &mut Vec<super::TransactionInput>,
+        meta: super::SignMessageMetadata<'a>,
+    ) -> crate::Result<Vec<iota::UnlockBlock>> {
+        // get ledger
+        let ledger = ledger_iota::get_ledger(self.is_simulator, *account.index() as u32 | HARDENED).map_err(|e| ledger_map_err(e))?;
+
+        // gather input indices into vec
+        let mut key_indices : Vec<u32> = Vec::new();
+        let input_len = inputs.len();
+        for input in inputs {
+            key_indices.push(input.address_index as u32 | HARDENED);
+        }
+ 
+        // figure out the remainder address and bip32 index (if there is one)
+        let (has_remainder, remainder_address, remainder_bip32) : (bool, Option<&AddressWrapper>, u32) = match meta.remainder_deposit_address {
+            Some(a) => {
+                (true, Some(a.address()), *a.key_index() as u32 | HARDENED)
+            }
+            None => {
+                (false, None, 0u32)
+            }
+        };
+
+        let mut remainder_index = 0u16;
+        if has_remainder {
+            // find the index of the remainder in the essence
+            // this has to be done because outputs in essences are sorted
+            // lexically and therefore the remainder is not always the last output
+            // The index within the essence and the bip32 index will be validated
+            // by the hardware wallet.
+            for output in essence.outputs().iter() {
+                match output {
+                    iota::Output::SignatureLockedSingle(s) => {
+                        if *remainder_address.unwrap() == *s.address() {
+                            break;
+                        }
+                    }
+                    _ => {
+                        return Err(crate::Error::LedgerMiscError);
+                    }
+                }
+                remainder_index += 1; 
+            }
+
+            // was index found?
+            if remainder_index as usize == essence.outputs().len() {
+                return Err(crate::Error::LedgerMiscError);
+            }
+        }
+    
+        // pack essence into bytes
+        let essence_bytes = essence.pack_new();
+
+        // prepare signing 
+        ledger.prepare_signing(
+                key_indices, 
+                essence_bytes, 
+                has_remainder,
+                remainder_index, 
+                remainder_bip32)
+            .map_err(|e| ledger_map_err(e))?;
+
+        // show essence to user
+        // if denied by user, it returns with `DeniedByUser` Error
+        ledger.user_confirm()
+            .map_err(|e| ledger_map_err(e))?;
+
+
+        // sign
+        let signature_bytes = ledger.sign(input_len as u16)
+            .map_err(|e| ledger_map_err(e))?;
+        
+
+        // unpack signature to unlockblocks
+        let mut unlock_blocks = Vec::new();
+        for _ in 0..input_len { 
+            unlock_blocks.push(UnlockBlock::unpack(&mut &signature_bytes[..])?);
+        }
+        Ok(unlock_blocks)
+    }
+}

--- a/src/signing/ledger.rs
+++ b/src/signing/ledger.rs
@@ -44,8 +44,8 @@ impl super::Signer for LedgerNanoSigner {
         meta: super::GenerateAddressMetadata,
     ) -> crate::Result<iota::Address> {
         // get ledger
-        let ledger = ledger_iota::get_ledger(self.is_simulator, *account.index() as u32 | HARDENED)
-            .map_err(ledger_map_err)?;
+        let ledger =
+            ledger_iota::get_ledger(self.is_simulator, *account.index() as u32 | HARDENED).map_err(ledger_map_err)?;
 
         // if the wallet is not generating addresses for syncing, we assume it's a new receiving address that
         // needs to be shown to the user
@@ -64,8 +64,8 @@ impl super::Signer for LedgerNanoSigner {
         meta: super::SignMessageMetadata<'a>,
     ) -> crate::Result<Vec<iota::UnlockBlock>> {
         // get ledger
-        let ledger = ledger_iota::get_ledger(self.is_simulator, *account.index() as u32 | HARDENED)
-            .map_err(ledger_map_err)?;
+        let ledger =
+            ledger_iota::get_ledger(self.is_simulator, *account.index() as u32 | HARDENED).map_err(ledger_map_err)?;
 
         // gather input indices into vec
         let mut key_indices: Vec<u32> = Vec::new();

--- a/src/signing/mod.rs
+++ b/src/signing/mod.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use slip10::BIP32Path;
 use tokio::sync::Mutex;
 
-#[cfg(any(feature = "ledger-nano", feature ="ledger-nano-simulator"))]
+#[cfg(any(feature = "ledger-nano", feature = "ledger-nano-simulator"))]
 mod ledger;
 
 #[cfg(feature = "stronghold")]
@@ -116,7 +116,7 @@ fn default_signers() -> Signers {
         signers.insert(
             SignerType::LedgerNanoSigner,
             Arc::new(Mutex::new(
-                Box::new(ledger::LedgerNanoSigner{is_simulator: false}) as Box<dyn Signer + Sync + Send>
+                Box::new(ledger::LedgerNanoSigner { is_simulator: false }) as Box<dyn Signer + Sync + Send>
             )),
         );
     }
@@ -126,7 +126,7 @@ fn default_signers() -> Signers {
         signers.insert(
             SignerType::LedgerNanoSimulatorSigner,
             Arc::new(Mutex::new(
-                Box::new(ledger::LedgerNanoSigner{is_simulator: true}) as Box<dyn Signer + Sync + Send>
+                Box::new(ledger::LedgerNanoSigner { is_simulator: true }) as Box<dyn Signer + Sync + Send>
             )),
         );
     }

--- a/src/signing/mod.rs
+++ b/src/signing/mod.rs
@@ -14,6 +14,9 @@ use serde::{Deserialize, Serialize};
 use slip10::BIP32Path;
 use tokio::sync::Mutex;
 
+#[cfg(any(feature = "ledger-nano", feature ="ledger-nano-simulator"))]
+mod ledger;
+
 #[cfg(feature = "stronghold")]
 mod stronghold;
 
@@ -29,6 +32,12 @@ pub enum SignerType {
     #[cfg(feature = "stronghold")]
     #[cfg_attr(docsrs, doc(cfg(feature = "stronghold")))]
     Stronghold,
+    /// Ledger Device
+    #[cfg(feature = "ledger-nano")]
+    LedgerNanoSigner,
+    /// Ledger Speculos Simulator
+    #[cfg(feature = "ledger-nano-simulator")]
+    LedgerNanoSimulatorSigner,
     /// Custom signer with its identifier.
     Custom(String),
 }
@@ -98,6 +107,26 @@ fn default_signers() -> Signers {
             SignerType::Stronghold,
             Arc::new(Mutex::new(
                 Box::new(self::stronghold::StrongholdSigner::default()) as Box<dyn Signer + Sync + Send>
+            )),
+        );
+    }
+
+    #[cfg(feature = "ledger-nano")]
+    {
+        signers.insert(
+            SignerType::LedgerNanoSigner,
+            Arc::new(Mutex::new(
+                Box::new(ledger::LedgerNanoSigner{is_simulator: false}) as Box<dyn Signer + Sync + Send>
+            )),
+        );
+    }
+
+    #[cfg(feature = "ledger-nano-simulator")]
+    {
+        signers.insert(
+            SignerType::LedgerNanoSimulatorSigner,
+            Arc::new(Mutex::new(
+                Box::new(ledger::LedgerNanoSigner{is_simulator: true}) as Box<dyn Signer + Sync + Send>
             )),
         );
     }

--- a/src/signing/mod.rs
+++ b/src/signing/mod.rs
@@ -34,10 +34,10 @@ pub enum SignerType {
     Stronghold,
     /// Ledger Device
     #[cfg(feature = "ledger-nano")]
-    LedgerNanoSigner,
+    LedgerNano,
     /// Ledger Speculos Simulator
     #[cfg(feature = "ledger-nano-simulator")]
-    LedgerNanoSimulatorSigner,
+    LedgerNanoSimulator,
     /// Custom signer with its identifier.
     Custom(String),
 }
@@ -114,7 +114,7 @@ fn default_signers() -> Signers {
     #[cfg(feature = "ledger-nano")]
     {
         signers.insert(
-            SignerType::LedgerNanoSigner,
+            SignerType::LedgerNano,
             Arc::new(Mutex::new(
                 Box::new(ledger::LedgerNanoSigner { is_simulator: false }) as Box<dyn Signer + Sync + Send>
             )),
@@ -124,7 +124,7 @@ fn default_signers() -> Signers {
     #[cfg(feature = "ledger-nano-simulator")]
     {
         signers.insert(
-            SignerType::LedgerNanoSimulatorSigner,
+            SignerType::LedgerNanoSimulator,
             Arc::new(Mutex::new(
                 Box::new(ledger::LedgerNanoSigner { is_simulator: true }) as Box<dyn Signer + Sync + Send>
             )),


### PR DESCRIPTION
# Description of change

Added signers for Ledger Nano S/X hardware wallets (and simulator)

Signers can be enabled via features 'ledger-nano' and 'ledger-nano-simulator' and two signers are provided ('LedgerNanoSigner' and 'LedgerNanoSimulatorSigner').

