### PR TITLE
fix(sync): do not generate addresses if stronghold is locked

### DIFF
--- a/src/signing/mod.rs
+++ b/src/signing/mod.rs
@@ -18,7 +18,7 @@ use tokio::sync::Mutex;
 pub(crate) mod ledger;
 
 #[cfg(feature = "stronghold")]
-mod stronghold;
+pub(crate) mod stronghold;
 
 type SignerHandle = Arc<Mutex<Box<dyn Signer + Sync + Send>>>;
 type Signers = Arc<Mutex<HashMap<SignerType, SignerHandle>>>;

--- a/src/signing/stronghold.rs
+++ b/src/signing/stronghold.rs
@@ -10,7 +10,7 @@ use std::{collections::HashMap, path::PathBuf};
 #[derive(Default)]
 pub struct StrongholdSigner;
 
-async fn stronghold_path(storage_path: &PathBuf) -> crate::Result<PathBuf> {
+pub(crate) async fn stronghold_path(storage_path: &PathBuf) -> crate::Result<PathBuf> {
     let storage_id = crate::storage::get(&storage_path).await?.lock().await.id();
     let path = if storage_id == crate::storage::stronghold::STORAGE_ID {
         storage_path.clone()

--- a/src/stronghold.rs
+++ b/src/stronghold.rs
@@ -147,7 +147,7 @@ pub async fn set_password_clear_interval(interval: Duration) {
 }
 
 /// Snapshot status.
-#[derive(Debug, Serialize)]
+#[derive(Debug, PartialEq, Eq, Serialize)]
 #[serde(tag = "status", content = "data")]
 pub enum SnapshotStatus {
     /// Snapshot is locked. This means that the password must be set again.
@@ -159,9 +159,11 @@ pub enum SnapshotStatus {
 #[derive(Debug, Serialize)]
 /// Stronghold status.
 pub struct Status {
+    /// The snapshot path.
     #[serde(rename = "snapshotPath")]
-    snapshot_path: PathBuf,
-    snapshot: SnapshotStatus,
+    pub snapshot_path: PathBuf,
+    /// The snapshot status.
+    pub snapshot: SnapshotStatus,
 }
 
 /// Gets the stronghold status for the given snapshot.


### PR DESCRIPTION
# Description of change

Skipping address generation when stronghold is locked so the sync finishes successfully for the existing addresses.

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Firefly.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked that new and existing unit tests pass locally with my changes
