### PR TITLE
refactor(message): add input details on transaction essence inputs

### DIFF
--- a/.changes/message-inputs.md
+++ b/.changes/message-inputs.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": patch
+---
+
+Adds a `metadata` field on the transaction essence inputs.

--- a/bindings/nodejs/lib/index.d.ts
+++ b/bindings/nodejs/lib/index.d.ts
@@ -22,16 +22,40 @@ export declare type Essence = {
   data: RegularEssence
 }
 
-export declare interface Input {
-  transactionId: string
-  outputIndex: number
+export declare interface UTXOInput {
+  input: string
+  metadata?: {
+    transactionId: string
+    messageId: string
+    index: number
+    amount: number
+    is_spent: boolean
+    address: string
+  }
 }
 
-export declare interface Output {
+export declare type Input = { type: 'UTXO', data: UTXOInput }
+
+export declare interface SignatureLockedSingleOutput {
   address: string
   amount: number
   remainder: boolean
 }
+
+export declare interface SignatureLockedDustAllowance {
+  address: string
+  amount: number
+  remainder: boolean
+}
+
+export declare type Output = {
+  type: 'SignatureLockedSingleOutput',
+  data: SignatureLockedSingleOutput
+}
+  | {
+    type: 'SignatureLockedDustAllowance',
+    data: SignatureLockedDustAllowance
+  }
 
 export declare interface Transaction {
   essence: Essence;

--- a/bindings/python/native/src/classes/account.rs
+++ b/bindings/python/native/src/classes/account.rs
@@ -297,18 +297,22 @@ impl AccountInitialiser {
     /// Messages associated with the seed.
     /// The account can be initialised with locally stored messages.
     fn messages(&mut self, messages: Vec<WalletMessage>) {
-        self.account_initialiser = Some(
-            self.account_initialiser.take().unwrap().messages(
-                messages
-                    .into_iter()
-                    .map(|msg| {
-                        // we use an empty bech32 HRP here because we update it later on wallet.rs
-                        to_rust_message(msg, "".to_string(), &self.addresses)
-                            .unwrap_or_else(|msg| panic!("AccountInitialiser: Message {:?} is invalid", msg))
-                    })
-                    .collect(),
-            ),
-        );
+        let mut account_initialiser = self.account_initialiser.take().unwrap();
+        let messages = messages
+            .into_iter()
+            .map(|msg| {
+                // we use an empty bech32 HRP here because we update it later on wallet.rs
+                to_rust_message(
+                    msg,
+                    "".to_string(),
+                    &self.addresses,
+                    &account_initialiser.client_options,
+                )
+                .unwrap_or_else(|msg| panic!("AccountInitialiser: Message {:?} is invalid", msg))
+            })
+            .collect();
+        account_initialiser = account_initialiser.messages(messages);
+        self.account_initialiser = Some(account_initialiser);
     }
 
     /// Address history associated with the seed.

--- a/bindings/python/native/src/classes/account.rs
+++ b/bindings/python/native/src/classes/account.rs
@@ -302,12 +302,12 @@ impl AccountInitialiser {
             .into_iter()
             .map(|msg| {
                 // we use an empty bech32 HRP here because we update it later on wallet.rs
-                to_rust_message(
+                crate::block_on(to_rust_message(
                     msg,
                     "".to_string(),
                     &self.addresses,
                     &account_initialiser.client_options,
-                )
+                ))
                 .unwrap_or_else(|msg| panic!("AccountInitialiser: Message {:?} is invalid", msg))
             })
             .collect();

--- a/bindings/python/native/src/types/account.rs
+++ b/bindings/python/native/src/types/account.rs
@@ -1,7 +1,6 @@
 // Copyright 2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use super::address::AddressWrapper;
 use dict_derive::{FromPyObject as DeriveFromPyObject, IntoPyObject as DeriveIntoPyObject};
 use iota_wallet::{
     account::{
@@ -51,22 +50,6 @@ pub struct AccountsSynchronizer {
 #[derive(Debug, Clone)]
 pub struct Transfer {
     pub transfer: RustTransfer,
-}
-
-#[derive(Debug, DeriveFromPyObject, DeriveIntoPyObject)]
-pub struct AddressOutput {
-    /// Transaction ID of the output
-    transaction_id: String,
-    /// Message ID of the output
-    message_id: String,
-    /// Output index.
-    index: u16,
-    /// Output amount.
-    amount: u64,
-    /// Spend status of the output,
-    is_spent: bool,
-    /// Associated address.
-    address: AddressWrapper,
 }
 
 #[derive(Debug, DeriveFromPyObject, DeriveIntoPyObject)]

--- a/bindings/python/native/src/types/address.rs
+++ b/bindings/python/native/src/types/address.rs
@@ -21,12 +21,12 @@ pub struct Address {
     outputs: Vec<AddressOutput>,
 }
 
-#[derive(Debug, DeriveFromPyObject, DeriveIntoPyObject)]
+#[derive(Debug, Clone, DeriveFromPyObject, DeriveIntoPyObject)]
 pub struct AddressWrapper {
     inner: String,
 }
 
-#[derive(Debug, DeriveFromPyObject, DeriveIntoPyObject)]
+#[derive(Debug, Clone, DeriveFromPyObject, DeriveIntoPyObject)]
 pub struct AddressOutput {
     /// Transaction ID of the output
     transaction_id: String,
@@ -69,8 +69,8 @@ impl From<RustAccountBalance> for AccountBalance {
     }
 }
 
-impl From<&RustAddressOutput> for AddressOutput {
-    fn from(output: &RustAddressOutput) -> Self {
+impl From<RustAddressOutput> for AddressOutput {
+    fn from(output: RustAddressOutput) -> Self {
         Self {
             transaction_id: output.transaction_id().to_string(),
             message_id: output.message_id().to_string(),
@@ -105,7 +105,11 @@ impl From<RustWalletAddress> for Address {
             balance: *wallet_address.balance(),
             key_index: *wallet_address.key_index(),
             internal: *wallet_address.internal(),
-            outputs: wallet_address.outputs().iter().map(|output| output.into()).collect(),
+            outputs: wallet_address
+                .outputs()
+                .iter()
+                .map(|output| output.clone().into())
+                .collect(),
         }
     }
 }

--- a/bindings/python/native/src/types/address.rs
+++ b/bindings/python/native/src/types/address.rs
@@ -69,8 +69,8 @@ impl From<RustAccountBalance> for AccountBalance {
     }
 }
 
-impl From<RustAddressOutput> for AddressOutput {
-    fn from(output: RustAddressOutput) -> Self {
+impl From<&RustAddressOutput> for AddressOutput {
+    fn from(output: &RustAddressOutput) -> Self {
         Self {
             transaction_id: output.transaction_id().to_string(),
             message_id: output.message_id().to_string(),
@@ -105,11 +105,7 @@ impl From<RustWalletAddress> for Address {
             balance: *wallet_address.balance(),
             key_index: *wallet_address.key_index(),
             internal: *wallet_address.internal(),
-            outputs: wallet_address
-                .outputs()
-                .iter()
-                .map(|output| output.clone().into())
-                .collect(),
+            outputs: wallet_address.outputs().iter().map(|output| output.into()).collect(),
         }
     }
 }

--- a/bindings/python/native/src/types/message.rs
+++ b/bindings/python/native/src/types/message.rs
@@ -1,7 +1,10 @@
 // Copyright 2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use super::error::{Error, Result};
+use super::{
+    error::{Error, Result},
+    AddressOutput,
+};
 use chrono::prelude::{DateTime, NaiveDateTime, Utc};
 use core::convert::TryFrom;
 use dict_derive::{FromPyObject as DeriveFromPyObject, IntoPyObject as DeriveIntoPyObject};
@@ -26,7 +29,8 @@ use iota_wallet::{
         Message as RustWalletMessage, MessagePayload as RustWalletPayload,
         MessageTransactionPayload as RustWalletMessageTransactionPayload,
         TransactionBuilderMetadata as RustWalletTransactionBuilderMetadata,
-        TransactionEssence as RustWalletTransactionEssence, TransactionOutput as RustWalletOutput,
+        TransactionEssence as RustWalletTransactionEssence, TransactionInput as RustWalletInput,
+        TransactionOutput as RustWalletOutput,
     },
 };
 use std::{
@@ -200,10 +204,11 @@ impl TryFrom<RustWalletTransactionEssence> for Essence {
                     .iter()
                     .cloned()
                     .map(|input| {
-                        if let RustInput::UTXO(input) = input {
+                        if let RustWalletInput::UTXO(input) = input {
                             Input {
-                                transaction_id: input.output_id().transaction_id().to_string(),
-                                index: input.output_id().index(),
+                                transaction_id: input.input.output_id().transaction_id().to_string(),
+                                index: input.input.output_id().index(),
+                                metadata: input.metadata.map(|m| m.into()),
                             }
                         } else {
                             unreachable!()
@@ -307,7 +312,7 @@ impl TryFrom<RustUnlockBlock> for UnlockBlock {
     }
 }
 
-pub fn to_rust_message(
+pub async fn to_rust_message(
     msg: WalletMessage,
     bech32_hrp: String,
     account_addresses: &[RustWalletAddress],
@@ -319,13 +324,7 @@ pub fn to_rust_message(
     }
     let id = MessageId::from_str(&msg.id)?;
     let payload = match msg.payload {
-        Some(payload) => Some(to_rust_payload(
-            &id,
-            payload,
-            bech32_hrp,
-            account_addresses,
-            client_options,
-        )?),
+        Some(payload) => Some(to_rust_payload(&id, payload, bech32_hrp, account_addresses, client_options).await?),
         None => None,
     };
     Ok(RustWalletMessage {
@@ -453,7 +452,7 @@ impl TryFrom<UnlockBlock> for RustUnlockBlock {
     }
 }
 
-pub fn to_rust_payload(
+pub async fn to_rust_payload(
     message_id: &MessageId,
     payload: Payload,
     bech32_hrp: Bech32HRP,
@@ -475,7 +474,7 @@ pub fn to_rust_payload(
             client_options,
         };
         Ok(RustWalletPayload::Transaction(Box::new(
-            RustWalletMessageTransactionPayload::new(&transaction.finish()?, &metadata),
+            RustWalletMessageTransactionPayload::new(&transaction.finish()?, &metadata).await?,
         )))
     } else {
         let indexation = RustIndexationPayload::new(
@@ -575,6 +574,7 @@ pub struct Output {
 pub struct Input {
     pub transaction_id: String,
     pub index: u16,
+    pub metadata: Option<AddressOutput>,
 }
 
 #[derive(Debug, Clone, DeriveFromPyObject, DeriveIntoPyObject)]

--- a/bindings/python/native/src/types/message.rs
+++ b/bindings/python/native/src/types/message.rs
@@ -208,7 +208,7 @@ impl TryFrom<RustWalletTransactionEssence> for Essence {
                             Input {
                                 transaction_id: input.input.output_id().transaction_id().to_string(),
                                 index: input.input.output_id().index(),
-                                metadata: input.metadata.map(|m| m.into()),
+                                metadata: input.metadata.map(|m| (&m).into()),
                             }
                         } else {
                             unreachable!()

--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -107,7 +107,8 @@ pub struct AccountInitialiser {
     created_at: Option<DateTime<Local>>,
     messages: Vec<Message>,
     addresses: Vec<Address>,
-    client_options: ClientOptions,
+    #[doc(hidden)]
+    pub client_options: ClientOptions,
     signer_type: Option<SignerType>,
     skip_persistance: bool,
 }
@@ -947,13 +948,15 @@ mod tests {
             .address(first_address.clone())
             .value(15)
             .input_transaction_id(first_address.outputs[0].transaction_id)
-            .build();
+            .build()
+            .await;
         let confirmed_message = crate::test_utils::GenerateMessageBuilder::default()
             .address(second_address.clone())
             .value(10)
             .input_transaction_id(second_address.outputs[0].transaction_id)
             .confirmed(Some(true))
-            .build();
+            .build()
+            .await;
 
         account_handle
             .write()
@@ -977,18 +980,22 @@ mod tests {
         let received_message = crate::test_utils::GenerateMessageBuilder::default()
             .address(latest_address.clone())
             .incoming(true)
-            .build();
+            .build()
+            .await;
         let failed_message = crate::test_utils::GenerateMessageBuilder::default()
             .address(latest_address.clone())
             .broadcasted(false)
-            .build();
+            .build()
+            .await;
         let unconfirmed_message = crate::test_utils::GenerateMessageBuilder::default()
             .address(latest_address.clone())
             .confirmed(None)
-            .build();
+            .build()
+            .await;
         let value_message = crate::test_utils::GenerateMessageBuilder::default()
             .address(latest_address.clone())
-            .build();
+            .build()
+            .await;
         account_handle.write().await.append_messages(vec![
             received_message,
             failed_message,
@@ -1016,31 +1023,36 @@ mod tests {
             .incoming(true)
             .confirmed(Some(true))
             .broadcasted(true)
-            .build();
+            .build()
+            .await;
         let sent_message = crate::test_utils::GenerateMessageBuilder::default()
             .address(external_address.clone())
             .incoming(false)
             .confirmed(Some(true))
             .broadcasted(true)
-            .build();
+            .build()
+            .await;
         let failed_message = crate::test_utils::GenerateMessageBuilder::default()
             .address(latest_address.clone())
             .incoming(false)
             .confirmed(Some(true))
             .broadcasted(false)
-            .build();
+            .build()
+            .await;
         let unconfirmed_message = crate::test_utils::GenerateMessageBuilder::default()
             .address(latest_address.clone())
             .incoming(false)
             .confirmed(None)
             .broadcasted(true)
-            .build();
+            .build()
+            .await;
         let value_message = crate::test_utils::GenerateMessageBuilder::default()
             .address(latest_address.clone())
             .incoming(false)
             .confirmed(Some(true))
             .broadcasted(true)
-            .build();
+            .build()
+            .await;
 
         account_handle.write().await.append_messages(vec![
             received_message.clone(),
@@ -1076,12 +1088,10 @@ mod tests {
         let manager = crate::test_utils::get_account_manager().await;
         let account_handle = crate::test_utils::AccountCreator::new(&manager).create().await;
 
-        let message = crate::test_utils::GenerateMessageBuilder::default().build();
-        account_handle.write().await.append_messages(vec![
-            crate::test_utils::GenerateMessageBuilder::default().build(),
-            message.clone(),
-        ]);
-        assert_eq!(account_handle.read().await.get_message(message.id()).unwrap(), &message);
+        let m1 = crate::test_utils::GenerateMessageBuilder::default().build().await;
+        let m2 = crate::test_utils::GenerateMessageBuilder::default().build().await;
+        account_handle.write().await.append_messages(vec![m1, m2.clone()]);
+        assert_eq!(account_handle.read().await.get_message(m2.id()).unwrap(), &m2);
     }
 
     #[tokio::test]
@@ -1101,7 +1111,8 @@ mod tests {
                 let spent_tx = crate::test_utils::GenerateMessageBuilder::default()
                     .address(spent_address.clone())
                     .incoming(false)
-                    .build();
+                    .build()
+                    .await;
 
                 account_handle.write().await.append_messages(vec![spent_tx]);
 

--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -387,14 +387,15 @@ async fn perform_sync(
 
     account.append_addresses(addresses_to_save);
 
-    let parsed_messages = new_messages
-        .into_iter()
-        .map(|(id, confirmed, message)| {
-            Message::from_iota_message(id, message, account.addresses())
+    let mut parsed_messages = Vec::new();
+    for (id, confirmed, message) in new_messages {
+        parsed_messages.push(
+            Message::from_iota_message(id, message, &account)
                 .with_confirmed(confirmed)
                 .finish()
-        })
-        .collect();
+                .await?,
+        );
+    }
     log::debug!("[SYNC] new messages: {:#?}", parsed_messages);
     account.append_messages(parsed_messages);
 
@@ -1161,7 +1162,9 @@ async fn perform_transfer(
         account_.append_addresses(vec![addr]);
     }
 
-    let message = Message::from_iota_message(message_id, message, account_.addresses()).finish();
+    let message = Message::from_iota_message(message_id, message, &account_)
+        .finish()
+        .await?;
     account_.append_messages(vec![message.clone()]);
 
     account_.save().await?;
@@ -1297,7 +1300,7 @@ pub(crate) async fn repost_message(
                 RepostAction::Reattach => client.reattach(message_id).await?,
                 RepostAction::Retry => client.retry(message_id).await?,
             };
-            let message = Message::from_iota_message(id, message, account.addresses()).finish();
+            let message = Message::from_iota_message(id, message, &account).finish().await?;
 
             account.append_messages(vec![message.clone()]);
 

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -1615,7 +1615,8 @@ mod tests {
                         .with_network_id(0)
                         .finish()
                         .unwrap(),
-                    &*crate::test_utils::AccountCreator::new(&manager)
+                    // dummy account
+                    &*crate::test_utils::AccountCreator::new(&crate::test_utils::get_account_manager().await)
                         .create()
                         .await
                         .read()

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -1615,10 +1615,16 @@ mod tests {
                         .with_network_id(0)
                         .finish()
                         .unwrap(),
-                    &[crate::test_utils::generate_random_address()],
+                    &*crate::test_utils::AccountCreator::new(&manager)
+                        .create()
+                        .await
+                        .read()
+                        .await,
                 )
                 .with_confirmed(Some(true))
-                .finish()])
+                .finish()
+                .await
+                .unwrap()])
                 .initialise()
                 .await
                 .unwrap();
@@ -1895,11 +1901,17 @@ mod tests {
         crate::test_utils::with_account_manager(crate::test_utils::TestType::Storage, |manager, _| async move {
             let account_handle = crate::test_utils::AccountCreator::new(&manager).create().await;
             let account = account_handle.read().await;
+            let m1 = crate::test_utils::GenerateMessageBuilder::default().build().await;
+            let m2 = crate::test_utils::GenerateMessageBuilder::default().build().await;
+            let m3 = crate::test_utils::GenerateMessageBuilder::default().build().await;
             let confirmation_change_events = vec![
-                (crate::test_utils::GenerateMessageBuilder::default().build(), true),
-                (crate::test_utils::GenerateMessageBuilder::default().build(), false),
-                (crate::test_utils::GenerateMessageBuilder::default().build(), false),
-                (crate::test_utils::GenerateMessageBuilder::default().build(), true),
+                (m1, true),
+                (
+                    crate::test_utils::GenerateMessageBuilder::default().build().await,
+                    false,
+                ),
+                (m2, false),
+                (m3, true),
             ];
             for (message, change) in &confirmation_change_events {
                 emit_confirmation_state_change(&account, message, *change)
@@ -1940,12 +1952,11 @@ mod tests {
                     |manager, _| async move {
                         let account_handle = crate::test_utils::AccountCreator::new(&manager).create().await;
                         let account = account_handle.read().await;
-                        let events = vec![
-                            crate::test_utils::GenerateMessageBuilder::default().build(),
-                            crate::test_utils::GenerateMessageBuilder::default().build(),
-                            crate::test_utils::GenerateMessageBuilder::default().build(),
-                            crate::test_utils::GenerateMessageBuilder::default().build(),
-                        ];
+                        let m1 = crate::test_utils::GenerateMessageBuilder::default().build().await;
+                        let m2 = crate::test_utils::GenerateMessageBuilder::default().build().await;
+                        let m3 = crate::test_utils::GenerateMessageBuilder::default().build().await;
+                        let m4 = crate::test_utils::GenerateMessageBuilder::default().build().await;
+                        let events = vec![m1, m2, m3, m4];
                         for message in &events {
                             emit_transaction_event($event_type, &account, message)
                                 .await

--- a/src/address.rs
+++ b/src/address.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     account::Account,
-    message::{MessagePayload, MessageType, TransactionEssence},
+    message::{MessagePayload, MessageType, TransactionEssence, TransactionInput},
     signing::GenerateAddressMetadata,
 };
 use getset::{Getters, Setters};
@@ -82,8 +82,8 @@ impl AddressOutput {
                 match m.payload() {
                     Some(MessagePayload::Transaction(tx)) => match tx.essence() {
                         TransactionEssence::Regular(essence) => essence.inputs().iter().any(|input| {
-                            if let Input::UTXO(x) = input {
-                                x == &output_id
+                            if let TransactionInput::UTXO(x) = input {
+                                x.input == output_id
                             } else {
                                 false
                             }
@@ -436,7 +436,8 @@ mod tests {
         let spent_tx = crate::test_utils::GenerateMessageBuilder::default()
             .address(address.clone())
             .incoming(false)
-            .build();
+            .build()
+            .await;
 
         account_handle.write().await.append_messages(vec![spent_tx]);
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -538,7 +538,7 @@ mod tests {
         let account_handle = crate::test_utils::AccountCreator::new(&manager).create().await;
         let account = account_handle.read().await;
         let account_id = account.id().to_string();
-        let message = crate::test_utils::GenerateMessageBuilder::default().build();
+        let message = crate::test_utils::GenerateMessageBuilder::default().build().await;
         let message_ = message.clone();
 
         on_new_transaction(move |event| {
@@ -558,7 +558,7 @@ mod tests {
         let account_handle = crate::test_utils::AccountCreator::new(&manager).create().await;
         let account = account_handle.read().await;
         let account_id = account.id().to_string();
-        let message = crate::test_utils::GenerateMessageBuilder::default().build();
+        let message = crate::test_utils::GenerateMessageBuilder::default().build().await;
         let message_ = message.clone();
 
         on_reattachment(move |event| {
@@ -578,7 +578,7 @@ mod tests {
         let account_handle = crate::test_utils::AccountCreator::new(&manager).create().await;
         let account = account_handle.read().await;
         let account_id = account.id().to_string();
-        let message = crate::test_utils::GenerateMessageBuilder::default().build();
+        let message = crate::test_utils::GenerateMessageBuilder::default().build().await;
         let message_ = message.clone();
 
         on_broadcast(move |event| {
@@ -598,7 +598,7 @@ mod tests {
         let account_handle = crate::test_utils::AccountCreator::new(&manager).create().await;
         let account = account_handle.read().await;
         let account_id = account.id().to_string();
-        let message = crate::test_utils::GenerateMessageBuilder::default().build();
+        let message = crate::test_utils::GenerateMessageBuilder::default().build().await;
         let message_ = message.clone();
         let confirmed = true;
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,14 +1,18 @@
 // Copyright 2020 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::address::{Address, AddressOutput, AddressWrapper, IotaAddress};
+use crate::{
+    account::Account,
+    address::{Address, AddressOutput, AddressWrapper, IotaAddress},
+    client::ClientOptions,
+};
 use bee_common::packable::Packable;
 use chrono::prelude::{DateTime, Utc};
 use getset::{Getters, Setters};
 pub use iota::{
     Essence, IndexationPayload, Input, Message as IotaMessage, MessageId, MilestonePayload, Output, Payload,
     ReceiptPayload, RegularEssence, SignatureLockedDustAllowanceOutput, SignatureLockedSingleOutput,
-    TransactionPayload, TreasuryOutput, TreasuryTransactionPayload, UnlockBlock,
+    TransactionPayload, TreasuryInput, TreasuryOutput, TreasuryTransactionPayload, UTXOInput, UnlockBlock,
 };
 use serde::{de::Deserializer, Deserialize, Serialize};
 use serde_repr::Deserialize_repr;
@@ -313,17 +317,36 @@ impl TransactionOutput {
     }
 }
 
+/// UTXO input.
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+pub struct TransactionUTXOInput {
+    /// UTXO input.
+    pub input: UTXOInput,
+    /// Metadata.
+    pub metadata: Option<AddressOutput>,
+}
+
+/// Transaction input.
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[serde(tag = "type", content = "data")]
+pub enum TransactionInput {
+    /// UTXO input.
+    UTXO(TransactionUTXOInput),
+    /// Treasury input.
+    Treasury(TreasuryInput),
+}
+
 /// Regular essence.
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub struct TransactionRegularEssence {
-    inputs: Box<[Input]>,
+    inputs: Box<[TransactionInput]>,
     outputs: Box<[TransactionOutput]>,
     payload: Option<Payload>,
 }
 
 impl TransactionRegularEssence {
     /// Gets the transaction inputs.
-    pub fn inputs(&self) -> &[Input] {
+    pub fn inputs(&self) -> &[TransactionInput] {
         &self.inputs
     }
 
@@ -339,15 +362,26 @@ impl TransactionRegularEssence {
 }
 
 impl TransactionRegularEssence {
-    fn new(
-        message_id: &MessageId,
-        regular_essence: &RegularEssence,
-        bech32_hrp: String,
-        account_addresses: &[Address],
-    ) -> Self {
+    async fn new(regular_essence: &RegularEssence, metadata: &TransactionBuilderMetadata<'_>) -> crate::Result<Self> {
+        let client = crate::client::get_client(metadata.client_options).await;
+        let client = client.read().await;
+
         let mut inputs = Vec::new();
         for input in regular_essence.inputs() {
-            inputs.push(input.clone());
+            let input = match input.clone() {
+                Input::UTXO(i) => {
+                    let metadata = if let Ok(output) = client.get_output(&i).await {
+                        let output = AddressOutput::from_output_response(output, metadata.bech32_hrp.clone())?;
+                        Some(output)
+                    } else {
+                        None
+                    };
+                    TransactionInput::UTXO(TransactionUTXOInput { input: i, metadata })
+                }
+                Input::Treasury(treasury) => TransactionInput::Treasury(treasury),
+                _ => unimplemented!(),
+            };
+            inputs.push(input);
         }
         let mut outputs = Vec::new();
 
@@ -356,7 +390,11 @@ impl TransactionRegularEssence {
             0 => {}
             // if the tx has one output, it is not a remainder output
             1 => {
-                outputs.push(TransactionOutput::new(tx_outputs.first().unwrap(), bech32_hrp, false));
+                outputs.push(TransactionOutput::new(
+                    tx_outputs.first().unwrap(),
+                    metadata.bech32_hrp.clone(),
+                    false,
+                ));
             }
             // if the tx has more than one output, we check which one is the remainder
             _ => {
@@ -375,13 +413,17 @@ impl TransactionRegularEssence {
                 // outgoing; so we assume that the highest address index holds the remainder, and the rest is the
                 // transfer outputs
                 let all_outputs_belongs_to_account = tx_outputs.iter().all(|(address, _)| {
-                    let address_belongs_to_account = account_addresses.iter().any(|a| &a.address().as_ref() == address);
+                    let address_belongs_to_account = metadata
+                        .account_addresses
+                        .iter()
+                        .any(|a| &a.address().as_ref() == address);
                     address_belongs_to_account
                 });
                 if all_outputs_belongs_to_account {
                     let mut remainder: Option<&Address> = None;
                     for (output_address, _) in &tx_outputs {
-                        let account_address = account_addresses
+                        let account_address = metadata
+                            .account_addresses
                             .iter()
                             .find(|a| &a.address().as_ref() == output_address)
                             .unwrap(); // safe to unwrap since we already asserted that the address belongs to the account
@@ -405,34 +447,37 @@ impl TransactionRegularEssence {
                     for (output_address, output) in tx_outputs {
                         outputs.push(TransactionOutput::new(
                             output,
-                            bech32_hrp.clone(),
+                            metadata.bech32_hrp.clone(),
                             remainder == Some(output_address),
                         ));
                     }
                 } else {
-                    let sent = !account_addresses
+                    let sent = !metadata
+                        .account_addresses
                         .iter()
-                        .any(|address| address.outputs().iter().any(|o| o.message_id() == message_id));
+                        .any(|address| address.outputs().iter().any(|o| o.message_id() == metadata.id));
                     for (output_address, output) in tx_outputs {
-                        let address_belongs_to_account =
-                            account_addresses.iter().any(|a| a.address().as_ref() == output_address);
+                        let address_belongs_to_account = metadata
+                            .account_addresses
+                            .iter()
+                            .any(|a| a.address().as_ref() == output_address);
                         if sent {
                             let remainder = address_belongs_to_account;
-                            outputs.push(TransactionOutput::new(output, bech32_hrp.clone(), remainder));
+                            outputs.push(TransactionOutput::new(output, metadata.bech32_hrp.clone(), remainder));
                         } else {
                             let remainder = !address_belongs_to_account;
-                            outputs.push(TransactionOutput::new(output, bech32_hrp.clone(), remainder));
+                            outputs.push(TransactionOutput::new(output, metadata.bech32_hrp.clone(), remainder));
                         }
                     }
                 }
             }
         }
 
-        Self {
+        Ok(Self {
             inputs: inputs.into_boxed_slice(),
             outputs: outputs.into_boxed_slice(),
             payload: regular_essence.payload().clone(),
-        }
+        })
     }
 }
 
@@ -446,16 +491,12 @@ pub enum TransactionEssence {
 
 impl TransactionEssence {
     #[doc(hidden)]
-    pub fn new(message_id: &MessageId, essence: &Essence, bech32_hrp: String, account_addresses: &[Address]) -> Self {
-        match essence {
-            Essence::Regular(regular) => Self::Regular(TransactionRegularEssence::new(
-                message_id,
-                regular,
-                bech32_hrp,
-                account_addresses,
-            )),
+    pub async fn new(essence: &Essence, metadata: &TransactionBuilderMetadata<'_>) -> crate::Result<Self> {
+        let essence = match essence {
+            Essence::Regular(regular) => Self::Regular(TransactionRegularEssence::new(regular, metadata).await?),
             _ => unimplemented!(),
-        }
+        };
+        Ok(essence)
     }
 }
 
@@ -482,20 +523,15 @@ impl MessageTransactionPayload {
     }
 
     #[doc(hidden)]
-    pub fn new(
-        message_id: &MessageId,
-        payload: &TransactionPayload,
-        bech32_hrp: String,
-        account_addresses: &[Address],
-    ) -> Self {
+    pub async fn new(payload: &TransactionPayload, metadata: &TransactionBuilderMetadata<'_>) -> crate::Result<Self> {
         let mut unlock_blocks = Vec::new();
         for unlock_block in payload.unlock_blocks() {
             unlock_blocks.push(unlock_block.clone());
         }
-        Self {
-            essence: TransactionEssence::new(message_id, payload.essence(), bech32_hrp, account_addresses),
+        Ok(Self {
+            essence: TransactionEssence::new(payload.essence(), metadata).await?,
             unlock_blocks: unlock_blocks.into_boxed_slice(),
-        }
+        })
     }
 }
 
@@ -516,25 +552,18 @@ pub enum MessagePayload {
 }
 
 impl MessagePayload {
-    pub(crate) fn new(
-        message_id: &MessageId,
-        payload: Payload,
-        bech32_hrp: String,
-        account_addresses: &[Address],
-    ) -> Self {
-        match payload {
-            Payload::Transaction(tx) => Self::Transaction(Box::new(MessageTransactionPayload::new(
-                message_id,
-                &tx,
-                bech32_hrp,
-                account_addresses,
-            ))),
+    pub(crate) async fn new(payload: Payload, metadata: &TransactionBuilderMetadata<'_>) -> crate::Result<Self> {
+        let payload = match payload {
+            Payload::Transaction(tx) => {
+                Self::Transaction(Box::new(MessageTransactionPayload::new(&tx, metadata).await?))
+            }
             Payload::Milestone(milestone) => Self::Milestone(milestone),
             Payload::Indexation(indexation) => Self::Indexation(indexation),
             Payload::Receipt(receipt) => Self::Receipt(receipt),
             Payload::TreasuryTransaction(treasury_tx) => Self::TreasuryTransaction(treasury_tx),
             _ => unimplemented!(),
-        }
+        };
+        Ok(payload)
     }
 }
 
@@ -619,22 +648,38 @@ impl PartialOrd for Message {
     }
 }
 
+#[doc(hidden)]
+pub struct TransactionBuilderMetadata<'a> {
+    pub id: &'a MessageId,
+    pub bech32_hrp: String,
+    pub account_addresses: &'a [Address],
+    pub client_options: &'a ClientOptions,
+}
+
 pub(crate) struct MessageBuilder<'a> {
     id: MessageId,
     iota_message: IotaMessage,
     account_addresses: &'a [Address],
     confirmed: Option<bool>,
     bech32_hrp: String,
+    client_options: &'a ClientOptions,
 }
 
 impl<'a> MessageBuilder<'a> {
-    pub fn new(id: MessageId, iota_message: IotaMessage, account_addresses: &'a [Address], bech32_hrp: String) -> Self {
+    pub fn new(
+        id: MessageId,
+        iota_message: IotaMessage,
+        account_addresses: &'a [Address],
+        bech32_hrp: String,
+        client_options: &'a ClientOptions,
+    ) -> Self {
         Self {
             id,
             iota_message,
             account_addresses,
             confirmed: None,
             bech32_hrp,
+            client_options,
         }
     }
 
@@ -643,15 +688,24 @@ impl<'a> MessageBuilder<'a> {
         self
     }
 
-    pub fn finish(self) -> Message {
+    pub async fn finish(self) -> crate::Result<Message> {
         let packed_payload = self.iota_message.payload().pack_new();
-        let bech32_hrp = self.bech32_hrp.to_string();
 
-        let payload = self
-            .iota_message
-            .payload()
-            .clone()
-            .map(|p| MessagePayload::new(&self.id, p, bech32_hrp, &self.account_addresses));
+        let payload = match self.iota_message.payload() {
+            Some(payload) => Some(
+                MessagePayload::new(
+                    payload.clone(),
+                    &TransactionBuilderMetadata {
+                        id: &self.id,
+                        bech32_hrp: self.bech32_hrp.clone(),
+                        account_addresses: &self.account_addresses,
+                        client_options: &self.client_options,
+                    },
+                )
+                .await?,
+            ),
+            None => None,
+        };
 
         let mut value = 0;
         let mut remainder_value = 0;
@@ -671,7 +725,7 @@ impl<'a> MessageBuilder<'a> {
             }
         }
 
-        Message {
+        let message = Message {
             id: self.id,
             version: 1,
             parents: self.iota_message.parents().to_vec(),
@@ -687,7 +741,8 @@ impl<'a> MessageBuilder<'a> {
                 .any(|address| address.outputs().iter().any(|o| o.message_id() == &self.id)),
             value,
             remainder_value,
-        }
+        };
+        Ok(message)
     }
 }
 
@@ -695,19 +750,21 @@ impl Message {
     pub(crate) fn from_iota_message(
         id: MessageId,
         iota_message: IotaMessage,
-        account_addresses: &'_ [Address],
+        account: &'_ Account,
     ) -> MessageBuilder<'_> {
         MessageBuilder::new(
             id,
             iota_message,
-            account_addresses,
-            account_addresses
+            account.addresses(),
+            account
+                .addresses()
                 .iter()
                 .next()
                 .unwrap()
                 .address()
                 .bech32_hrp()
                 .to_string(),
+            account.client_options(),
         )
     }
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -378,7 +378,7 @@ impl TransactionRegularEssence {
                             Some(output)
                         } else {
                             None
-                        };
+                        }
                     };
                     TransactionInput::UTXO(TransactionUTXOInput { input: i, metadata })
                 }

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -153,9 +153,10 @@ async fn process_output(
                 .data(&message_id)
                 .await
             {
-                let message = Message::from_iota_message(message_id, message, account.addresses())
+                let message = Message::from_iota_message(message_id, message, &account)
                     .with_confirmed(Some(true))
-                    .finish();
+                    .finish()
+                    .await?;
                 crate::event::emit_transaction_event(
                     crate::event::TransactionEventType::NewTransaction,
                     &account,


### PR DESCRIPTION
# Description of change

Fetch input information from the node /output/{output_id} endpoint and store it on the Message object.

## Links to any relevant issues

N/A

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

CLI wallet.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
