### PR TITLE
added id that is needed by latest ledger-iota.rs for address-pooling

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -158,6 +158,9 @@ pub enum Error {
     /// Ledger Device not found
     #[error("ledger device not found")]
     LedgerDeviceNotFound,
+    /// Ledger Essence Too Large
+    #[error("ledger essence too large")]
+    LedgerEssenceTooLarge,
     /// Account alias must be unique.
     #[error("can't create account: account alias already exists")]
     AccountAliasAlreadyExists,
@@ -244,6 +247,7 @@ impl serde::Serialize for Error {
             Self::LedgerDongleLocked => serialize_variant(self, serializer, "LedgerDongleLocked"),
             Self::LedgerDeniedByUser => serialize_variant(self, serializer, "LedgerDeniedByUser"),
             Self::LedgerDeviceNotFound => serialize_variant(self, serializer, "LedgerDeviceNotFound"),
+            Self::LedgerEssenceTooLarge => serialize_variant(self, serializer, "LedgerEssenceTooLarge"),
             Self::AccountAliasAlreadyExists => serialize_variant(self, serializer, "AccountAliasAlreadyExists"),
         }
     }

--- a/src/signing/ledger.rs
+++ b/src/signing/ledger.rs
@@ -12,7 +12,7 @@ const HARDENED: u32 = 0x80000000;
 
 #[derive(Default)]
 pub struct LedgerNanoSigner {
-    pub id : u64,
+    pub id: u64,
     pub is_simulator: bool,
 }
 
@@ -56,16 +56,17 @@ impl super::Signer for LedgerNanoSigner {
         meta: super::GenerateAddressMetadata,
     ) -> crate::Result<iota::Address> {
         // get ledger
-        let mut ledger =
-            ledger_iota::get_ledger(self.id, self.is_simulator, *account.index() as u32 | HARDENED).map_err(ledger_map_err)?;
+        let mut ledger = ledger_iota::get_ledger(self.id, self.is_simulator, *account.index() as u32 | HARDENED)
+            .map_err(ledger_map_err)?;
 
-        let bip32 = ledger_iota::LedgerBIP32Index{bip32_index: address_index as u32 | HARDENED, bip32_change: if internal { 1 } else { 0 } | HARDENED};
+        let bip32 = ledger_iota::LedgerBIP32Index {
+            bip32_index: address_index as u32 | HARDENED,
+            bip32_change: if internal { 1 } else { 0 } | HARDENED,
+        };
 
         // if the wallet is not generating addresses for syncing, we assume it's a new receiving address that
         // needs to be shown to the user
-        let address_bytes = ledger
-            .get_new_address(!meta.syncing, bip32)
-            .map_err(ledger_map_err)?;
+        let address_bytes = ledger.get_new_address(!meta.syncing, bip32).map_err(ledger_map_err)?;
 
         Ok(iota::Address::Ed25519(iota::Ed25519Address::new(address_bytes)))
     }
