### PR TITLE
refactor(backup): unencrypted db when copying from SQLite to stronghold

### DIFF
--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -147,11 +147,6 @@ impl AccountManagerBuilder {
         Ok(self)
     }
 
-    pub(crate) fn with_storage_encryption_key(mut self, key: Option<[u8; 32]>) -> Self {
-        self.storage_encryption_key = key;
-        self
-    }
-
     /// Sets the polling interval.
     pub fn with_polling_interval(mut self, polling_interval: Duration) -> Self {
         self.polling_interval = polling_interval;
@@ -699,13 +694,6 @@ impl AccountManager {
                         None,
                     )
                     .unwrap() // safe to unwrap - password is None
-                    .with_storage_encryption_key(
-                        crate::storage::get(&self.storage_path)
-                            .await?
-                            .lock()
-                            .await
-                            .encryption_key,
-                    )
                     .skip_polling()
                     .finish()
                     .await?;
@@ -806,13 +794,6 @@ impl AccountManager {
                 let mut stronghold_manager = Self::builder()
                     .with_storage(&source, ManagerStorage::Stronghold, None)
                     .unwrap() // safe to unwrap - password is None
-                    .with_storage_encryption_key(
-                        crate::storage::get(&self.storage_path)
-                            .await?
-                            .lock()
-                            .await
-                            .encryption_key,
-                    )
                     .skip_polling()
                     .finish()
                     .await?;

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -80,11 +80,20 @@ pub(crate) async fn set<P: AsRef<Path>>(
     storage: Box<dyn StorageAdapter + Send + Sync + 'static>,
 ) {
     let mut instances = INSTANCES.get_or_init(Default::default).write().await;
+    #[allow(unused_variables)]
+    let storage_id = storage.id();
     instances.insert(
         storage_path.as_ref().to_path_buf(),
         Arc::new(Mutex::new(Storage {
             storage_path: storage_path.as_ref().to_path_buf(),
             inner: storage,
+            #[cfg(any(feature = "stronghold", feature = "stronghold-storage"))]
+            encryption_key: if storage_id == stronghold::STORAGE_ID {
+                None
+            } else {
+                encryption_key
+            },
+            #[cfg(not(any(feature = "stronghold", feature = "stronghold-storage")))]
             encryption_key,
         })),
     );


### PR DESCRIPTION
# Description of change

The stronghold file is already encrypted so removing the storage encrpytion key from the backup simplifies the restore process on Firefly. When using stronghold as storage DB the storage encryption key is still used so it wouldn't conflict with the user's API usage.

## Links to any relevant issues

N/A

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

Unit test, Firefly.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
