### PR TITLE
fix(sync): don't error out if message was pruned

### DIFF
--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -82,14 +82,15 @@ pub(crate) async fn sync_address(
         }
 
         if let Ok(message) = client.get_message().data(&message_id).await {
-            let metadata = client.get_message().metadata(&message_id).await?;
-            found_messages.push((
-                message_id,
-                metadata
-                    .ledger_inclusion_state
-                    .map(|l| l == LedgerInclusionStateDto::Included),
-                message,
-            ));
+            if let Ok(metadata) = client.get_message().metadata(&message_id).await {
+                found_messages.push((
+                    message_id,
+                    metadata
+                        .ledger_inclusion_state
+                        .map(|l| l == LedgerInclusionStateDto::Included),
+                    message,
+                ));
+            }
         }
     }
 
@@ -286,14 +287,15 @@ async fn sync_messages(
                     }
 
                     if let Ok(message) = client.get_message().data(&output_message_id).await {
-                        let metadata = client.get_message().metadata(&output_message_id).await?;
-                        messages.push((
-                            output_message_id,
-                            metadata
-                                .ledger_inclusion_state
-                                .map(|l| l == LedgerInclusionStateDto::Included),
-                            message,
-                        ));
+                        if let Ok(metadata) = client.get_message().metadata(&output_message_id).await {
+                            messages.push((
+                                output_message_id,
+                                metadata
+                                    .ledger_inclusion_state
+                                    .map(|l| l == LedgerInclusionStateDto::Included),
+                                message,
+                            ));
+                        }
                     }
                 }
 


### PR DESCRIPTION
# Description of change

Ignore errors when getting a message metadata on the sync process (the message might be pruned).

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
