### PR TITLE
fix(sync): do not overwrite addresses/messages

### DIFF
--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -484,8 +484,26 @@ impl AccountSynchronizer {
                     let mut account_ref = self.account_handle.write().await;
                     account_ref
                         .do_mut(|account| {
-                            account.set_addresses(account_.addresses().to_vec());
-                            account.set_messages(account_.messages().to_vec());
+                            for address in account_.addresses() {
+                                match account.addresses().iter().position(|a| a == address) {
+                                    Some(index) => {
+                                        account.addresses_mut()[index] = address.clone();
+                                    }
+                                    None => {
+                                        account.addresses_mut().push(address.clone());
+                                    }
+                                }
+                            }
+                            for message in account_.messages() {
+                                match account.messages().iter().position(|m| m == message) {
+                                    Some(index) => {
+                                        account.messages_mut()[index] = message.clone();
+                                    }
+                                    None => {
+                                        account.messages_mut().push(message.clone());
+                                    }
+                                }
+                            }
                             account.set_last_synced_at(Some(chrono::Local::now()));
                             Ok(())
                         })


### PR DESCRIPTION
# Description of change

The sync process shouldn't overwrite addresses/messages because it might overwrite updates on another tasks.

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

CLI Wallet.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
