### PR TITLE
fix(transfer): can't duplicate addresses on the transaction payload outputs

### DIFF
--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -13,7 +13,7 @@ use chrono::prelude::{DateTime, Local};
 use getset::{Getters, Setters};
 use iota::message::prelude::MessageId;
 use serde::{Deserialize, Serialize};
-use tokio::sync::{Mutex, RwLock};
+use tokio::sync::{Mutex, RwLock, RwLockWriteGuard};
 
 use std::{
     hash::{Hash, Hasher},
@@ -366,6 +366,14 @@ impl AccountHandle {
     /// Gets a new unused address and links it to this account.
     pub async fn generate_address(&self) -> crate::Result<Address> {
         let mut account = self.inner.write().await;
+        self.generate_address_internal(&mut account).await
+    }
+
+    /// Generates an address without locking the account.
+    pub(crate) async fn generate_address_internal(
+        &self,
+        account: &mut RwLockWriteGuard<'_, Account>,
+    ) -> crate::Result<Address> {
         let address = crate::address::get_new_address(&account, GenerateAddressMetadata { syncing: false }).await?;
 
         account

--- a/src/account/sync/input_selection.rs
+++ b/src/account/sync/input_selection.rs
@@ -134,6 +134,7 @@ mod tests {
             available_utxos.push(super::Input {
                 address: address.address().clone(),
                 balance: *address.balance(),
+                internal: false,
             });
         }
         available_utxos


### PR DESCRIPTION
# Description of change

Fixes an issue with the `outputs` array on the transfer - can't be duplicated.
Also changes the input selection to prioritize change addresses.

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

CLI wallet.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
