### PR TITLE
reference unlock block index fix

### DIFF
--- a/src/signing/stronghold.rs
+++ b/src/signing/stronghold.rs
@@ -58,11 +58,10 @@ impl super::Signer for StrongholdSigner {
         let serialized_essence = essence.pack_new();
 
         let mut unlock_blocks = vec![];
-        let mut current_block_index: usize = 0;
         let mut signature_indexes = HashMap::<usize, usize>::new();
         inputs.sort_by(|a, b| a.input.cmp(&b.input));
 
-        for recorder in inputs.iter() {
+        for (current_block_index, recorder) in inputs.iter().enumerate() {
             // Check if current path is same as previous path
             // If so, add a reference unlock block
             if let Some(block_index) = signature_indexes.get(&recorder.address_index) {
@@ -79,9 +78,6 @@ impl super::Signer for StrongholdSigner {
                 .await?;
                 unlock_blocks.push(UnlockBlock::Signature(signature.into()));
                 signature_indexes.insert(recorder.address_index, current_block_index);
-
-                // Update current block index
-                current_block_index += 1;
             }
         }
         Ok(unlock_blocks)


### PR DESCRIPTION
# Description of change

Fixes the wrong reference-unlock-blocks-indices (issue [265](https://github.com/iotaledger/wallet.rs/issues/265) )

## Type of change

Bug fix

## How the change has been tested

Tested in a separate test-programm (but not within wallet.rs)

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [X] I have followed the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
