### PR TITLE
add clang prereq

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ We recommend you update Rust to the latest stable version [`rustup update stable
 
 ### Dependencies
 
-`cmake` and `openssl` are required. In order to run the build process succesfully using Cargo you might need install additional build tools on your system. 
+`cmake`, `clang` and `openssl` are required. In order to run the build process succesfully using Cargo you might need install additional build tools on your system. 
 
 ### Windows
 
@@ -54,7 +54,7 @@ $ brew install cmake openssl@1.1
 
 ### Linux
 
-Install `cmake` and `openssl` with your distro's package manager or download from their websites. On Debian and Ubuntu you will also need `build-essential`.
+Install `cmake`, `lang` and `openssl` with your distro's package manager or download from their websites. On Debian and Ubuntu you will also need `build-essential`.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ $ brew install cmake openssl@1.1
 
 ### Linux
 
-Install `cmake`, `lang` and `openssl` with your distro's package manager or download from their websites. On Debian and Ubuntu you will also need `build-essential`.
+Install `cmake`, `clang` and `openssl` with your distro's package manager or download from their websites. On Debian and Ubuntu you will also need `build-essential`.
 
 ## Usage
 


### PR DESCRIPTION


# Description of change

At least for Ubuntu 18.4. the package clang is needed in addition to cmake and openssl. 
I have updated the "Ubuntu" section, for Windows and Mac this is still to be clarified

## Links to any relevant issues


## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation Fix

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
