### PR TITLE
fix(sync): synced account serialization

### DIFF
--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -16,7 +16,7 @@ use iota::{
     },
     ClientMiner,
 };
-use serde::{ser::Serializer, Serialize};
+use serde::Serialize;
 use slip10::BIP32Path;
 use tokio::{
     sync::{mpsc::channel, MutexGuard},
@@ -419,6 +419,7 @@ impl AccountSynchronizer {
                 let account_ref = self.account_handle.read().await;
 
                 let synced_account = SyncedAccount {
+                    account_id: account_ref.id().to_string(),
                     account_handle: self.account_handle.clone(),
                     deposit_address: account_ref.latest_address().unwrap().clone(),
                     is_empty,
@@ -451,21 +452,14 @@ impl AccountSynchronizer {
     }
 }
 
-fn serialize_as_id<S>(x: &AccountHandle, s: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    futures::executor::block_on(async move {
-        let account = x.read().await;
-        account.id().serialize(s)
-    })
-}
-
 /// Data returned from account synchronization.
 #[derive(Debug, Clone, Getters, Serialize)]
 pub struct SyncedAccount {
-    /// The associated account identifier.
-    #[serde(rename = "accountId", serialize_with = "serialize_as_id")]
+    /// The account identifier.
+    #[serde(rename = "accountId")]
+    account_id: String,
+    /// The associated account handle.
+    #[serde(skip)]
     #[getset(get = "pub")]
     account_handle: AccountHandle,
     /// The account's deposit address.
@@ -948,7 +942,6 @@ mod tests {
         })
         .await;
 
-        // let synced_accounts = account.sync().execute().await.unwrap();
         // TODO improve test when the node API is ready to use
     }
 }

--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -455,7 +455,7 @@ fn serialize_as_id<S>(x: &AccountHandle, s: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {
-    crate::block_on(async move {
+    futures::executor::block_on(async move {
         let account = x.read().await;
         account.id().serialize(s)
     })


### PR DESCRIPTION
# Description of change

Fixes a panic when using `tokio::runtime::Runtime#block_on` on the SyncedAccount serialization function (tokio panicks running block_on on an async context).

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Firefly.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
