### PR TITLE
fix(stronghold): map referenced signatures with both index and internal

### DIFF
--- a/src/signing/stronghold.rs
+++ b/src/signing/stronghold.rs
@@ -62,7 +62,7 @@ impl super::Signer for StrongholdSigner {
         inputs.sort_by(|a, b| a.input.cmp(&b.input));
 
         for (current_block_index, recorder) in inputs.iter().enumerate() {
-            let signature_index = format!("{}/{}", recorder.address_index, recorder.address_internal);
+            let signature_index = format!("{}{}", recorder.address_index, recorder.address_internal);
             // Check if current path is same as previous path
             // If so, add a reference unlock block
             if let Some(block_index) = signature_indexes.get(&signature_index) {

--- a/src/signing/stronghold.rs
+++ b/src/signing/stronghold.rs
@@ -58,13 +58,14 @@ impl super::Signer for StrongholdSigner {
         let hashed_essence = essence.hash();
 
         let mut unlock_blocks = vec![];
-        let mut signature_indexes = HashMap::<usize, usize>::new();
+        let mut signature_indexes = HashMap::<String, usize>::new();
         inputs.sort_by(|a, b| a.input.cmp(&b.input));
 
         for (current_block_index, recorder) in inputs.iter().enumerate() {
+            let signature_index = format!("{}/{}", recorder.address_index, recorder.address_internal);
             // Check if current path is same as previous path
             // If so, add a reference unlock block
-            if let Some(block_index) = signature_indexes.get(&recorder.address_index) {
+            if let Some(block_index) = signature_indexes.get(&signature_index) {
                 unlock_blocks.push(UnlockBlock::Reference(ReferenceUnlock::new(*block_index as u16)?));
             } else {
                 // If not, we should create a signature unlock block
@@ -77,7 +78,7 @@ impl super::Signer for StrongholdSigner {
                 )
                 .await?;
                 unlock_blocks.push(UnlockBlock::Signature(signature.into()));
-                signature_indexes.insert(recorder.address_index, current_block_index);
+                signature_indexes.insert(signature_index, current_block_index);
             }
         }
         Ok(unlock_blocks)


### PR DESCRIPTION
# Description of change

This PR fixes an issue when two addresses of the same index are part of a transaction (a public address and a change address), the signature would be invalid since the second signature would be considered a reference of the first one.

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have checked that new and existing unit tests pass locally with my changes
