### PR TITLE
fix(actor): GetStrongholdStatus when not using stronghold as storage

### DIFF
--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -291,6 +291,17 @@ impl AccountManager {
         Ok((Arc::new(RwLock::new(parsed_accounts)), encrypted_accounts))
     }
 
+    #[cfg(any(feature = "stronghold", feature = "stronghold-storage"))]
+    pub(crate) async fn stronghold_snapshot_path(&self) -> crate::Result<PathBuf> {
+        let storage_id = crate::storage::get(&self.storage_path).await?.lock().await.id();
+        let stronghold_snapshot_path = if storage_id == crate::storage::stronghold::STORAGE_ID {
+            self.storage_path.clone()
+        } else {
+            self.storage_folder.join(STRONGHOLD_FILENAME)
+        };
+        Ok(stronghold_snapshot_path)
+    }
+
     // error out if the storage is encrypted
     fn check_storage_encryption(&self) -> crate::Result<()> {
         if self.encrypted_accounts.is_empty() {
@@ -588,7 +599,7 @@ impl AccountManager {
             any(feature = "stronghold", feature = "stronghold-storage")
         ))]
         let (storage_path, backup_entire_directory) = {
-            let storage_id = crate::storage::get(&&self.storage_path).await?.lock().await.id();
+            let storage_id = crate::storage::get(&self.storage_path).await?.lock().await.id();
             // if we're actually using the SQLite storage adapter
             let storage_path = if storage_id == crate::storage::sqlite::STORAGE_ID {
                 // create a account manager to setup the stronghold storage for the backup
@@ -1395,7 +1406,7 @@ mod tests {
             #[cfg(any(feature = "stronghold", feature = "stronghold-storage"))]
             {
                 // wait for stronghold to finish pending operations and delete the storage file
-                crate::stronghold::unload_snapshot(manager.storage_path(), false)
+                crate::stronghold::unload_snapshot(&manager.stronghold_snapshot_path().await.unwrap(), false)
                     .await
                     .unwrap();
                 let _ = crate::stronghold::actor_runtime().lock().await;

--- a/src/actor/mod.rs
+++ b/src/actor/mod.rs
@@ -118,7 +118,8 @@ impl WalletMessageHandler {
             #[cfg(any(feature = "stronghold", feature = "stronghold-storage"))]
             MessageType::GetStrongholdStatus => {
                 convert_async_panics(|| async {
-                    let status = crate::stronghold::get_status(self.account_manager.storage_path()).await;
+                    let status =
+                        crate::stronghold::get_status(&self.account_manager.stronghold_snapshot_path().await?).await;
                     Ok(ResponseType::StrongholdStatus(status))
                 })
                 .await


### PR DESCRIPTION
# Description of change

Currently there's an issue with the GetStrongholdStatus message - it passes the storage path to `stronghold::get_status`, which might be a SQLite file path, and should be the stronghold snapshot path. 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Firefly, CLI wallet.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
