### PR TITLE
chore(deps): use `bee-rest-api` for node API types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ serde_json = "1.0"
 serde_repr = "0.1"
 once_cell = "1.5"
 iota-core = { git = "https://github.com/iotaledger/iota.rs", branch = "dev" }
+bee-rest-api = { git = "https://github.com/iotaledger/bee.git", branch = "chrysalis-pt-2" }
 url = { version = "2.2", features = [ "serde" ] }
 tokio = { version = "1.0", features = ["macros", "sync", "time", "rt", "rt-multi-thread"] }
 rand = "0.7"

--- a/src/address.rs
+++ b/src/address.rs
@@ -2,11 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{account::Account, message::MessageType, signing::GenerateAddressMetadata};
-use getset::{Getters, Setters};
-use iota::{
-    message::prelude::{MessageId, TransactionId},
-    OutputMetadata,
+use bee_rest_api::{
+    handlers::output::OutputResponse,
+    types::{AddressDto, OutputDto},
 };
+use getset::{Getters, Setters};
+use iota::message::prelude::{MessageId, TransactionId};
 pub use iota::{Address as IotaAddress, Ed25519Address, Input, Payload, UTXOInput};
 use serde::{Deserialize, Serialize};
 use std::{
@@ -58,22 +59,35 @@ impl AddressOutput {
         })
     }
 
-    pub(crate) fn from_output_metadata(metadata: OutputMetadata, bech32_hrp: String) -> crate::Result<Self> {
+    pub(crate) fn from_output_response(output: OutputResponse, bech32_hrp: String) -> crate::Result<Self> {
+        let (address, amount) = match output.output {
+            OutputDto::SignatureLockedSingle(output) => {
+                let address = match output.address {
+                    AddressDto::Ed25519(ed25519_address) => IotaAddress::Ed25519(Ed25519Address::new(
+                        hex::decode(ed25519_address.address)
+                            .map_err(|_| crate::Error::InvalidAddress)?
+                            .try_into()
+                            .map_err(|_| crate::Error::InvalidAddressLength)?,
+                    )),
+                };
+                (address, output.amount)
+            }
+        };
         let output = Self {
             transaction_id: TransactionId::new(
-                metadata.transaction_id[..]
+                hex::decode(output.transaction_id).map_err(|_| crate::Error::InvalidTransactionId)?[..]
                     .try_into()
                     .map_err(|_| crate::Error::InvalidTransactionId)?,
             ),
             message_id: MessageId::new(
-                metadata.message_id[..]
+                hex::decode(output.message_id).map_err(|_| crate::Error::InvalidMessageId)?[..]
                     .try_into()
                     .map_err(|_| crate::Error::InvalidMessageId)?,
             ),
-            index: metadata.output_index,
-            amount: metadata.amount,
-            is_spent: metadata.is_spent,
-            address: AddressWrapper::new(metadata.address, bech32_hrp),
+            index: output.output_index,
+            amount,
+            is_spent: output.is_spent,
+            address: AddressWrapper::new(address, bech32_hrp),
         };
         Ok(output)
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -65,6 +65,9 @@ pub enum Error {
     /// failed to parse address.
     #[error("invalid address")]
     InvalidAddress,
+    /// Address length response invalid.
+    #[error("invalid address length")]
+    InvalidAddressLength,
     /// Tried to backup but storage file doesn't exist.
     #[error("storage file doesn't exist")]
     StorageDoesntExist,
@@ -211,6 +214,7 @@ impl serde::Serialize for Error {
             Self::MessageNotFound => serialize_variant(self, serializer, "MessageNotFound"),
             Self::InvalidMessageIdLength => serialize_variant(self, serializer, "InvalidMessageIdLength"),
             Self::InvalidAddress => serialize_variant(self, serializer, "InvalidAddress"),
+            Self::InvalidAddressLength => serialize_variant(self, serializer, "InvalidAddressLength"),
             Self::StorageDoesntExist => serialize_variant(self, serializer, "StorageDoesntExist"),
             Self::InsufficientFunds => serialize_variant(self, serializer, "InsufficientFunds"),
             Self::AccountNotEmpty => serialize_variant(self, serializer, "AccountNotEmpty"),


### PR DESCRIPTION
# Description of change

Use `bee-rest-api` for node response types.

## Links to any relevant issues

N/A

## Type of change

- Chore

## How the change has been tested

Unit tests.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
