### PR TITLE
fix(sync): do not set tx as unconfirmed when the inclusion state is null

### DIFF
--- a/.changes/fix-message-confirmation.md
+++ b/.changes/fix-message-confirmation.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": patch
+---
+
+Fixes the message confirmation state update on the background sync system.

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -1068,9 +1068,9 @@ async fn poll(accounts: AccountStore, storage_file_path: PathBuf, is_mqtt_monito
         for message_id in retried_data.no_need_promote_or_reattach {
             let message = account.get_message_mut(&message_id).unwrap();
             if let Ok(metadata) = client.read().await.get_message().metadata(&message_id).await {
-                message.set_confirmed(Some(
-                    metadata.ledger_inclusion_state == Some(LedgerInclusionStateDto::Included),
-                ));
+                if let Some(ledger_inclusion_state) = metadata.ledger_inclusion_state {
+                    message.set_confirmed(Some(ledger_inclusion_state == LedgerInclusionStateDto::Included));
+                }
             }
         }
         account.save().await?;


### PR DESCRIPTION
# Description of change

Message was incorrectly marked as unconfirmed when the state was pending.

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)