### PR TITLE
fix(transfer): deadlock on `get_signer`

### DIFF
--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -797,10 +797,10 @@ impl SyncedAccount {
 
         let essence = essence_builder.finish()?;
 
-        let signer = crate::signing::get_signer(account_.signer_type()).await;
-        let mut signer = signer.lock().await;
-
-        let unlock_blocks = signer
+        let unlock_blocks = crate::signing::get_signer(account_.signer_type())
+            .await
+            .lock()
+            .await
             .sign_message(
                 &account_,
                 &essence,


### PR DESCRIPTION
# Description of change

Fixes a deadlock on the transfer when using `get_signer`. The method shouldn't lock the signer because a new address generation might be needed afterwards. 

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

CLI Wallet.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
