### PR TITLE
feat(nodejs): add API to get an address by bech32 string

### DIFF
--- a/.changes/get-address.md
+++ b/.changes/get-address.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": patch
+---
+
+New method on the Account object to get an address by its bech32 representation.

--- a/bindings/nodejs/lib/index.d.ts
+++ b/bindings/nodejs/lib/index.d.ts
@@ -81,6 +81,7 @@ export declare class Account {
   setAlias(alias: string): void
   setClientOptions(options: ClientOptions): void
   getMessage(id: string): Message | undefined
+  getAddress(addressBech32: string): Address | undefined
   generateAddress(): Address
   latestAddress(): Address
   getUnusedAddress(): Address

--- a/bindings/nodejs/tests/account.js
+++ b/bindings/nodejs/tests/account.js
@@ -18,7 +18,7 @@ async function run() {
 
   const account = manager.createAccount({
     clientOptions: {
-      node: 'http://localhost:14265',
+      node: 'http://api.hornet-1.testnet.chrysalis2.com',
       requestTimeout: {
         secs: 5000,
         nanos: 0

--- a/docs/libraries/nodejs/api_reference.md
+++ b/docs/libraries/nodejs/api_reference.md
@@ -295,6 +295,14 @@ Gets the message associated with the given identifier.
 | --------- | ------------------- | ----------------- | ------------------------ |
 | messageId | <code>string</code> | <code>null</code> | The message's identifier |
 
+#### getAddress(addressBech32)
+
+Gets the address object by its bech32 representation.
+
+| Param         | Type                | Default           | Description                       |
+| ------------- | ------------------- | ----------------- | --------------------------------- |
+| addressBech32 | <code>string</code> | <code>null</code> | The address bech32 representation |
+
 #### generateAddress()
 
 Generates a new unused address and returns it.

--- a/src/address.rs
+++ b/src/address.rs
@@ -345,15 +345,9 @@ impl Address {
 pub fn parse<A: AsRef<str>>(address: A) -> crate::Result<AddressWrapper> {
     let address = address.as_ref();
     let mut tokens = address.split('1');
-    let hrp = tokens.next().unwrap();
-    let address = iota::Address::try_from_bech32(address).or_else(|_| {
-        if let Ok(ed25519_address) = Ed25519Address::from_str(address) {
-            Ok(IotaAddress::Ed25519(ed25519_address))
-        } else {
-            Err(crate::Error::InvalidAddress)
-        }
-    });
-    Ok(AddressWrapper::new(address?, hrp.to_string()))
+    let hrp = tokens.next().ok_or(crate::Error::InvalidAddress)?;
+    let address = iota::Address::try_from_bech32(address)?;
+    Ok(AddressWrapper::new(address, hrp.to_string()))
 }
 
 pub(crate) async fn get_iota_address(


### PR DESCRIPTION
# Description of change

Adds a new API on the nodejs binding: getting an address by its bech32 representation.

## Links to any relevant issues

N/A

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Test script on tests/account.js

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
