### PR TITLE
refactor: get ledger status instead of open_ledger_app

### DIFF
--- a/src/actor/message.rs
+++ b/src/actor/message.rs
@@ -182,10 +182,10 @@ pub enum MessageType {
     },
     /// Checks if all accounts has unused latest address after syncing with the Tangle.
     IsLatestAddressUnused,
-    /// Open the iota ledger app on Ledger Nano or Speculos simulator.
+    /// Get the Ledger Nano or Speculos simulator status.
     #[cfg(any(feature = "ledger-nano", feature = "ledger-nano-simulator"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "ledger-nano", feature = "ledger-nano-simulator"))))]
-    OpenLedgerApp(bool),
+    GetLedgerStatus(bool),
     /// Deletes the storage.
     DeleteStorage,
     /// Changes stronghold snapshot password.
@@ -266,7 +266,7 @@ impl Serialize for MessageType {
                 serializer.serialize_unit_variant("MessageType", 19, "IsLatestAddressUnused")
             }
             #[cfg(any(feature = "ledger-nano", feature = "ledger-nano-simulator"))]
-            MessageType::OpenLedgerApp(_) => serializer.serialize_unit_variant("MessageType", 20, "OpenLedgerApp"),
+            MessageType::GetLedgerStatus(_) => serializer.serialize_unit_variant("MessageType", 20, "GetLedgerStatus"),
             MessageType::DeleteStorage => serializer.serialize_unit_variant("MessageType", 21, "DeleteStorage"),
             #[cfg(any(feature = "stronghold", feature = "stronghold-storage"))]
             MessageType::ChangeStrongholdPassword {
@@ -381,10 +381,10 @@ pub enum ResponseType {
     UpdatedAlias,
     /// Account method SetClientOptions response.
     UpdatedClientOptions,
-    /// OpenLedgerApp response.
+    /// GetLedgerStatus response.
     #[cfg(any(feature = "ledger-nano", feature = "ledger-nano-simulator"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "ledger-nano", feature = "ledger-nano-simulator"))))]
-    OpenedLedgerApp,
+    LedgerStatus(crate::LedgerStatus),
     /// DeleteStorage response.
     DeletedStorage,
     /// ChangeStrongholdPassword response.

--- a/src/actor/mod.rs
+++ b/src/actor/mod.rs
@@ -166,8 +166,8 @@ impl WalletMessageHandler {
                 .await
             }
             #[cfg(any(feature = "ledger-nano", feature = "ledger-nano-simulator"))]
-            MessageType::OpenLedgerApp(is_simulator) => {
-                convert_panics(|| crate::open_ledger_app(*is_simulator).map(|_| ResponseType::OpenedLedgerApp))
+            MessageType::GetLedgerStatus(is_simulator) => {
+                convert_panics(|| Ok(ResponseType::LedgerStatus(crate::get_ledger_status(*is_simulator))))
             }
             MessageType::DeleteStorage => {
                 convert_async_panics(|| async move {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@ pub async fn with_actor_system<F: FnOnce(&riker::actors::ActorSystem)>(cb: F) {
     cb(&runtime.stronghold.system)
 }
 
-/// The ledger status.
+/// The Ledger device status.
 #[cfg(any(feature = "ledger-nano", feature = "ledger-nano-simulator"))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "ledger-nano", feature = "ledger-nano-simulator"))))]
 #[derive(Debug, ::serde::Serialize)]


### PR DESCRIPTION
# Description of change

The `open_ledger_app` name is misleading since it doesn't open the app, just checks the ledger status. This PR renames it.

## Links to any relevant issues

N/A

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
