### PR TITLE
perf(sync): use tokio::spawn on client usage, optionally fetch spent output

### DIFF
--- a/bindings/nodejs/lib/index.d.ts
+++ b/bindings/nodejs/lib/index.d.ts
@@ -174,6 +174,7 @@ export declare interface ManagerOptions {
   storagePassword?: string
   outputConsolidationThreshold?: number
   automaticOutputConsolidation?: boolean
+  syncSpentOutputs?: boolean
 }
 
 export declare interface BalanceChangeEvent {

--- a/bindings/nodejs/native/src/classes/account_manager/mod.rs
+++ b/bindings/nodejs/native/src/classes/account_manager/mod.rs
@@ -82,6 +82,8 @@ struct ManagerOptions {
         default = "default_automatic_output_consolidation"
     )]
     automatic_output_consolidation: bool,
+    #[serde(rename = "syncSpentOutputs", default)]
+    sync_spent_outputs: bool,
 }
 
 fn default_automatic_output_consolidation() -> bool {
@@ -163,6 +165,9 @@ declare_types! {
                 .expect("failed to init storage");
             if !options.automatic_output_consolidation {
                 manager = manager.with_automatic_output_consolidation_disabled();
+            }
+            if options.sync_spent_outputs {
+                manager = manager.with_sync_spent_outputs();
             }
             if let Some(threshold) = options.output_consolidation_threshold {
                 manager = manager.with_output_consolidation_threshold(threshold);

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -82,18 +82,19 @@ Also for all the optional values, the default values are the same as the ones in
 
 ### AccountManager
 
-#### constructor(storage_path (optional), storage (optional), password (optional), polling_interval (optional), automatic_output_consolidation(optional), output_consolidation_threshold(optional)): [AccountManager](#accountmanager)
+#### constructor(storage_path (optional), storage (optional), password (optional), polling_interval (optional), automatic_output_consolidation(optional), output_consolidation_threshold(optional), sync_spent_outputs(optional)): [AccountManager](#accountmanager)
 
 Creates a new instance of the AccountManager.
 
-| Param                            | Type              | Default                   | Description                                                                                    |
-| -------------------------------- | ----------------- | ------------------------- | ---------------------------------------------------------------------------------------------- |
-| [storage_path]                   | <code>str</code>  | <code>`./storage`</code>  | The path where the database file will be saved                                                 |
-| [storage]                        | <code>str</code>  | <code>`Stronghold`</code> | The storage implementation to use. Should be `Stronghold` or `Sqlite`                          |
-| [storage_password]               | <code>str</code>  | <code>undefined</code>    | The storage password to encrypt/decrypt accounts                                               |
-| [polling_interval]               | <code>int</code>  | <code>30000</code>        | The polling interval in milliseconds                                                           |
-| [automatic_output_consolidation] | <code>bool</code> | <code>true</code>         | Disables the automatic output consolidation process                                            |
-| [output_consolidation_threshold] | <code>int</code>  | <code>100</code>          | Sets the number of outputs an address must have to trigger the automatic consolidation process |
+| Param                            | Type                 | Default                   | Description                                                                                    |
+| -------------------------------- | -------------------- | ------------------------- | ---------------------------------------------------------------------------------------------- |
+| [storage_path]                   | <code>str</code>     | <code>`./storage`</code>  | The path where the database file will be saved                                                 |
+| [storage]                        | <code>str</code>     | <code>`Stronghold`</code> | The storage implementation to use. Should be `Stronghold` or `Sqlite`                          |
+| [storage_password]               | <code>str</code>     | <code>undefined</code>    | The storage password to encrypt/decrypt accounts                                               |
+| [polling_interval]               | <code>int</code>     | <code>30000</code>        | The polling interval in milliseconds                                                           |
+| [automatic_output_consolidation] | <code>bool</code>    | <code>true</code>         | Disables the automatic output consolidation process                                            |
+| [output_consolidation_threshold] | <code>int</code>     | <code>100</code>          | Sets the number of outputs an address must have to trigger the automatic consolidation process |
+| [sync_spent_outputs]             | <code>boolean</code> | <code>false</code>        | Enables fetching spent output history on account sync                                          |
 
 Note: if the `storage_path` is set, then the `storage` needs to be set too. An exception will be thrown when errors happened.
 

--- a/bindings/python/native/src/classes/account_manager.rs
+++ b/bindings/python/native/src/classes/account_manager.rs
@@ -81,6 +81,7 @@ impl AccountManager {
         polling_interval: Option<u64>,
         automatic_output_consolidation: Option<bool>,
         output_consolidation_threshold: Option<usize>,
+        sync_spent_outputs: Option<bool>,
     ) -> Result<Self> {
         let mut account_manager = RustAccountManager::builder();
         if storage_path.is_some() & storage.is_some() {
@@ -108,6 +109,9 @@ impl AccountManager {
         }
         if !automatic_output_consolidation.unwrap_or(true) {
             account_manager = account_manager.with_automatic_output_consolidation_disabled();
+        }
+        if sync_spent_outputs.unwrap_or(false) {
+            account_manager = account_manager.with_sync_spent_outputs();
         }
         if let Some(threshold) = output_consolidation_threshold {
             account_manager = account_manager.with_output_consolidation_threshold(threshold);

--- a/docs/libraries/nodejs/api_reference.md
+++ b/docs/libraries/nodejs/api_reference.md
@@ -44,6 +44,7 @@ Creates a new instance of the AccountManager.
 | [storagePassword]              | <code>string</code>  | <code>undefined</code> | The storage password                                                                      |
 | [outputConsolidationThreshold] | <code>number</code>  | <code>100</code>       | The number of outputs an address must have to trigger the automatic consolidation process |
 | [automaticOutputConsolidation] | <code>boolean</code> | <code>true</code>      | Disables the automatic output consolidation if false                                      |
+| [syncSpentOutputs]             | <code>boolean</code> | <code>false</code>     | Enables fetching spent output history on account sync                                     |
 
 #### setStrongholdPassword(password): void
 

--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    account_manager::AccountStore,
+    account_manager::{AccountOptions, AccountStore},
     address::{Address, AddressBuilder, AddressWrapper},
     client::ClientOptions,
     event::TransferProgressType,
@@ -103,7 +103,7 @@ impl From<usize> for AccountIdentifier {
 pub struct AccountInitialiser {
     accounts: AccountStore,
     storage_path: PathBuf,
-    output_consolidation_threshold: usize,
+    account_options: AccountOptions,
     alias: Option<String>,
     created_at: Option<DateTime<Local>>,
     messages: Vec<Message>,
@@ -120,12 +120,12 @@ impl AccountInitialiser {
         client_options: ClientOptions,
         accounts: AccountStore,
         storage_path: PathBuf,
-        output_consolidation_threshold: usize,
+        account_options: AccountOptions,
     ) -> Self {
         Self {
             accounts,
             storage_path,
-            output_consolidation_threshold,
+            account_options,
             alias: None,
             created_at: None,
             messages: vec![],
@@ -274,11 +274,11 @@ impl AccountInitialiser {
         account.set_id(format!("{}{}", ACCOUNT_ID_PREFIX, hex::encode(digest)));
 
         let guard = if self.skip_persistance {
-            AccountHandle::new(account, self.output_consolidation_threshold)
+            AccountHandle::new(account, self.account_options)
         } else {
             account.save().await?;
             let account_id = account.id().clone();
-            let guard = AccountHandle::new(account, self.output_consolidation_threshold);
+            let guard = AccountHandle::new(account, self.account_options);
             drop(accounts);
             self.accounts.write().await.insert(account_id, guard.clone());
             let _ = crate::monitor::monitor_account_addresses_balance(guard.clone()).await;
@@ -334,15 +334,15 @@ pub struct Account {
 pub struct AccountHandle {
     inner: Arc<RwLock<Account>>,
     locked_addresses: Arc<Mutex<Vec<AddressWrapper>>>,
-    pub(crate) output_consolidation_threshold: usize,
+    pub(crate) account_options: AccountOptions,
 }
 
 impl AccountHandle {
-    pub(crate) fn new(account: Account, output_consolidation_threshold: usize) -> Self {
+    pub(crate) fn new(account: Account, account_options: AccountOptions) -> Self {
         Self {
             inner: Arc::new(RwLock::new(account)),
             locked_addresses: Default::default(),
-            output_consolidation_threshold,
+            account_options,
         }
     }
 
@@ -356,7 +356,7 @@ impl AccountHandle {
         let mut addresses = Vec::new();
         let account = self.inner.read().await;
         for address in account.addresses() {
-            if address.available_outputs(&account).len() >= self.output_consolidation_threshold {
+            if address.available_outputs(&account).len() >= self.account_options.output_consolidation_threshold {
                 addresses.push(address.address().clone());
             }
         }

--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -487,6 +487,7 @@ impl AccountHandle {
             Some(latest_address.outputs().to_vec()),
             &mut latest_address,
             bech32_hrp,
+            self.account_options,
         )
         .await?;
         Ok(*latest_address.balance() == 0 && latest_address.outputs().is_empty())

--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -853,7 +853,7 @@ impl SyncedAccount {
             for address in account.addresses() {
                 let address_outputs = address.available_outputs(&account);
                 // the address outputs exceed the threshold, so we push a transfer to our vector
-                if address_outputs.len() >= self.account_handle.output_consolidation_threshold {
+                if address_outputs.len() >= self.account_handle.account_options.output_consolidation_threshold {
                     for outputs in address_outputs.chunks(INPUT_OUTPUT_COUNT_MAX) {
                         transfers.push(
                             Transfer::builder(

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -1824,7 +1824,7 @@ mod tests {
                 BalanceChange::spent(3),
             ];
             for change in &change_events {
-                emit_balance_change(&account, account.latest_address().address(), vec![], change.clone())
+                emit_balance_change(&account, account.latest_address().address(), change.clone())
                     .await
                     .unwrap();
             }

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -1824,7 +1824,7 @@ mod tests {
                 BalanceChange::spent(3),
             ];
             for change in &change_events {
-                emit_balance_change(&account, account.latest_address().address(), change.clone())
+                emit_balance_change(&account, account.latest_address().address(), vec![], change.clone())
                     .await
                     .unwrap();
             }

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -1568,7 +1568,7 @@ mod tests {
                         .finish()
                         .unwrap(),
                     // dummy account
-                    &[],
+                    &[crate::test_utils::generate_random_address()],
                     &ClientOptionsBuilder::new().build().unwrap(),
                 )
                 .with_confirmed(Some(true))

--- a/src/message.rs
+++ b/src/message.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    account::Account,
     address::{Address, AddressOutput, AddressWrapper, IotaAddress},
     client::ClientOptions,
     event::{emit_transfer_progress, TransferProgressType},
@@ -770,24 +769,24 @@ impl<'a> MessageBuilder<'a> {
 }
 
 impl Message {
-    pub(crate) fn from_iota_message(
+    pub(crate) fn from_iota_message<'a>(
         id: MessageId,
         iota_message: IotaMessage,
-        account: &'_ Account,
-    ) -> MessageBuilder<'_> {
+        account_addresses: &'a [Address],
+        client_options: &'a ClientOptions,
+    ) -> MessageBuilder<'a> {
         MessageBuilder::new(
             id,
             iota_message,
-            account.addresses(),
-            account
-                .addresses()
+            account_addresses,
+            account_addresses
                 .iter()
                 .next()
                 .unwrap()
                 .address()
                 .bech32_hrp()
                 .to_string(),
-            account.client_options(),
+            client_options,
         )
     }
 

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -154,10 +154,11 @@ async fn process_output(
                 .data(&message_id)
                 .await
             {
-                let message = Message::from_iota_message(message_id, message, &account)
-                    .with_confirmed(Some(true))
-                    .finish()
-                    .await?;
+                let message =
+                    Message::from_iota_message(message_id, message, account.addresses(), account.client_options())
+                        .with_confirmed(Some(true))
+                        .finish()
+                        .await?;
                 crate::event::emit_transaction_event(
                     crate::event::TransactionEventType::NewTransaction,
                     &account,


### PR DESCRIPTION
# Description of change

Some performance improvements on the account syncing.

## Links to any relevant issues

N/A

## Type of change

- Perf improvement

## How the change has been tested

Faucet.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have checked that new and existing unit tests pass locally with my changes
