### PR TITLE
example: adjust generate-address example

### DIFF
--- a/bindings/nodejs/examples/2-generate-address.js
+++ b/bindings/nodejs/examples/2-generate-address.js
@@ -19,13 +19,14 @@ async function run() {
     // Always sync before doing anything with the account
     const synced = await account.sync()
     console.log('Syncing...')
-    // let address = account.generateAddress()
-    
-    // get latest address
-    let addressObject = account.latestAddress()
 
-    console.log("Address:", addressObject.address)
-    
+    const { address } = account.generateAddress()
+    console.log('New address:', address)
+
+    // You can also get the latest unused address:
+    // const addressObject = account.latestAddress()
+    // console.log("Address:", addressObject.address)
+
     // Use the Chrysalis Faucet to send testnet tokens to your address:
     console.log("Fill your address with the Faucet: https://faucet.testnet.chrysalis2.com/")
 }


### PR DESCRIPTION
this changes the example code for generating an address
to create an address, instead of returning the last unused
address, which stays the same.

# Description of change

this changes the example code for generating an address
to create an address, instead of returning the last unused
address, which stays the same.

## Links to any relevant issues

-

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix 

## How the change has been tested

` node 2-generate-address.js`

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