@@ -78,8 +79,8 @@ impl super::Signer for LedgerNanoSigner {
         meta: super::SignMessageMetadata<'a>,
     ) -> crate::Result<Vec<iota::UnlockBlock>> {
         // get ledger
-        let ledger =
-            ledger_iota::get_ledger(self.id, self.is_simulator, *account.index() as u32 | HARDENED).map_err(ledger_map_err)?;
+        let ledger = ledger_iota::get_ledger(self.id, self.is_simulator, *account.index() as u32 | HARDENED)
+            .map_err(ledger_map_err)?;
 
         let input_len = inputs.len();
 

--- a/src/signing/ledger.rs
+++ b/src/signing/ledger.rs
@@ -32,12 +32,14 @@ struct AddressIndexRecorder {
 // LedgerDeniedByUser: The user denied a signing
 // LedgerDeviceNotFound: No usable Ledger device was found
 // LedgerMiscError: Everything else.
+// LedgerEssenceTooLarge: Essence with bip32 input indices need more space then the internal buffer is big
 fn ledger_map_err(err: errors::APIError) -> crate::Error {
     // println!("{}", err);
     match err {
         errors::APIError::SecurityStatusNotSatisfied => crate::Error::LedgerDongleLocked,
         errors::APIError::ConditionsOfUseNotSatisfied => crate::Error::LedgerDeniedByUser,
         errors::APIError::TransportError => crate::Error::LedgerDeviceNotFound,
+        errors::APIError::EssenceTooLarge => crate::Error::EssenceTooLarge,
         _ => crate::Error::LedgerMiscError,
     }
 }

--- a/src/signing/ledger.rs
+++ b/src/signing/ledger.rs
@@ -39,7 +39,7 @@ fn ledger_map_err(err: errors::APIError) -> crate::Error {
         errors::APIError::SecurityStatusNotSatisfied => crate::Error::LedgerDongleLocked,
         errors::APIError::ConditionsOfUseNotSatisfied => crate::Error::LedgerDeniedByUser,
         errors::APIError::TransportError => crate::Error::LedgerDeviceNotFound,
-        errors::APIError::EssenceTooLarge => crate::Error::EssenceTooLarge,
+        errors::APIError::EssenceTooLarge => crate::Error::LedgerEssenceTooLarge,
         _ => crate::Error::LedgerMiscError,
     }
 }

--- a/src/signing/ledger.rs
+++ b/src/signing/ledger.rs
@@ -12,6 +12,7 @@ const HARDENED: u32 = 0x80000000;
 
 #[derive(Default)]
 pub struct LedgerNanoSigner {
+    pub id : u64,
     pub is_simulator: bool,
 }
 
@@ -55,13 +56,15 @@ impl super::Signer for LedgerNanoSigner {
         meta: super::GenerateAddressMetadata,
     ) -> crate::Result<iota::Address> {
         // get ledger
-        let ledger =
-            ledger_iota::get_ledger(self.is_simulator, *account.index() as u32 | HARDENED).map_err(ledger_map_err)?;
+        let mut ledger =
+            ledger_iota::get_ledger(self.id, self.is_simulator, *account.index() as u32 | HARDENED).map_err(ledger_map_err)?;
+
+        let bip32 = ledger_iota::LedgerBIP32Index{bip32_index: address_index as u32 | HARDENED, bip32_change: if internal { 1 } else { 0 } | HARDENED};
 
         // if the wallet is not generating addresses for syncing, we assume it's a new receiving address that
         // needs to be shown to the user
         let address_bytes = ledger
-            .get_new_address(!meta.syncing, internal, address_index as u32 | HARDENED)
+            .get_new_address(!meta.syncing, bip32)
             .map_err(ledger_map_err)?;
 
         Ok(iota::Address::Ed25519(iota::Ed25519Address::new(address_bytes)))
@@ -76,7 +79,7 @@ impl super::Signer for LedgerNanoSigner {
     ) -> crate::Result<Vec<iota::UnlockBlock>> {
         // get ledger
         let ledger =
-            ledger_iota::get_ledger(self.is_simulator, *account.index() as u32 | HARDENED).map_err(ledger_map_err)?;
+            ledger_iota::get_ledger(self.id, self.is_simulator, *account.index() as u32 | HARDENED).map_err(ledger_map_err)?;
 
         let input_len = inputs.len();
 

--- a/src/signing/mod.rs
+++ b/src/signing/mod.rs
@@ -115,9 +115,10 @@ fn default_signers() -> Signers {
     {
         signers.insert(
             SignerType::LedgerNano,
-            Arc::new(Mutex::new(
-                Box::new(ledger::LedgerNanoSigner { id: 0u64, is_simulator: false }) as Box<dyn Signer + Sync + Send>
-            )),
+            Arc::new(Mutex::new(Box::new(ledger::LedgerNanoSigner {
+                id: 0u64,
+                is_simulator: false,
+            }) as Box<dyn Signer + Sync + Send>)),
         );
     }
 
@@ -125,9 +126,10 @@ fn default_signers() -> Signers {
     {
         signers.insert(
             SignerType::LedgerNanoSimulator,
-            Arc::new(Mutex::new(
-                Box::new(ledger::LedgerNanoSigner { id: 1u64, is_simulator: true }) as Box<dyn Signer + Sync + Send>
-            )),
+            Arc::new(Mutex::new(Box::new(ledger::LedgerNanoSigner {
+                id: 1u64,
+                is_simulator: true,
+            }) as Box<dyn Signer + Sync + Send>)),
         );
     }
 

--- a/src/signing/mod.rs
+++ b/src/signing/mod.rs
@@ -116,7 +116,7 @@ fn default_signers() -> Signers {
         signers.insert(
             SignerType::LedgerNano,
             Arc::new(Mutex::new(
-                Box::new(ledger::LedgerNanoSigner { is_simulator: false }) as Box<dyn Signer + Sync + Send>
+                Box::new(ledger::LedgerNanoSigner { id: 0u64, is_simulator: false }) as Box<dyn Signer + Sync + Send>
             )),
         );
     }
@@ -126,7 +126,7 @@ fn default_signers() -> Signers {
         signers.insert(
             SignerType::LedgerNanoSimulator,
             Arc::new(Mutex::new(
-                Box::new(ledger::LedgerNanoSigner { is_simulator: true }) as Box<dyn Signer + Sync + Send>
+                Box::new(ledger::LedgerNanoSigner { id: 1u64, is_simulator: true }) as Box<dyn Signer + Sync + Send>
             )),
         );
     }


### PR DESCRIPTION
# Description of change

in ledger-iota.rs address-pooling was introduced that significantly reduces the time for querying addresses.

Also it makes a nice flicker-free "Generating Addresses" display possible because if an bip32 index is not found in the pool, a bunch of 15 addresses is generated what takes about 5s.

To distinguish which address is for which HardwareLedgerSigner, an `id` was introduced.

This is a breaking change, so the current wallet.rs won't compile without it.


## Type of change

Enhancement, Breaking change

## How the change has been tested

Tested with the `cli-wallet`

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [X] I have followed the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
