### PR TITLE
feat(bindings): add messageCount API

### DIFF
--- a/.changes/message-count.md
+++ b/.changes/message-count.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": patch
+---
+
+Adds a `messageCount` function on the Account class.

--- a/bindings/nodejs/lib/index.d.ts
+++ b/bindings/nodejs/lib/index.d.ts
@@ -75,6 +75,7 @@ export declare class Account {
   index(): number;
   alias(): string;
   balance(): AccountBalance;
+  messageCount(): number;
   listMessages(count?: number, from?: number, messageType?: MessageType): Message[]
   listAddresses(unspent?: boolean): Address[]
   sync(options?: SyncOptions): Promise<SyncedAccount>

--- a/bindings/nodejs/native/src/classes/account/mod.rs
+++ b/bindings/nodejs/native/src/classes/account/mod.rs
@@ -70,6 +70,17 @@ declare_types! {
             Ok(neon_serde::to_value(&mut cx, &balance)?.upcast())
         }
 
+        method messageCount(mut cx) {
+            let this = cx.this();
+            let id = cx.borrow(&this, |r| r.0.clone());
+            crate::block_on(async move {
+                let account_handle = crate::get_account(&id).await;
+                let account = account_handle.read().await;
+                let count = account.messages().len();
+                Ok(cx.number(count as f64).upcast())
+            })
+        }
+
         method listMessages(mut cx) {
             let count = match cx.argument_opt(0) {
                 Some(arg) => arg.downcast::<JsNumber>().or_throw(&mut cx)?.value() as usize,

--- a/bindings/nodejs/tests/account.js
+++ b/bindings/nodejs/tests/account.js
@@ -32,6 +32,7 @@ async function run() {
     }
   })
   console.log('messages', account.listMessages(0, 0, MessageType.Failed))
+  console.log(account.messageCount())
   account.setAlias('new alias')
 
   const savedAccount = manager.getAccount('new alias')

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -381,6 +381,10 @@ Updates the account's client options.
 | ------- | -------------------------------------------- | ---------------------- | ------------------------- |
 | options | <code>[ClientOptions](#clientoptions)</code> | <code>undefined</code> | The client options to set |
 
+#### message_count(): int
+
+Returns the number of messages associated with the account.
+
 #### list_messages(count, from, message_type (optional)): list([WalletMessage](#walletmessage))
 
 Get the list of messages of this account.

--- a/bindings/python/native/src/classes/account.rs
+++ b/bindings/python/native/src/classes/account.rs
@@ -189,6 +189,13 @@ impl AccountHandle {
         })?)
     }
 
+    /// The number of messages associated with the account.
+    fn message_count(&self) -> usize {
+        crate::block_on(async {
+            self.account_handle.read().await.messages().len()
+        })
+    }
+
     /// Bridge to [Account#list_messages](struct.Account.html#method.list_messages).
     /// This method clones the account's messages so when querying a large list of messages
     /// prefer using the `read` method to access the account instance.

--- a/bindings/python/native/src/classes/account.rs
+++ b/bindings/python/native/src/classes/account.rs
@@ -191,9 +191,7 @@ impl AccountHandle {
 
     /// The number of messages associated with the account.
     fn message_count(&self) -> usize {
-        crate::block_on(async {
-            self.account_handle.read().await.messages().len()
-        })
+        crate::block_on(async { self.account_handle.read().await.messages().len() })
     }
 
     /// Bridge to [Account#list_messages](struct.Account.html#method.list_messages).

--- a/docs/libraries/nodejs/api_reference.md
+++ b/docs/libraries/nodejs/api_reference.md
@@ -231,6 +231,10 @@ Returns the account's balance information object.
 
 Balance object: { total: number, available: number, incoming: number, outgoing: number }
 
+#### messageCount()
+
+Returns the number of messages associated with the account.
+
 #### listMessages([count, from, type])
 
 Returns the account's messages.


### PR DESCRIPTION
# Description of change

Adds a `message count` API on the bindings so the usage of a paginated message querying is easier.

## Links to any relevant issues

N/A

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

With the test script.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
