### PR TITLE
feat(account): add `isLatestAddressUnused` API

### DIFF
--- a/bindings/nodejs/README.md
+++ b/bindings/nodejs/README.md
@@ -208,6 +208,12 @@ Imports a database file.
 | source   | <code>string</code> | <code>undefined</code> | The path to the backup file    |
 | password | <code>string</code> | <code>undefined</code> | The backup stronghold password |
 
+#### isLatestAddressUnused()
+
+Determines whether all accounts has unused latest address after syncing with the Tangle.
+
+**Returns** A promise resolving to the boolean value.
+
 ### SyncedAccount
 
 #### send(address, amount[, options])
@@ -321,6 +327,12 @@ Synchronizes the account with the Tangle.
 
 **Returns** a [SyncedAccount](#syncedaccount) instance.
 
+#### isLatestAddressUnused()
+
+Determines whether the account has unused latest address after syncing with the Tangle.
+
+**Returns** A promise resolving to the boolean value.
+
 #### setAlias(alias)
 
 Updates the account alias.
@@ -351,7 +363,7 @@ Generates a new unused address and returns it.
 
 #### latestAddress()
 
-Returns the latest address (the one with the biggest keyIndex) or undefined if the account address list is empty.
+Returns the latest address (the one with the biggest keyIndex).
 
 ### ClientOptions
 

--- a/bindings/nodejs/lib/index.d.ts
+++ b/bindings/nodejs/lib/index.d.ts
@@ -72,7 +72,8 @@ export declare class Account {
   setClientOptions(options: ClientOptions): void
   getMessage(id: string): Message | undefined
   generateAddress(): Address
-  latestAddress(): Address | undefined
+  latestAddress(): Address
+  isLatestAddressUnused(): Promise<bool>
 }
 
 export declare class RemainderValueStrategy {

--- a/bindings/nodejs/lib/index.js
+++ b/bindings/nodejs/lib/index.js
@@ -54,6 +54,8 @@ class RemainderValueStrategy {
 }
 
 Account.prototype.sync = promisify(Account.prototype.sync)
+Account.prototype.isLatestAddressUnused = promisify(Account.prototype.isLatestAddressUnused)
+
 const send = SyncedAccount.prototype.send
 SyncedAccount.prototype.send = function (address, amount, options) {
   if (options && (typeof options === 'object') && options.indexation && options.indexation.data) {
@@ -68,6 +70,7 @@ SyncedAccount.prototype.send = function (address, amount, options) {
     return promisify(send).apply(this, options ? [address, amount, options] : [address, amount])
   }
 }
+
 SyncedAccount.prototype.retry = promisify(SyncedAccount.prototype.retry)
 SyncedAccount.prototype.reattach = promisify(SyncedAccount.prototype.reattach)
 SyncedAccount.prototype.promote = promisify(SyncedAccount.prototype.promote)
@@ -98,6 +101,7 @@ AccountManager = function () {
 AccountManager.prototype = managerClass.prototype
 AccountManager.prototype.syncAccounts = promisify(AccountManager.prototype.syncAccounts)
 AccountManager.prototype.internalTransfer = promisify(AccountManager.prototype.internalTransfer)
+AccountManager.prototype.isLatestAddressUnused = promisify(AccountManager.prototype.isLatestAddressUnused)
 
 module.exports = {
   AccountManager,

--- a/bindings/nodejs/native/src/classes/account/is_latest_address_unused.rs
+++ b/bindings/nodejs/native/src/classes/account/is_latest_address_unused.rs
@@ -1,0 +1,29 @@
+// Copyright 2020 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use iota_wallet::Error;
+use neon::prelude::*;
+
+pub struct IsLatestAddressUnusedTask {
+    pub account_id: String,
+}
+
+impl Task for IsLatestAddressUnusedTask {
+    type Output = bool;
+    type Error = Error;
+    type JsEvent = JsBoolean;
+
+    fn perform(&self) -> Result<Self::Output, Self::Error> {
+        crate::block_on(async move {
+            let account_handle = crate::get_account(&self.account_id).await;
+            account_handle.is_latest_address_unused().await
+        })
+    }
+
+    fn complete(self, mut cx: TaskContext, value: Result<Self::Output, Self::Error>) -> JsResult<Self::JsEvent> {
+        match value {
+            Ok(val) => Ok(cx.boolean(val)),
+            Err(e) => cx.throw_error(e.to_string()),
+        }
+    }
+}

--- a/bindings/nodejs/native/src/classes/account_manager/is_latest_address_unused.rs
+++ b/bindings/nodejs/native/src/classes/account_manager/is_latest_address_unused.rs
@@ -1,0 +1,32 @@
+// Copyright 2020 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use iota_wallet::{account_manager::AccountManager, Error};
+use neon::prelude::*;
+use tokio::sync::RwLock;
+
+pub struct IsLatestAddressUnusedTask {
+    pub manager: Arc<RwLock<AccountManager>>,
+}
+
+impl Task for IsLatestAddressUnusedTask {
+    type Output = bool;
+    type Error = Error;
+    type JsEvent = JsBoolean;
+
+    fn perform(&self) -> Result<Self::Output, Self::Error> {
+        crate::block_on(crate::convert_async_panics(|| async {
+            let manager = self.manager.read().await;
+            manager.is_latest_address_unused().await
+        }))
+    }
+
+    fn complete(self, mut cx: TaskContext, value: Result<Self::Output, Self::Error>) -> JsResult<Self::JsEvent> {
+        match value {
+            Ok(flag) => Ok(cx.boolean(flag)),
+            Err(e) => cx.throw_error(e.to_string()),
+        }
+    }
+}

--- a/bindings/nodejs/native/src/classes/account_manager/mod.rs
+++ b/bindings/nodejs/native/src/classes/account_manager/mod.rs
@@ -17,6 +17,7 @@ use serde_repr::Deserialize_repr;
 use tokio::sync::RwLock;
 
 mod internal_transfer;
+mod is_latest_address_unused;
 mod sync;
 
 #[derive(Deserialize_repr)]
@@ -331,6 +332,18 @@ declare_types! {
                     manager.import_accounts(source, password).await
                 }).expect("error importing accounts");
             };
+            Ok(cx.undefined().upcast())
+        }
+
+        method isLatestAddressUnused(mut cx) {
+            let cb = cx.argument::<JsFunction>(0)?;
+
+            let this = cx.this();
+            let manager = cx.borrow(&this, |r| r.0.clone());
+            let task = is_latest_address_unused::IsLatestAddressUnusedTask {
+                manager,
+            };
+            task.schedule(cb);
             Ok(cx.undefined().upcast())
         }
     }

--- a/docs/src/libraries/nodejs/api_reference.md
+++ b/docs/src/libraries/nodejs/api_reference.md
@@ -128,10 +128,16 @@ Backups the database.
 
 Imports a database file.
 
-| Param    | Type                | Default                  | Description                    |
-| ------   | ------------------- | ----------------------   | ---------------------------    |
-| source   | <code>string</code> | <code>undefined</code>   | The path to the backup file    |
-| password | <code>string</code> | <code>undefined</code>   | The backup stronghold password |
+| Param    | Type                | Default                | Description                    |
+| -------- | ------------------- | ---------------------- | ------------------------------ |
+| source   | <code>string</code> | <code>undefined</code> | The path to the backup file    |
+| password | <code>string</code> | <code>undefined</code> | The backup stronghold password |
+
+#### isLatestAddressUnused()
+
+Determines whether all accounts has unused latest address after syncing with the Tangle.
+
+**Returns** A promise resolving to the boolean value.
 
 ### SyncedAccount
 
@@ -244,6 +250,12 @@ Synchronizes the account with the Tangle.
 
 **Returns** a [SyncedAccount](#syncedaccount) instance.
 
+#### isLatestAddressUnused()
+
+Determines whether the account has unused latest address after syncing with the Tangle.
+
+**Returns** A promise resolving to the boolean value.
+
 #### setAlias(alias)
 
 Updates the account alias.
@@ -274,7 +286,7 @@ Generates a new unused address and returns it.
 
 #### latestAddress()
 
-Returns the latest address (the one with the biggest keyIndex) or undefined if the account address list is empty.
+Returns the latest address (the one with the biggest keyIndex).
 
 ### ClientOptions
 

--- a/examples/transfer.rs
+++ b/examples/transfer.rs
@@ -27,7 +27,7 @@ async fn main() -> iota_wallet::Result<()> {
     sync_account
         .transfer(
             Transfer::builder(
-                account.latest_address().await.unwrap().address().clone(),
+                account.latest_address().await.address().clone(),
                 NonZeroU64::new(150).unwrap(),
             )
             .finish(),

--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -1010,7 +1010,7 @@ mod tests {
                     .create()
                     .await;
 
-                let spent_address = account_handle.generate_address().await.unwrap();
+                let spent_address = account_handle.latest_address().await;
                 let unspent_address1 = account_handle.generate_address().await.unwrap();
                 let unspent_address2 = account_handle.generate_address().await.unwrap();
 

--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     account_manager::AccountStore,
-    address::{Address, AddressWrapper},
+    address::{Address, AddressBuilder, AddressWrapper},
     client::ClientOptions,
     message::{Message, MessageType},
     signing::{GenerateAddressMetadata, SignerType},
@@ -227,6 +227,18 @@ impl AccountInitialiser {
             GenerateAddressMetadata { syncing: false },
         )
         .await?;
+
+        account.addresses.push(
+            AddressBuilder::new()
+                .address(address.clone())
+                .key_index(0)
+                .internal(false)
+                .outputs(Vec::new())
+                .balance(0)
+                .build()
+                .unwrap(), // safe to unwrap since we provide all required fields
+        );
+
         let mut digest = [0; 32];
         let raw = match address.as_ref() {
             iota::Address::Ed25519(a) => a.as_ref().to_vec(),
@@ -377,12 +389,23 @@ impl AccountHandle {
             .execute()
             .await?;
         // safe to clone since the `sync` guarantees a latest unused address
-        Ok(self.latest_address().await.unwrap())
+        Ok(self.latest_address().await)
+    }
+
+    /// Syncs the latest address with the Tangle and determines whether it's unused or not.
+    /// An unused address is an address without balance and associated message history.
+    /// Note that such address might have been used in the past, because the message history might have been pruned by
+    /// the node.
+    pub async fn is_latest_address_unused(&self) -> crate::Result<bool> {
+        let mut latest_address = self.latest_address().await;
+        let bech32_hrp = latest_address.address().bech32_hrp().to_string();
+        sync::sync_address(&*self.inner.read().await, &mut latest_address, bech32_hrp).await?;
+        Ok(*latest_address.balance() == 0 && latest_address.outputs().is_empty())
     }
 
     /// Bridge to [Account#latest_address](struct.Account.html#method.latest_address).
-    pub async fn latest_address(&self) -> Option<Address> {
-        self.inner.read().await.latest_address().cloned()
+    pub async fn latest_address(&self) -> Address {
+        self.inner.read().await.latest_address().clone()
     }
 
     /// Bridge to [Account#total_balance](struct.Account.html#method.total_balance).
@@ -471,11 +494,13 @@ impl Account {
     }
 
     /// Returns the most recent address of the account.
-    pub fn latest_address(&self) -> Option<&Address> {
+    pub fn latest_address(&self) -> &Address {
+        // the addresses list is never empty because we generate an address on the accout creation
         self.addresses
             .iter()
             .filter(|a| !a.internal())
             .max_by_key(|a| a.key_index())
+            .unwrap()
     }
 
     /// Gets the account's total balance.
@@ -792,7 +817,7 @@ mod tests {
                 let generated_address = account_handle.generate_address().await.unwrap();
 
                 assert_eq!(generated_address, account_next_address);
-                assert_eq!(account_handle.latest_address().await.unwrap(), generated_address);
+                assert_eq!(account_handle.latest_address().await, generated_address);
             },
         )
         .await;
@@ -802,7 +827,7 @@ mod tests {
     async fn latest_address() {
         let manager = crate::test_utils::get_account_manager().await;
         let (account_handle, latest_address, _) = _generate_account(&manager, vec![]).await;
-        assert_eq!(account_handle.read().await.latest_address(), Some(&latest_address));
+        assert_eq!(account_handle.read().await.latest_address(), &latest_address);
     }
 
     #[tokio::test]
@@ -864,7 +889,7 @@ mod tests {
             .addresses(vec![crate::test_utils::generate_random_address()])
             .create()
             .await;
-        let latest_address = account_handle.read().await.latest_address().unwrap().clone();
+        let latest_address = account_handle.read().await.latest_address().clone();
         let received_message = crate::test_utils::GenerateMessageBuilder::default()
             .address(latest_address.clone())
             .incoming(true)
@@ -900,7 +925,7 @@ mod tests {
             .await;
 
         let external_address = crate::test_utils::generate_random_address();
-        let latest_address = account_handle.read().await.latest_address().unwrap().clone();
+        let latest_address = account_handle.read().await.latest_address().clone();
 
         let received_message = crate::test_utils::GenerateMessageBuilder::default()
             .address(latest_address.clone())

--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -35,6 +35,97 @@ mod input_selection;
 
 const OUTPUT_LOCK_TIMEOUT: Duration = Duration::from_secs(30);
 
+pub(crate) async fn sync_address(
+    account: &Account,
+    address: &mut Address,
+    bech32_hrp: String,
+) -> crate::Result<Vec<(MessageId, Option<bool>, IotaMessage)>> {
+    let client = crate::client::get_client(account.client_options());
+    let client = client.read().await;
+
+    let iota_address = address.address();
+
+    let address_outputs = client.get_address().outputs(&iota_address.to_bech32().into()).await?;
+    let balance = client
+        .get_address()
+        .balance(&iota_address.to_bech32().into())
+        .await?
+        .balance;
+    let mut found_messages = vec![];
+
+    log::debug!(
+        "[SYNC] syncing address {}, got {} outputs and balance {}",
+        iota_address.to_bech32(),
+        address_outputs.len(),
+        balance
+    );
+
+    let mut found_outputs: Vec<AddressOutput> = vec![];
+    for output in address_outputs.iter() {
+        let output = client.get_output(output).await?;
+        let message_id = MessageId::new(
+            hex::decode(&output.message_id).map_err(|_| crate::Error::InvalidMessageId)?[..]
+                .try_into()
+                .map_err(|_| crate::Error::InvalidMessageIdLength)?,
+        );
+        found_outputs.push(AddressOutput::from_output_response(output, bech32_hrp.to_string())?);
+
+        // if we already have the message stored
+        // and the confirmation state is known
+        // we skip the `get_message` call
+        if account
+            .messages()
+            .iter()
+            .any(|m| m.id() == &message_id && m.confirmed().is_some())
+        {
+            continue;
+        }
+
+        if let Ok(message) = client.get_message().data(&message_id).await {
+            let metadata = client.get_message().metadata(&message_id).await?;
+            found_messages.push((
+                message_id,
+                metadata
+                    .ledger_inclusion_state
+                    .map(|l| l == LedgerInclusionStateDto::Included),
+                message,
+            ));
+        }
+    }
+
+    address.set_balance(balance);
+    address.set_outputs(found_outputs);
+
+    crate::Result::Ok(found_messages)
+}
+
+// Gets an address for the sync process.
+// If the account already has the address with the given index + internal flag, we'll use it
+// otherwise we'll generate a new one.
+async fn get_address_for_sync(
+    account: &Account,
+    bech32_hrp: String,
+    index: usize,
+    internal: bool,
+) -> crate::Result<AddressWrapper> {
+    if let Some(address) = account
+        .addresses()
+        .iter()
+        .find(|a| *a.key_index() == index && *a.internal() == internal)
+    {
+        Ok(address.address().clone())
+    } else {
+        crate::address::get_iota_address(
+            &account,
+            index,
+            false,
+            bech32_hrp,
+            GenerateAddressMetadata { syncing: true },
+        )
+        .await
+    }
+}
+
 /// Syncs addresses with the tangle.
 /// The method ensures that the wallet local state has all used addresses plus an unused address.
 ///
@@ -52,7 +143,7 @@ const OUTPUT_LOCK_TIMEOUT: Duration = Duration::from_secs(30);
 /// Returns a (addresses, messages) tuples representing the address history up to latest unused address,
 /// and the messages associated with the addresses.
 async fn sync_addresses(
-    account: &'_ Account,
+    account: &Account,
     address_index: usize,
     gap_limit: usize,
 ) -> crate::Result<(Vec<Address>, Vec<(MessageId, Option<bool>, IotaMessage)>)> {
@@ -74,109 +165,39 @@ async fn sync_addresses(
             generated_iota_addresses.push((
                 i,
                 false,
-                crate::address::get_iota_address(
-                    &account,
-                    i,
-                    false,
-                    bech32_hrp.to_string(),
-                    GenerateAddressMetadata { syncing: true },
-                )
-                .await?,
+                get_address_for_sync(&account, bech32_hrp.to_string(), i, false).await?,
             ));
             generated_iota_addresses.push((
                 i,
                 true,
-                crate::address::get_iota_address(
-                    &account,
-                    i,
-                    true,
-                    bech32_hrp.to_string(),
-                    GenerateAddressMetadata { syncing: true },
-                )
-                .await?,
+                get_address_for_sync(&account, bech32_hrp.to_string(), i, true).await?,
             ));
         }
 
         let mut curr_generated_addresses = vec![];
         let mut curr_found_messages = vec![];
 
-        let mut futures_ = vec![];
+        let mut futures_ = Vec::new();
         for (iota_address_index, iota_address_internal, iota_address) in &generated_iota_addresses {
             let bech32_hrp_ = bech32_hrp.clone();
             futures_.push(async move {
-                let client = crate::client::get_client(account.client_options());
-                let client = client.read().await;
-
-                let address_outputs = client.get_address().outputs(&iota_address.to_bech32().into()).await?;
-                let balance = client
-                    .get_address()
-                    .balance(&iota_address.to_bech32().into())
-                    .await?
-                    .balance;
-                let mut curr_found_messages = vec![];
-
-                log::debug!(
-                    "[SYNC] syncing address {}, got {} outputs and balance {}",
-                    iota_address.to_bech32(),
-                    address_outputs.len(),
-                    balance
-                );
-
-                let mut curr_found_outputs: Vec<AddressOutput> = vec![];
-                for output in address_outputs.iter() {
-                    let output = client.get_output(output).await?;
-                    let message_id = MessageId::new(
-                        hex::decode(&output.message_id).map_err(|_| crate::Error::InvalidMessageId)?[..]
-                            .try_into()
-                            .map_err(|_| crate::Error::InvalidMessageIdLength)?,
-                    );
-                    curr_found_outputs.push(AddressOutput::from_output_response(output, bech32_hrp_.to_string())?);
-
-                    // if we already have the message stored
-                    // and the confirmation state is known
-                    // we skip the `get_message` call
-                    if account
-                        .messages()
-                        .iter()
-                        .any(|m| m.id() == &message_id && m.confirmed().is_some())
-                    {
-                        continue;
-                    }
-
-                    if let Ok(message) = client.get_message().data(&message_id).await {
-                        let metadata = client.get_message().metadata(&message_id).await?;
-                        curr_found_messages.push((
-                            message_id,
-                            metadata
-                                .ledger_inclusion_state
-                                .map(|l| l == LedgerInclusionStateDto::Included),
-                            message,
-                        ));
-                    }
-                }
-
-                // ignore unused change addresses
-                if *iota_address_internal && curr_found_outputs.is_empty() {
-                    log::debug!("[SYNC] ignoring address because it's internal and the output list is empty");
-                    return crate::Result::Ok((curr_found_messages, None));
-                }
-
-                let address = AddressBuilder::new()
+                let mut address = AddressBuilder::new()
                     .address(iota_address.clone())
                     .key_index(*iota_address_index)
-                    .balance(balance)
-                    .outputs(curr_found_outputs)
+                    .balance(0)
+                    .outputs(Vec::new())
                     .internal(*iota_address_internal)
                     .build()?;
-
-                crate::Result::Ok((curr_found_messages, Some(address)))
+                let messages = sync_address(&account, &mut address, bech32_hrp_).await?;
+                crate::Result::Ok((messages, address))
             });
         }
 
         let results = futures::future::join_all(futures_).await;
         for result in results {
-            let (found_messages, address_opt) = result?;
-            if let Some(address) = address_opt {
+            let (found_messages, address) = result?;
+            // if the address is a change address and has no outputs, we ignore it
+            if !(*address.internal() && address.outputs().is_empty()) {
                 curr_generated_addresses.push(address);
             }
             curr_found_messages.extend(found_messages);
@@ -463,7 +484,7 @@ impl AccountSynchronizer {
                 let synced_account = SyncedAccount {
                     account_id: account_ref.id().to_string(),
                     account_handle: self.account_handle.clone(),
-                    deposit_address: account_ref.latest_address().unwrap().clone(),
+                    deposit_address: account_ref.latest_address().clone(),
                     is_empty,
                     addresses: account_ref
                         .addresses()
@@ -806,7 +827,7 @@ async fn perform_transfer(
             // generate a new change address to send the remainder value
             RemainderValueStrategy::ChangeAddress => {
                 if *remainder_address.internal() {
-                    let deposit_address = account_.latest_address().unwrap().address().clone();
+                    let deposit_address = account_.latest_address().address().clone();
                     log::debug!(
                         "[TRANSFER] the remainder address is internal, so using latest address as remainder target: {}",
                         deposit_address.to_bech32()
@@ -898,7 +919,7 @@ async fn perform_transfer(
 
     // if this is a transfer to the account's latest address or we used the latest as deposit of the remainder
     // value, we generate a new one to keep the latest address unused
-    let latest_address = account_.latest_address().unwrap().address();
+    let latest_address = account_.latest_address().address();
     if latest_address == &transfer_obj.address
         || (remainder_value_deposit_address.is_some() && &remainder_value_deposit_address.unwrap() == latest_address)
     {

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -386,6 +386,17 @@ impl AccountManager {
         Ok(())
     }
 
+    /// Determines whether all accounts has the latest address unused.
+    pub async fn is_latest_address_unused(&self) -> crate::Result<bool> {
+        self.check_storage_encryption()?;
+        for account_handle in self.accounts.read().await.values() {
+            if !account_handle.is_latest_address_unused().await? {
+                return Ok(false);
+            }
+        }
+        Ok(true)
+    }
+
     /// Starts the polling mechanism.
     fn start_polling(
         &mut self,
@@ -547,7 +558,6 @@ impl AccountManager {
             .read()
             .await
             .latest_address()
-            .ok_or(crate::Error::InternalTransferDestinationEmpty)?
             .clone();
 
         let from_synchronized = self.get_account(from_account_id).await?.sync().await.execute().await?;

--- a/src/actor/message.rs
+++ b/src/actor/message.rs
@@ -78,6 +78,8 @@ pub enum AccountMethod {
         #[serde(rename = "skipPersistance")]
         skip_persistance: Option<bool>,
     },
+    /// Checks if the account's latest address is unused after syncing with the Tangle.
+    IsLatestAddressUnused,
 }
 
 /// The messages that can be sent to the actor.
@@ -172,6 +174,8 @@ pub enum MessageType {
         /// The mnemonic. If empty, we'll generate one.
         mnemonic: Option<String>,
     },
+    /// Checks if all accounts has unused latest address after syncing with the Tangle.
+    IsLatestAddressUnused,
 }
 
 impl Serialize for MessageType {
@@ -231,6 +235,9 @@ impl Serialize for MessageType {
                 signer_type: _,
                 mnemonic: _,
             } => serializer.serialize_unit_variant("MessageType", 17, "StoreMnemonic"),
+            MessageType::IsLatestAddressUnused => {
+                serializer.serialize_unit_variant("MessageType", 17, "IsLatestAddressUnused")
+            }
         }
     }
 }
@@ -281,7 +288,7 @@ pub enum ResponseType {
     /// GetUnusedAddress response.
     UnusedAddress(Address),
     /// GetLatestAddress response.
-    LatestAddress(Option<Address>),
+    LatestAddress(Address),
     /// GetAvailableBalance response.
     AvailableBalance(u64),
     /// GetTotalBalance response.
@@ -326,6 +333,8 @@ pub enum ResponseType {
     VerifiedMnemonic,
     /// StoreMnemonic response.
     StoredMnemonic,
+    /// IsLatestAddressUnused response.
+    IsLatestAddressUnused(bool),
 }
 
 /// The message type.

--- a/src/actor/mod.rs
+++ b/src/actor/mod.rs
@@ -142,6 +142,15 @@ impl WalletMessageHandler {
                 })
                 .await
             }
+            MessageType::IsLatestAddressUnused => {
+                convert_async_panics(|| async {
+                    self.account_manager
+                        .is_latest_address_unused()
+                        .await
+                        .map(ResponseType::IsLatestAddressUnused)
+                })
+                .await
+            }
             MessageType::SendTransfer { account_id, transfer } => {
                 convert_async_panics(|| async { self.send_transfer(account_id, transfer.clone().finish()).await }).await
             }
@@ -251,7 +260,7 @@ impl WalletMessageHandler {
             }
             AccountMethod::GetLatestAddress => {
                 let account = account_handle.read().await;
-                Ok(ResponseType::LatestAddress(account.latest_address().cloned()))
+                Ok(ResponseType::LatestAddress(account.latest_address().clone()))
             }
             AccountMethod::SyncAccount {
                 address_index,
@@ -273,6 +282,9 @@ impl WalletMessageHandler {
                 let synced = synchronizer.execute().await?;
                 Ok(ResponseType::SyncedAccount(synced))
             }
+            AccountMethod::IsLatestAddressUnused => Ok(ResponseType::IsLatestAddressUnused(
+                account_handle.is_latest_address_unused().await?,
+            )),
         }
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -93,9 +93,6 @@ pub enum Error {
     /// Panic error.
     #[error("a panic happened: {0}")]
     Panic(String),
-    /// Error on `internal_transfer` when the destination account address list is empty
-    #[error("destination account has no addresses")]
-    InternalTransferDestinationEmpty,
     /// Invalid message identifier.
     #[error("invalid message id received by node")]
     InvalidMessageId,
@@ -226,9 +223,6 @@ impl serde::Serialize for Error {
             Self::InvalidRemainderValueAddress => serialize_variant(self, serializer, "InvalidRemainderValueAddress"),
             Self::Storage(_) => serialize_variant(self, serializer, "Storage"),
             Self::Panic(_) => serialize_variant(self, serializer, "Panic"),
-            Self::InternalTransferDestinationEmpty => {
-                serialize_variant(self, serializer, "InternalTransferDestinationEmpty")
-            }
             Self::InvalidMessageId => serialize_variant(self, serializer, "InvalidMessageId"),
             Self::InvalidTransactionId => serialize_variant(self, serializer, "InvalidTransactionId"),
             Self::AddressBuildRequiredField(_) => serialize_variant(self, serializer, "AddressBuildRequiredField"),


### PR DESCRIPTION
# Description of change

Adds a `isLatestAddressUnused` method to the AccountManager and the Account - it syncs the latest address with the Tangle and returns a bool indicating whether it's unused or not.

## Links to any relevant issues

N/A

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

CLI Wallet.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
