### PR TITLE
refactor(transaction): sign essence hash instead of whole essence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,7 +298,7 @@ dependencies = [
 [[package]]
 name = "bee-ledger"
 version = "0.1.0-alpha"
-source = "git+https://github.com/iotaledger/bee.git?branch=chrysalis-pt-2#3cba1a5682c3f5c952037e1b0a2e927cc93841a9"
+source = "git+https://github.com/iotaledger/bee.git?branch=chrysalis-pt-2#1489882b06332e71104ccde5b91a832d2eb5cba2"
 dependencies = [
  "async-trait",
  "bee-common",
@@ -323,7 +323,7 @@ dependencies = [
 [[package]]
 name = "bee-message"
 version = "0.1.0-alpha"
-source = "git+https://github.com/iotaledger/bee.git?branch=chrysalis-pt-2#3cba1a5682c3f5c952037e1b0a2e927cc93841a9"
+source = "git+https://github.com/iotaledger/bee.git?branch=chrysalis-pt-2#1489882b06332e71104ccde5b91a832d2eb5cba2"
 dependencies = [
  "bech32",
  "bee-common",
@@ -340,7 +340,7 @@ dependencies = [
 [[package]]
 name = "bee-network"
 version = "0.1.0-alpha"
-source = "git+https://github.com/iotaledger/bee.git?branch=chrysalis-pt-2#3cba1a5682c3f5c952037e1b0a2e927cc93841a9"
+source = "git+https://github.com/iotaledger/bee.git?branch=chrysalis-pt-2#1489882b06332e71104ccde5b91a832d2eb5cba2"
 dependencies = [
  "async-trait",
  "bee-runtime",
@@ -359,7 +359,7 @@ dependencies = [
 [[package]]
 name = "bee-pow"
 version = "0.1.0-alpha"
-source = "git+https://github.com/iotaledger/bee.git?branch=chrysalis-pt-2#3cba1a5682c3f5c952037e1b0a2e927cc93841a9"
+source = "git+https://github.com/iotaledger/bee.git?branch=chrysalis-pt-2#1489882b06332e71104ccde5b91a832d2eb5cba2"
 dependencies = [
  "bee-crypto",
  "bee-ternary",
@@ -370,7 +370,7 @@ dependencies = [
 [[package]]
 name = "bee-protocol"
 version = "0.1.0-alpha"
-source = "git+https://github.com/iotaledger/bee.git?branch=chrysalis-pt-2#3cba1a5682c3f5c952037e1b0a2e927cc93841a9"
+source = "git+https://github.com/iotaledger/bee.git?branch=chrysalis-pt-2#1489882b06332e71104ccde5b91a832d2eb5cba2"
 dependencies = [
  "async-channel",
  "async-priority-queue",
@@ -407,7 +407,7 @@ dependencies = [
 [[package]]
 name = "bee-rest-api"
 version = "0.1.0-alpha"
-source = "git+https://github.com/iotaledger/bee.git?branch=chrysalis-pt-2#3cba1a5682c3f5c952037e1b0a2e927cc93841a9"
+source = "git+https://github.com/iotaledger/bee.git?branch=chrysalis-pt-2#1489882b06332e71104ccde5b91a832d2eb5cba2"
 dependencies = [
  "async-trait",
  "bech32",
@@ -447,7 +447,7 @@ dependencies = [
 [[package]]
 name = "bee-snapshot"
 version = "0.1.0-alpha"
-source = "git+https://github.com/iotaledger/bee.git?branch=chrysalis-pt-2#3cba1a5682c3f5c952037e1b0a2e927cc93841a9"
+source = "git+https://github.com/iotaledger/bee.git?branch=chrysalis-pt-2#1489882b06332e71104ccde5b91a832d2eb5cba2"
 dependencies = [
  "async-trait",
  "bee-common",
@@ -477,7 +477,7 @@ dependencies = [
 [[package]]
 name = "bee-tangle"
 version = "0.1.0-alpha"
-source = "git+https://github.com/iotaledger/bee.git?branch=chrysalis-pt-2#3cba1a5682c3f5c952037e1b0a2e927cc93841a9"
+source = "git+https://github.com/iotaledger/bee.git?branch=chrysalis-pt-2#1489882b06332e71104ccde5b91a832d2eb5cba2"
 dependencies = [
  "async-trait",
  "bee-common",
@@ -752,9 +752,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0659001ab56b791be01d4b729c44376edc6718cf389a502e579b77b758f3296c"
+checksum = "5cb92721cb37482245ed88428f72253ce422b3b4ee169c70a0642521bb5db4cc"
 dependencies = [
  "glob",
  "libc",
@@ -1754,7 +1754,7 @@ dependencies = [
 [[package]]
 name = "iota-client"
 version = "0.5.0-alpha.3"
-source = "git+https://github.com/iotaledger/iota.rs?branch=dev#b939969fcb2a93a70e0743961d666fd982a40526"
+source = "git+https://github.com/iotaledger/iota.rs?branch=dev#9859c3348573a89464382676c5459f116f386541"
 dependencies = [
  "bee-common",
  "bee-common-derive",
@@ -1780,7 +1780,7 @@ dependencies = [
 [[package]]
 name = "iota-core"
 version = "0.2.0-alpha.3"
-source = "git+https://github.com/iotaledger/iota.rs?branch=dev#b939969fcb2a93a70e0743961d666fd982a40526"
+source = "git+https://github.com/iotaledger/iota.rs?branch=dev#9859c3348573a89464382676c5459f116f386541"
 dependencies = [
  "bee-common",
  "bee-message",
@@ -1807,7 +1807,7 @@ dependencies = [
 [[package]]
 name = "iota-crypto"
 version = "0.2.0"
-source = "git+https://github.com/iotaledger/crypto.rs?branch=dev#6e67b652dd55df05877f575b9a09ccb5a7006694"
+source = "git+https://github.com/iotaledger/crypto.rs?branch=dev#ec5dec1d0fbed8042a89ea8e613eb338a2214e68"
 dependencies = [
  "blake2b_simd",
  "ed25519-zebra",
@@ -1816,7 +1816,7 @@ dependencies = [
 [[package]]
 name = "iota-ledger"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/ledger.rs?branch=develop#7e346e1699655c025ac3923c48d30c34bf9b0a93"
+source = "git+https://github.com/iotaledger/ledger.rs?branch=develop#84ef9be0bdf344305d5c309a766a985f55c753df"
 dependencies = [
  "bech32",
  "enum-iterator",
@@ -4057,9 +4057,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13e63ab62dbe32aeee58d1c5408d35c36c392bba5d9d3142287219721afe606"
+checksum = "07fbfce1c8a97d547e8b5334978438d9d6ec8c20e38f56d4a4374d181493eaef"
 dependencies = [
  "tinyvec",
 ]

--- a/bindings/nodejs/native/Cargo.lock
+++ b/bindings/nodejs/native/Cargo.lock
@@ -298,7 +298,7 @@ dependencies = [
 [[package]]
 name = "bee-ledger"
 version = "0.1.0-alpha"
-source = "git+https://github.com/iotaledger/bee.git?branch=chrysalis-pt-2#e5b8a6591a2c1ada48db33e158c5eb7394361fd8"
+source = "git+https://github.com/iotaledger/bee.git?branch=chrysalis-pt-2#1489882b06332e71104ccde5b91a832d2eb5cba2"
 dependencies = [
  "async-trait",
  "bee-common",
@@ -323,7 +323,7 @@ dependencies = [
 [[package]]
 name = "bee-message"
 version = "0.1.0-alpha"
-source = "git+https://github.com/iotaledger/bee.git?branch=chrysalis-pt-2#e5b8a6591a2c1ada48db33e158c5eb7394361fd8"
+source = "git+https://github.com/iotaledger/bee.git?branch=chrysalis-pt-2#1489882b06332e71104ccde5b91a832d2eb5cba2"
 dependencies = [
  "bech32",
  "bee-common",
@@ -340,7 +340,7 @@ dependencies = [
 [[package]]
 name = "bee-network"
 version = "0.1.0-alpha"
-source = "git+https://github.com/iotaledger/bee.git?branch=chrysalis-pt-2#e5b8a6591a2c1ada48db33e158c5eb7394361fd8"
+source = "git+https://github.com/iotaledger/bee.git?branch=chrysalis-pt-2#1489882b06332e71104ccde5b91a832d2eb5cba2"
 dependencies = [
  "async-trait",
  "bee-runtime",
@@ -359,7 +359,7 @@ dependencies = [
 [[package]]
 name = "bee-pow"
 version = "0.1.0-alpha"
-source = "git+https://github.com/iotaledger/bee.git?branch=chrysalis-pt-2#e5b8a6591a2c1ada48db33e158c5eb7394361fd8"
+source = "git+https://github.com/iotaledger/bee.git?branch=chrysalis-pt-2#1489882b06332e71104ccde5b91a832d2eb5cba2"
 dependencies = [
  "bee-crypto",
  "bee-ternary",
@@ -370,7 +370,7 @@ dependencies = [
 [[package]]
 name = "bee-protocol"
 version = "0.1.0-alpha"
-source = "git+https://github.com/iotaledger/bee.git?branch=chrysalis-pt-2#e5b8a6591a2c1ada48db33e158c5eb7394361fd8"
+source = "git+https://github.com/iotaledger/bee.git?branch=chrysalis-pt-2#1489882b06332e71104ccde5b91a832d2eb5cba2"
 dependencies = [
  "async-channel",
  "async-priority-queue",
@@ -407,7 +407,7 @@ dependencies = [
 [[package]]
 name = "bee-rest-api"
 version = "0.1.0-alpha"
-source = "git+https://github.com/iotaledger/bee.git?branch=chrysalis-pt-2#e5b8a6591a2c1ada48db33e158c5eb7394361fd8"
+source = "git+https://github.com/iotaledger/bee.git?branch=chrysalis-pt-2#1489882b06332e71104ccde5b91a832d2eb5cba2"
 dependencies = [
  "async-trait",
  "bech32",
@@ -447,7 +447,7 @@ dependencies = [
 [[package]]
 name = "bee-snapshot"
 version = "0.1.0-alpha"
-source = "git+https://github.com/iotaledger/bee.git?branch=chrysalis-pt-2#e5b8a6591a2c1ada48db33e158c5eb7394361fd8"
+source = "git+https://github.com/iotaledger/bee.git?branch=chrysalis-pt-2#1489882b06332e71104ccde5b91a832d2eb5cba2"
 dependencies = [
  "async-trait",
  "bee-common",
@@ -477,7 +477,7 @@ dependencies = [
 [[package]]
 name = "bee-tangle"
 version = "0.1.0-alpha"
-source = "git+https://github.com/iotaledger/bee.git?branch=chrysalis-pt-2#e5b8a6591a2c1ada48db33e158c5eb7394361fd8"
+source = "git+https://github.com/iotaledger/bee.git?branch=chrysalis-pt-2#1489882b06332e71104ccde5b91a832d2eb5cba2"
 dependencies = [
  "async-trait",
  "bee-common",
@@ -752,9 +752,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0659001ab56b791be01d4b729c44376edc6718cf389a502e579b77b758f3296c"
+checksum = "5cb92721cb37482245ed88428f72253ce422b3b4ee169c70a0642521bb5db4cc"
 dependencies = [
  "glob",
  "libc",
@@ -1742,7 +1742,7 @@ dependencies = [
 [[package]]
 name = "iota-crypto"
 version = "0.2.0"
-source = "git+https://github.com/iotaledger/crypto.rs?branch=dev#6e67b652dd55df05877f575b9a09ccb5a7006694"
+source = "git+https://github.com/iotaledger/crypto.rs?branch=dev#ec5dec1d0fbed8042a89ea8e613eb338a2214e68"
 dependencies = [
  "blake2b_simd",
  "ed25519-zebra",

--- a/src/signing/stronghold.rs
+++ b/src/signing/stronghold.rs
@@ -3,11 +3,11 @@
 
 use crate::account::Account;
 
-use iota::{common::packable::Packable, ReferenceUnlock, UnlockBlock};
 use blake2::{
     digest::{Update, VariableOutput},
     VarBlake2b,
 };
+use iota::{common::packable::Packable, ReferenceUnlock, UnlockBlock};
 
 use std::{collections::HashMap, path::PathBuf};
 

--- a/src/stronghold.rs
+++ b/src/stronghold.rs
@@ -540,9 +540,9 @@ pub async fn generate_address(
     Ok(address)
 }
 
-pub async fn sign_essence(
+pub async fn sign_transaction(
     snapshot_path: &PathBuf,
-    transaction_essence: Vec<u8>,
+    transaction_essence_hash: &[u8; 32],
     account_index: usize,
     address_index: usize,
     internal: bool,
@@ -566,7 +566,7 @@ pub async fn sign_essence(
         .stronghold
         .runtime_exec(Procedure::Ed25519Sign {
             private_key: derived_location,
-            msg: transaction_essence,
+            msg: transaction_essence_hash.to_vec(),
         })
         .await;
     if let ProcResult::Ed25519Sign(response) = res {


### PR DESCRIPTION
# Description of change

We're changing the sign algorithm so it signs the transaction hash instead of the whole transaction.

## Links to any relevant issues

N/A

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

Can't test it yet :P waiting on testnet update

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have checked that new and existing unit tests pass locally with my changes
