### PR TITLE
fix(mqtt): spawn instead of block_on

### DIFF
--- a/.changes/fix-mqtt.md
+++ b/.changes/fix-mqtt.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": patch
+---
+
+Fixes a panic on the MQTT handling.

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -78,7 +78,7 @@ pub async fn monitor_address_balance(account_handle: AccountHandle, address: &Ad
             let client_options = client_options.clone();
             let account_handle = account_handle.clone();
 
-            crate::block_on(async {
+            crate::spawn(async move {
                 if let Err(e) =
                     process_output(topic_event.payload.clone(), account_handle, address, client_options).await
                 {
@@ -174,8 +174,10 @@ pub async fn monitor_confirmation_state_change(
         &client_options,
         format!("messages/{}/metadata", message_id.to_string()),
         move |topic_event| {
+            let topic_event = topic_event.clone();
+            let message = message.clone();
             let account_handle = account_handle.clone();
-            crate::block_on(async {
+            crate::spawn(async move {
                 if let Err(e) =
                     process_metadata(topic_event.payload.clone(), account_handle, message_id, &message).await
                 {


### PR DESCRIPTION
# Description of change

Calling block_on causes a tokio panic since the context from iota.rs is async.

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

CLI wallet.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
