### PR TITLE
fix(ci): Require version-or-publish output for electron prebuild

### DIFF
--- a/.github/workflows/covector-version-or-publish.yml
+++ b/.github/workflows/covector-version-or-publish.yml
@@ -138,8 +138,10 @@ jobs:
         run: yarn prebuild --upload-all ${{ secrets.GITHUB_TOKEN }} --tag-prefix nodejs-binding-v
         working-directory: bindings/nodejs
   
-  electron:
+  electron-binding-prebuild:
     runs-on: ${{ matrix.os }}
+    needs: version-or-publish
+    if: needs.version-or-publish.outputs.successfulPublish == 'true'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
# Description of change

I forgot the `if` in the electron prebuild job, so it seems to be running on every push instead of only when Covector decides that the packages should be published

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

N/A

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code