### PR TITLE
fix(stronghold): load before setting current snapshot path

### DIFF
--- a/src/stronghold.rs
+++ b/src/stronghold.rs
@@ -322,12 +322,12 @@ async fn check_snapshot(mut runtime: &mut ActorRuntime, snapshot_path: &PathBuf)
             switch_snapshot(&mut runtime, snapshot_path).await?;
         }
     } else {
+        load_actors(&mut runtime, snapshot_path).await?;
         CURRENT_SNAPSHOT_PATH
             .get_or_init(Default::default)
             .lock()
             .await
             .replace(snapshot_path.clone());
-        load_actors(&mut runtime, snapshot_path).await?;
     }
 
     Ok(())
@@ -386,14 +386,13 @@ async fn load_actors(mut runtime: &mut ActorRuntime, snapshot_path: &PathBuf) ->
 
 async fn switch_snapshot(mut runtime: &mut ActorRuntime, snapshot_path: &PathBuf) -> Result<()> {
     clear_stronghold_cache(&mut runtime, true).await?;
+    load_actors(&mut runtime, snapshot_path).await?;
 
     CURRENT_SNAPSHOT_PATH
         .get_or_init(Default::default)
         .lock()
         .await
         .replace(snapshot_path.clone());
-
-    load_actors(&mut runtime, snapshot_path).await?;
 
     Ok(())
 }


### PR DESCRIPTION
# Description of change

Fixes stronghold load issue where subsequent wrong passwords wouldn't return errors.

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Unit tests, Firefly.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have checked that new and existing unit tests pass locally with my changes
