### PR TITLE
feature(ci): Move Node.js bindings to its own job

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,7 +11,7 @@ on:
       - 'specs/**'
 
 jobs:
-  build-and-test:
+  crate:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -71,16 +71,6 @@ jobs:
         restore-keys: |
           ${{ matrix.os }}-stable-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
           ${{ matrix.os }}-stable-cargo-build-target-
-    - name: Cache nodejs binding cargo target
-      uses: actions/cache@v2
-      with:
-        path: bindings/nodejs/native/target
-        # Add date to the cache to keep it up to date
-        key: ${{ matrix.os }}-stable-cargo-build-node-target-${{ hashFiles('**/Cargo.lock') }}-${{ env.CURRENT_DATE }}
-        # Restore from outdated cache for speed
-        restore-keys: |
-          ${{ matrix.os }}-stable-cargo-build-node-target-${{ hashFiles('**/Cargo.lock') }}
-          ${{ matrix.os }}-stable-cargo-build-node-target-
 
     # paho.mqtt requires openssl and OPENSSL_DIR on Windows
     - name: Install OpenSSL (Windows)
@@ -101,6 +91,76 @@ jobs:
         command: test
         args: --all-features --release
 
-    - name: Build nodejs binding
-      run: yarn
-      working-directory: bindings/nodejs
+  nodejs-bindings:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Get current date
+        run: echo "CURRENT_DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+        if: matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest'
+
+      - name: Get current date
+        if: matrix.os == 'windows-latest'
+        run: echo "CURRENT_DATE=$(Get-Date -Format "yyyy-MM-dd")" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Install required packages (Ubuntu)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install libudev-dev libusb-1.0-0-dev
+
+      - name: Cache cargo registry
+        uses: actions/cache@v2
+        with:
+          path: ~/.cargo/registry
+          # Add date to the cache to keep it up to date
+          key: ${{ matrix.os }}-stable-cargo-registry-${{ hashFiles('**/Cargo.lock') }}-${{ env.CURRENT_DATE }}
+          # Restore from outdated cache for speed
+          restore-keys: |
+            ${{ matrix.os }}-stable-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+            ${{ matrix.os }}-stable-cargo-registry-
+
+      - name: Cache cargo index
+        uses: actions/cache@v2
+        with:
+          path: ~/.cargo/git
+          # Add date to the cache to keep it up to date
+          key: ${{ matrix.os }}-stable-cargo-index-${{ hashFiles('**/Cargo.lock') }}-${{ env.CURRENT_DATE }}
+          # Restore from outdated cache for speed
+          restore-keys: |
+            ${{ matrix.os }}-stable-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+            ${{ matrix.os }}-stable-cargo-index-
+     
+      - name: Cache nodejs binding cargo target
+        uses: actions/cache@v2
+        with:
+          path: bindings/nodejs/native/target
+          # Add date to the cache to keep it up to date
+          key: ${{ matrix.os }}-stable-cargo-build-node-target-${{ hashFiles('**/Cargo.lock') }}-${{ env.CURRENT_DATE }}
+          # Restore from outdated cache for speed
+          restore-keys: |
+            ${{ matrix.os }}-stable-cargo-build-node-target-${{ hashFiles('**/Cargo.lock') }}
+            ${{ matrix.os }}-stable-cargo-build-node-target-
+
+      # paho.mqtt requires openssl and OPENSSL_DIR on Windows
+      - name: Install OpenSSL (Windows)
+        if: matrix.os == 'windows-latest'
+        run: |
+          choco install openssl --no-progress
+          echo "OPENSSL_DIR=C:\Program Files\OpenSSL-Win64" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Build nodejs binding
+        run: yarn
+        working-directory: bindings/nodejs


### PR DESCRIPTION
# Description of change

Moves building of Node.js bindings to its own job to speed up the CI pipeline

## Links to any relevant issues

N/A

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

N/A

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code