### PR TITLE
fix(manager): enable all features on tokio runtime used on the polling

### DIFF
--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -382,7 +382,7 @@ impl AccountManager {
 
         let handle = thread::spawn(move || {
             let runtime = tokio::runtime::Builder::new_current_thread()
-                .enable_time()
+                .enable_all()
                 .build()
                 .unwrap();
             runtime.block_on(async {


### PR DESCRIPTION
# Description of change

Fixes the polling thread usage of iota.rs reattachment libs (needs all features from tokio runtime).

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Faucet

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
