### PR TITLE
feat(message): add `remainder` field to the TransactionOutput struct

### DIFF
--- a/.changes/output-remainder-field.md
+++ b/.changes/output-remainder-field.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": patch
+---
+
+Adds a `remainder` property to the transaction's `output` object.

--- a/bindings/nodejs/lib/index.d.ts
+++ b/bindings/nodejs/lib/index.d.ts
@@ -30,6 +30,7 @@ export declare interface Input {
 export declare interface Output {
   address: string
   amount: number
+  remainder: boolean
 }
 
 export declare interface Transaction {

--- a/bindings/python/native/src/classes/account.rs
+++ b/bindings/python/native/src/classes/account.rs
@@ -293,7 +293,7 @@ impl AccountInitialiser {
                     .into_iter()
                     .map(|msg| {
                         // we use an empty bech32 HRP here because we update it later on wallet.rs
-                        to_rust_message(msg, "".to_string())
+                        to_rust_message(msg, "".to_string(), &self.addresses)
                             .unwrap_or_else(|msg| panic!("AccountInitialiser: Message {:?} is invalid", msg))
                     })
                     .collect(),
@@ -303,7 +303,10 @@ impl AccountInitialiser {
 
     /// Address history associated with the seed.
     /// The account can be initialised with locally stored address history.
-    fn addresses(&mut self, addresses: Vec<WalletAddress>) {
+    fn addresses(&mut self, addresses: Vec<WalletAddress>) -> Result<()> {
+        for address in &addresses {
+            self.addresses.push(address.clone().try_into()?);
+        }
         self.account_initialiser = Some(
             self.account_initialiser.take().unwrap().addresses(
                 addresses
@@ -316,6 +319,7 @@ impl AccountInitialiser {
                     .collect(),
             ),
         );
+        Ok(())
     }
 
     /// Skips storing the account to the database.

--- a/bindings/python/native/src/classes/account_manager.rs
+++ b/bindings/python/native/src/classes/account_manager.rs
@@ -133,6 +133,7 @@ impl AccountManager {
     fn create_account(&self, client_options: ClientOptions) -> Result<AccountInitialiser> {
         Ok(AccountInitialiser {
             account_initialiser: Some(self.account_manager.create_account(client_options.into())?),
+            addresses: Default::default(),
         })
     }
 

--- a/bindings/python/native/src/types/account.rs
+++ b/bindings/python/native/src/types/account.rs
@@ -10,6 +10,7 @@ use iota_wallet::{
         SyncedAccount as RustSyncedAccount,
     },
     account_manager::{AccountManager as RustAccountManager, AccountsSynchronizer as RustAccountsSynchronizer},
+    address::Address as RustWalletAddress,
     message::Transfer as RustTransfer,
 };
 use pyo3::prelude::*;
@@ -23,6 +24,7 @@ pub struct AccountManager {
 #[pyclass]
 pub struct AccountInitialiser {
     pub account_initialiser: Option<RustAccountInitialiser>,
+    pub addresses: Vec<RustWalletAddress>,
 }
 
 #[pyclass]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -501,6 +501,7 @@ mod test_utils {
                 parents: vec![MessageId::new([0; 32])],
                 payload_length: 0,
                 payload: Some(MessagePayload::new(
+                    &MessageId::new([0; 32]),
                     Payload::Transaction(Box::new(
                         TransactionPayloadBuilder::new()
                             .with_essence(Essence::Regular(
@@ -522,6 +523,7 @@ mod test_utils {
                             .unwrap(),
                     )),
                     bech32_hrp,
+                    &[],
                 )),
                 timestamp: chrono::Utc::now(),
                 nonce: 0,

--- a/src/message.rs
+++ b/src/message.rs
@@ -376,11 +376,11 @@ impl TransactionRegularEssence {
                         match remainder {
                             Some(remainder_address) => {
                                 let address_index = *account_address.key_index();
-                                // if the address index is the highest or it's the same as the previous one and this is
-                                // a change address, we assume that it holds the remainder value
-                                if address_index > *remainder_address.key_index()
-                                    || (address_index == *remainder_address.key_index() && *account_address.internal())
-                                {
+                                // if the address index is the highest or it's is a change address,
+                                // we assume that it holds the remainder value.
+                                // note that this also means that the last output to a change address
+                                // is considered the remainder output, which is the case for transactions with this library.
+                                if address_index > *remainder_address.key_index() || *account_address.internal() {
                                     remainder = Some(account_address);
                                 }
                             }

--- a/src/message.rs
+++ b/src/message.rs
@@ -376,12 +376,11 @@ impl TransactionRegularEssence {
                         match remainder {
                             Some(remainder_address) => {
                                 let address_index = *account_address.key_index();
-                                // if the address index is the highest or it's is a change address,
-                                // we assume that it holds the remainder value.
-                                // note that this also means that the last output to a change address
-                                // is considered the remainder output, which is the case for transactions with this
-                                // library.
-                                if address_index > *remainder_address.key_index() || *account_address.internal() {
+                                // if the address index is the highest or it's the same as the previous one and this is
+                                // a change address, we assume that it holds the remainder value
+                                if address_index > *remainder_address.key_index()
+                                    || (address_index == *remainder_address.key_index() && *account_address.internal())
+                                {
                                     remainder = Some(account_address);
                                 }
                             }

--- a/src/message.rs
+++ b/src/message.rs
@@ -379,7 +379,8 @@ impl TransactionRegularEssence {
                                 // if the address index is the highest or it's is a change address,
                                 // we assume that it holds the remainder value.
                                 // note that this also means that the last output to a change address
-                                // is considered the remainder output, which is the case for transactions with this library.
+                                // is considered the remainder output, which is the case for transactions with this
+                                // library.
                                 if address_index > *remainder_address.key_index() || *account_address.internal() {
                                     remainder = Some(account_address);
                                 }


### PR DESCRIPTION
# Description of change

Adds a `remainder` property to the output object.

## Links to any relevant issues

N/A

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

With the CLI wallet, making a transaction to another wallet and to the same account.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
