### PR TITLE
Update README.md

### DIFF
--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -12,7 +12,7 @@ Currently the package isn't published so you'd need to build by yourself.
 
 - Go to `bindings/python/native`
 - $ cargo build --release
-- The built library is located in `target/release/` On MacOS, rename `libiota_wallet.dylib` to `iota_wallet.so`, on Windows, use `iota_wallet.dll` directly, and on Linux, rename `libiota_wallet.so` to `iota_wallet.so`.
+- The built library is located in `target/release/` On MacOS, rename `libiota_wallet.dylib` to `iota_wallet.so`, on Windows rename `iota_wallet.dll` to `iota_wallet.pyd`, and on Linux, rename `libiota_wallet.so` to `iota_wallet.so`.
 - Copy your renamed library to `bindings/python/examples/``
 - Go to `binding/python/examples`
 - `$ python account_operations.py`


### PR DESCRIPTION
# Description of change

When trying to replicate installation steps on Win it turned out the compiled python library should be renamed also on Windows as of now.

## Type of change

- Documentation Fix

## How the change has been tested

Replicated installation steps on Win 10 (20H2) in order to compile python binding and use it in Python 3.7.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [X ] I have performed a self-review of my own code
- [X ] I have made corresponding changes to the documentation
