### PR TITLE
fix(sync): `sync_addresses` condition on `is_empty` flag

### DIFF
--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -212,7 +212,7 @@ async fn sync_addresses(
         let is_empty = curr_found_messages.is_empty()
             && curr_generated_addresses
                 .iter()
-                .all(|address| !address.outputs().iter().any(|output| *output.is_spent()));
+                .all(|address| address.outputs().is_empty());
 
         found_messages.extend(curr_found_messages.into_iter());
         generated_addresses.extend(curr_generated_addresses.into_iter());


### PR DESCRIPTION
# Description of change

Currently the sync process isn't finding all addresses, this PR fixes it. 

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

CLI Wallet.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
