### PR TITLE
fix(message): incorrect `value` field on internal transfers

### DIFF
--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -853,9 +853,11 @@ async fn perform_transfer(
             );
             current_output_sum += *utxo.amount();
 
-            let remaining_balance_on_source = current_output_sum - transfer_obj.amount.get();
-            if remaining_balance_on_source < DUST_ALLOWANCE_VALUE && remaining_balance_on_source != 0 {
-                dust_and_allowance_recorders.push((remaining_balance_on_source, utxo.address().to_bech32(), true));
+            if current_output_sum > transfer_obj.amount.get() {
+                let remaining_balance_on_source = current_output_sum - transfer_obj.amount.get();
+                if remaining_balance_on_source < DUST_ALLOWANCE_VALUE && remaining_balance_on_source != 0 {
+                    dust_and_allowance_recorders.push((remaining_balance_on_source, utxo.address().to_bech32(), true));
+                }
             }
         }
     }
@@ -1028,9 +1030,7 @@ async fn perform_transfer(
         account_.append_addresses(vec![addr]);
     }
 
-    let message = Message::from_iota_message(message_id, message, account_.addresses())
-        .with_value(transfer_obj.amount.get(), remainder_value)
-        .finish();
+    let message = Message::from_iota_message(message_id, message, account_.addresses()).finish();
     account_.append_messages(vec![message.clone()]);
 
     account_.save().await?;

--- a/src/address.rs
+++ b/src/address.rs
@@ -60,7 +60,7 @@ impl AddressOutput {
             // message is pending or confirmed
             if m.confirmed().unwrap_or(true) {
                 match m.payload() {
-                    Payload::Transaction(tx) => tx.essence().inputs().iter().any(|input| {
+                    Some(Payload::Transaction(tx)) => tx.essence().inputs().iter().any(|input| {
                         if let Input::UTXO(x) = input {
                             x == &output_id
                         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -482,7 +482,7 @@ mod test_utils {
                 version: 1,
                 parents: vec![MessageId::new([0; 32])],
                 payload_length: 0,
-                payload: Payload::Transaction(Box::new(
+                payload: Some(Payload::Transaction(Box::new(
                     TransactionPayloadBuilder::new()
                         .with_essence(
                             TransactionPayloadEssence::builder()
@@ -501,7 +501,7 @@ mod test_utils {
                         ))))
                         .finish()
                         .unwrap(),
-                )),
+                ))),
                 timestamp: chrono::Utc::now(),
                 nonce: 0,
                 value: self.value,

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -119,7 +119,9 @@ async fn process_output(
                 .data(&message_id)
                 .await
             {
-                let message = Message::from_iota_message(message_id, account.addresses(), message, Some(true));
+                let message = Message::from_iota_message(message_id, message, account.addresses())
+                    .with_confirmed(Some(true))
+                    .finish();
                 crate::event::emit_transaction_event(
                     crate::event::TransactionEventType::NewTransaction,
                     account.id(),


### PR DESCRIPTION
# Description of change

We can't compute the `value` for the Message for internal transfers since all outputs belongs to the account. This PR changes the message building so it can take the value from outside instead of computing it.

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

CLI wallet - internal account transfer and external transfer.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
