### PR TITLE
refactor: balance as single fn, return object with incoming & outgoing

### DIFF
--- a/bindings/nodejs/README.md
+++ b/bindings/nodejs/README.md
@@ -283,13 +283,11 @@ Returns the account's index.
 
 Returns the account's alias.
 
-#### availableBalance()
+#### balance(): AccountBalance
 
-Returns the account's available balance.
+Returns the account's balance information object.
 
-#### totalBalance()
-
-Returns the account's total balance.
+Balance object: { total: number, available: number, incoming: number, outgoing: number }
 
 #### listMessages([count, from, type])
 

--- a/bindings/nodejs/examples/1-create-account.js
+++ b/bindings/nodejs/examples/1-create-account.js
@@ -22,7 +22,7 @@ async function run() {
     })
 
     console.log('alias', account.alias())
-    console.log('balance', account.availableBalance())
+    console.log('balance', account.balance())
     
     console.log('syncing account now')
 

--- a/bindings/nodejs/examples/2-sync-and-check.js
+++ b/bindings/nodejs/examples/2-sync-and-check.js
@@ -12,7 +12,7 @@ async function run() {
     const account = manager.getAccountByAlias('Test')
 
     console.log('alias', account.alias())
-    console.log('available balance', account.availableBalance())
+    console.log('available balance', account.balance().available)
     console.log('syncing...')
     
     const synced = await account.sync()

--- a/bindings/nodejs/examples/3-send.js
+++ b/bindings/nodejs/examples/3-send.js
@@ -12,7 +12,7 @@ async function run() {
     const account = manager.getAccountByAlias('Test')
 
     console.log('alias', account.alias())
-    console.log('available balance', account.availableBalance())
+    console.log('available balance', account.balance().available)
     console.log('syncing...')
     
     const synced = await account.sync()

--- a/bindings/nodejs/lib/index.d.ts
+++ b/bindings/nodejs/lib/index.d.ts
@@ -59,12 +59,18 @@ export declare interface SyncOptions {
   skipPersistance?: boolean
 }
 
+export declare interface AccountBalance {
+  total: number
+  available: number
+  incoming: number
+  outgoing: number
+}
+
 export declare class Account {
   id(): string;
   index(): number;
   alias(): string;
-  availableBalance(): number;
-  totalBalance(): number;
+  balance(): AccountBalance;
   listMessages(count?: number, from?: number, messageType?: MessageType): Message[]
   listAddresses(unspent?: boolean): Address[]
   sync(options?: SyncOptions): Promise<SyncedAccount>

--- a/bindings/nodejs/native/src/classes/account/mod.rs
+++ b/bindings/nodejs/native/src/classes/account/mod.rs
@@ -57,30 +57,17 @@ declare_types! {
             Ok(cx.string(alias).upcast())
         }
 
-        method availableBalance(mut cx) {
+        method balance(mut cx) {
             let balance = {
                 let this = cx.this();
                 let guard = cx.lock();
                 let id = &this.borrow(&guard).0;
                 crate::block_on(async move {
                     let account_handle = crate::get_account(id).await;
-                    account_handle.available_balance().await
+                    account_handle.balance().await
                 })
             };
-            Ok(cx.number(balance as f64).upcast())
-        }
-
-        method totalBalance(mut cx) {
-            let balance = {
-                let this = cx.this();
-                let guard = cx.lock();
-                let id = &this.borrow(&guard).0;
-                crate::block_on(async move {
-                    let account_handle = crate::get_account(id).await;
-                    account_handle.total_balance().await
-                })
-            };
-            Ok(cx.number(balance as f64).upcast())
+            Ok(neon_serde::to_value(&mut cx, &balance)?.upcast())
         }
 
         method listMessages(mut cx) {

--- a/docs/src/libraries/nodejs/api_reference.md
+++ b/docs/src/libraries/nodejs/api_reference.md
@@ -208,13 +208,11 @@ Returns the account's index.
 
 Returns the account's alias.
 
-#### availableBalance()
+#### balance(): AccountBalance
 
-Returns the account's available balance.
+Returns the account's balance information object.
 
-#### totalBalance()
-
-Returns the account's total balance.
+Balance object: { total: number, available: number, incoming: number, outgoing: number }
 
 #### listMessages([count, from, type])
 

--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -524,7 +524,7 @@ impl Account {
                     if *message.incoming() {
                         (incoming + *message.value(), outgoing)
                     } else {
-                        (incoming + *message.remainder_value(), outgoing + *message.value())
+                        (incoming, outgoing + *message.value())
                     }
                 });
         AccountBalance {

--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -517,13 +517,16 @@ impl Account {
 
     /// Gets the account balance information.
     pub fn balance(&self) -> AccountBalance {
-        let (incoming, outgoing) = self.messages.iter().fold((0, 0), |(incoming, outgoing), message| {
-            if *message.incoming() {
-                (incoming + *message.value(), outgoing)
-            } else {
-                (incoming, outgoing + *message.value())
-            }
-        });
+        let (incoming, outgoing) =
+            self.list_messages(0, 0, None)
+                .iter()
+                .fold((0, 0), |(incoming, outgoing), message| {
+                    if *message.incoming() {
+                        (incoming + *message.value(), outgoing)
+                    } else {
+                        (incoming + *message.remainder_value(), outgoing + *message.value())
+                    }
+                });
         AccountBalance {
             total: self.addresses.iter().fold(0, |acc, address| acc + address.balance()),
             available: self

--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -187,7 +187,7 @@ impl AccountInitialiser {
 
         if let Some(latest_account_handle) = accounts.values().last() {
             let latest_account = latest_account_handle.read().await;
-            if latest_account.messages().is_empty() && latest_account.total_balance() == 0 {
+            if latest_account.messages().is_empty() && latest_account.balance().total == 0 {
                 return Err(crate::Error::LatestAccountIsEmpty);
             }
         }
@@ -408,14 +408,9 @@ impl AccountHandle {
         self.inner.read().await.latest_address().clone()
     }
 
-    /// Bridge to [Account#total_balance](struct.Account.html#method.total_balance).
-    pub async fn total_balance(&self) -> u64 {
-        self.inner.read().await.total_balance()
-    }
-
-    /// Bridge to [Account#available_balance](struct.Account.html#method.available_balance).
-    pub async fn available_balance(&self) -> u64 {
-        self.inner.read().await.available_balance()
+    /// Bridge to [Account#balance](struct.Account.html#method.balance).
+    pub async fn balance(&self) -> AccountBalance {
+        self.inner.read().await.balance()
     }
 
     /// Bridge to [Account#set_alias](struct.Account.html#method.set_alias).
@@ -473,6 +468,23 @@ impl AccountHandle {
     }
 }
 
+/// Account balance information.
+#[derive(Debug, Serialize)]
+pub struct AccountBalance {
+    /// Account's total balance.
+    pub total: u64,
+    // The available balance is the balance users are allowed to spend.
+    /// For example, if a user with 50i total account balance has made a message spending 20i,
+    /// the available balance should be (50i-30i) = 20i.
+    pub available: u64,
+    /// Balances from message with `incoming: true`.
+    /// Note that this may not be accurate since the node prunes the messags.
+    pub incoming: u64,
+    /// Balances from message with `incoming: false`.
+    /// Note that this may not be accurate since the node prunes the messags.
+    pub outgoing: u64,
+}
+
 impl Account {
     pub(crate) async fn save(&mut self) -> crate::Result<()> {
         if !self.skip_persistance {
@@ -503,22 +515,24 @@ impl Account {
             .unwrap()
     }
 
-    /// Gets the account's total balance.
-    /// It's read directly from the storage. To read the latest account balance, you should `sync` first.
-    pub fn total_balance(&self) -> u64 {
-        self.addresses.iter().fold(0, |acc, address| acc + address.balance())
-    }
-
-    /// Gets the account's available balance.
-    /// It's read directly from the storage. To read the latest account balance, you should `sync` first.
-    ///
-    /// The available balance is the balance users are allowed to spend.
-    /// For example, if a user with 50i total account balance has made a message spending 20i,
-    /// the available balance should be (50i-30i) = 20i.
-    pub fn available_balance(&self) -> u64 {
-        self.addresses()
-            .iter()
-            .fold(0, |acc, addr| acc + addr.available_balance(&self))
+    /// Gets the account balance information.
+    pub fn balance(&self) -> AccountBalance {
+        let (incoming, outgoing) = self.messages.iter().fold((0, 0), |(incoming, outgoing), message| {
+            if *message.incoming() {
+                (incoming + *message.value(), outgoing)
+            } else {
+                (incoming, outgoing + *message.value())
+            }
+        });
+        AccountBalance {
+            total: self.addresses.iter().fold(0, |acc, address| acc + address.balance()),
+            available: self
+                .addresses()
+                .iter()
+                .fold(0, |acc, addr| acc + addr.available_balance(&self)),
+            incoming,
+            outgoing,
+        }
     }
 
     /// Updates the account alias.
@@ -834,14 +848,14 @@ mod tests {
     async fn total_balance() {
         let manager = crate::test_utils::get_account_manager().await;
         let (account_handle, _, balance) = _generate_account(&manager, vec![]).await;
-        assert_eq!(account_handle.read().await.total_balance(), balance);
+        assert_eq!(account_handle.read().await.balance().total, balance);
     }
 
     #[tokio::test]
     async fn available_balance() {
         let manager = crate::test_utils::get_account_manager().await;
         let (account_handle, _, balance) = _generate_account(&manager, vec![]).await;
-        assert_eq!(account_handle.read().await.available_balance(), balance);
+        assert_eq!(account_handle.read().await.balance().available, balance);
 
         let first_address = {
             let mut account = account_handle.write().await;
@@ -877,7 +891,7 @@ mod tests {
             .append_messages(vec![unconfirmed_message.clone(), confirmed_message]);
 
         assert_eq!(
-            account_handle.read().await.available_balance(),
+            account_handle.read().await.balance().available,
             balance - *unconfirmed_message.value()
         );
     }

--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -603,11 +603,13 @@ impl SyncedAccount {
         // prepare the transfer getting some needed objects and values
         let value = transfer_obj.amount.get();
 
-        if value > account_.total_balance() {
+        let balance = account_.balance();
+
+        if value > balance.total {
             return Err(crate::Error::InsufficientFunds);
         }
 
-        let available_balance = account_.available_balance();
+        let available_balance = balance.available;
         drop(account_);
 
         // if the transfer value exceeds the account's available balance,
@@ -623,7 +625,7 @@ impl SyncedAccount {
                     thread::sleep(OUTPUT_LOCK_TIMEOUT / 30);
                     let account = crate::block_on(async { account_handle.read().await });
                     // the account received an update and now the balance is sufficient
-                    if value <= account.available_balance() {
+                    if value <= account.balance().available {
                         let _ = tx.send(());
                         break;
                     }

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -517,7 +517,7 @@ impl AccountManager {
             let account_handle = self.get_account(account_id).await?;
             let account = account_handle.read().await;
 
-            if !(account.messages().is_empty() && account.total_balance() == 0) {
+            if !(account.messages().is_empty() && account.balance().total == 0) {
                 return Err(crate::Error::AccountNotEmpty);
             }
 

--- a/src/actor/message.rs
+++ b/src/actor/message.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    account::{Account, AccountIdentifier, SyncedAccount},
+    account::{Account, AccountBalance, AccountIdentifier, SyncedAccount},
     address::Address,
     client::ClientOptions,
     message::{Message as WalletMessage, MessageType as WalletMessageType, TransferBuilder},
@@ -60,10 +60,8 @@ pub enum AccountMethod {
     ListSpentAddresses,
     /// List unspent addresses.
     ListUnspentAddresses,
-    /// Get available balance.
-    GetAvailableBalance,
-    /// Get total balance.
-    GetTotalBalance,
+    /// Get account balance information.
+    GetBalance,
     /// Get latest address.
     GetLatestAddress,
     /// Sync the account.
@@ -293,10 +291,8 @@ pub enum ResponseType {
     UnusedAddress(Address),
     /// GetLatestAddress response.
     LatestAddress(Address),
-    /// GetAvailableBalance response.
-    AvailableBalance(u64),
-    /// GetTotalBalance response.
-    TotalBalance(u64),
+    /// GetBalance response.
+    Balance(AccountBalance),
     /// SyncAccounts response.
     SyncedAccounts(Vec<SyncedAccount>),
     /// SyncAccount response.

--- a/src/actor/mod.rs
+++ b/src/actor/mod.rs
@@ -251,12 +251,7 @@ impl WalletMessageHandler {
                 let addresses = account_handle.list_unspent_addresses().await;
                 Ok(ResponseType::Addresses(addresses))
             }
-            AccountMethod::GetAvailableBalance => Ok(ResponseType::AvailableBalance(
-                account_handle.read().await.available_balance(),
-            )),
-            AccountMethod::GetTotalBalance => {
-                Ok(ResponseType::TotalBalance(account_handle.read().await.total_balance()))
-            }
+            AccountMethod::GetBalance => Ok(ResponseType::Balance(account_handle.read().await.balance())),
             AccountMethod::GetLatestAddress => Ok(ResponseType::LatestAddress(
                 account_handle.read().await.latest_address().clone(),
             )),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -493,6 +493,7 @@ mod test_utils {
                 timestamp: chrono::Utc::now(),
                 nonce: 0,
                 value: self.value,
+                remainder_value: 0,
                 confirmed: Some(self.confirmed),
                 broadcasted: self.broadcasted,
                 incoming: self.incoming,


### PR DESCRIPTION
# Description of change

Moves `total_balance` and `available_balance` to a single `balance()` object, and add `incoming` and `outgoing` balance.

## Links to any relevant issues

N/A

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

Unit tests.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
