### PR TITLE
fix(stronghold): mark client as loaded if the snapshot decrypt succeded

### DIFF
--- a/.changes/set-stronghold-password.md
+++ b/.changes/set-stronghold-password.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": patch
+---
+
+Fixes `setStrongholdPassword` accepting a wrong password after a few tries.

--- a/src/stronghold.rs
+++ b/src/stronghold.rs
@@ -408,7 +408,6 @@ pub async fn unload_snapshot(storage_path: &PathBuf, persist: bool) -> Result<()
 
 pub async fn load_snapshot(snapshot_path: &PathBuf, password: Vec<u8>) -> Result<()> {
     let mut runtime = actor_runtime().lock().await;
-    println!("LOAD CALLED");
     load_snapshot_internal(&mut runtime, snapshot_path, password).await
 }
 


### PR DESCRIPTION
# Description of change

Fixes `set_stronghold_password` accepting a wrong password after a few tries. 

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

CLI wallet.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
