### PR TITLE
fix: prevent duplicated message on `append_messages`

### DIFF
--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -759,9 +759,17 @@ impl Account {
             .collect()
     }
 
-    #[doc(hidden)]
-    pub fn append_messages(&mut self, messages: Vec<Message>) {
-        self.messages.extend(messages);
+    pub(crate) fn append_messages(&mut self, messages: Vec<Message>) {
+        messages.into_iter().for_each(
+            |message| match self.messages.iter().position(|m| m.id() == message.id()) {
+                Some(index) => {
+                    self.messages[index] = message;
+                }
+                None => {
+                    self.messages.push(message);
+                }
+            },
+        );
     }
 
     pub(crate) fn append_addresses(&mut self, addresses: Vec<Address>) {


### PR DESCRIPTION
# Description of change

Prevent message duplication on account.

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

CLI wallet.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
