### PR TITLE
fix(bindings/nodejs): Run scripts with NPM instead of Yarn

### DIFF
--- a/.changes/js-bindings-npm-scripts.md
+++ b/.changes/js-bindings-npm-scripts.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": patch
+---
+
+Fixes issues with the installation script when using with NPM instead of Yarn

--- a/bindings/nodejs/package.json
+++ b/bindings/nodejs/package.json
@@ -14,9 +14,9 @@
     "prebuild-install": "^5.3.3"
   },
   "scripts": {
-    "install": "prebuild-install --tag-prefix nodejs-binding-v || yarn rebuild",
+    "install": "prebuild-install --tag-prefix nodejs-binding-v || npm run rebuild",
     "build:neon": "neon build --release && node scripts/move-lib.js",
-    "rebuild": "yarn build:neon && node scripts/strip.js",
+    "rebuild": "npm run build:neon && node scripts/strip.js",
     "prebuild:node": "prebuild --prepack scripts/node-neon-build.js --strip",
     "prebuild:electron": "node scripts/electron-prebuild.js",
     "build:docs": "./node_modules/.bin/jsdoc lib/index.js"


### PR DESCRIPTION
# Description of change

NPM users who don't have Yarn installed are not able to use the JS bindings since they explicitly use Yarn in the `install` and `rebuild` scripts. ~~TIL we can use `$npm_execpath` to call either Yarn or NPM (https://stackoverflow.com/a/55440486/3188334).~~ This PR uses NPM instead of Yarn since NPM is included with Node.js

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested with Yarn and NPM

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code