### PR TITLE
fix(sync): initial address index should ignore change addresses

### DIFF
--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -416,12 +416,16 @@ pub struct AccountSynchronizer {
 impl AccountSynchronizer {
     /// Initialises a new instance of the sync helper.
     pub(super) async fn new(account_handle: AccountHandle) -> Self {
-        let address_index = account_handle.read().await.addresses().len();
+        let latest_address_index = *account_handle.read().await.latest_address().key_index();
         Self {
             account_handle,
             // by default we synchronize from the latest address (supposedly unspent)
-            address_index: if address_index == 0 { 0 } else { address_index - 1 },
-            gap_limit: if address_index == 0 { 10 } else { 1 },
+            address_index: if latest_address_index == 0 {
+                0
+            } else {
+                latest_address_index - 1
+            },
+            gap_limit: if latest_address_index == 0 { 10 } else { 1 },
             skip_persistance: false,
             steps: vec![
                 AccountSynchronizeStep::SyncAddresses,


### PR DESCRIPTION
# Description of change

The initial sync address is incorrect. It should be the latest index, and not the length since there's change addresses.

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Node.js binding.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
