### PR TITLE
fix(polling): perform sync on first run

### DIFF
--- a/bindings/python/native/src/types/message.rs
+++ b/bindings/python/native/src/types/message.rs
@@ -265,7 +265,7 @@ impl TryFrom<RustMilestonePayloadEssence> for MilestonePayloadEssence {
         Ok(MilestonePayloadEssence {
             index: essence.index(),
             timestamp: essence.timestamp(),
-            parents: essence.parents().iter().map(|parent| parent.to_string()).collect(),
+            parents: essence.parents().map(|parent| parent.to_string()).collect(),
             merkle_proof: essence.merkle_proof().try_into()?,
             public_keys: essence
                 .public_keys()

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -553,6 +553,7 @@ impl AccountManager {
                 .unwrap();
             runtime.block_on(async {
                 let mut interval = interval(polling_interval);
+                let mut synced = false;
                 loop {
                     tokio::select! {
                         _ = async {
@@ -561,22 +562,30 @@ impl AccountManager {
                             let storage_file_path_ = storage_file_path.clone();
                             let account_options = account_options;
 
-                            if let Err(error) = AssertUnwindSafe(poll(accounts.clone(), storage_file_path_, account_options, is_monitoring.load(Ordering::Relaxed), automatic_output_consolidation))
-                                .catch_unwind()
-                                .await {
-                                    // if the error isn't a crate::Error type
-                                if error.downcast_ref::<crate::Error>().is_none() {
-                                    let msg = if let Some(message) = error.downcast_ref::<String>() {
-                                        format!("Internal error: {}", message)
-                                    } else if let Some(message) = error.downcast_ref::<&str>() {
-                                        format!("Internal error: {}", message)
-                                    } else {
-                                        "Internal error".to_string()
-                                    };
-                                    log::error!("[POLLING] error: {}", msg);
-                                    let _error = crate::Error::Panic(msg);
-                                    // when the error is dropped, the on_error event will be triggered
-                                }
+                            if !accounts.read().await.is_empty() {
+                                let should_sync = !(synced && is_monitoring.load(Ordering::Relaxed));
+                                match AssertUnwindSafe(poll(accounts.clone(), storage_file_path_, account_options, should_sync, automatic_output_consolidation))
+                                    .catch_unwind()
+                                    .await {
+                                        Ok(_) => {
+                                            synced = true;
+                                        }
+                                        Err(error) => {
+                                            // if the error isn't a crate::Error type
+                                            if error.downcast_ref::<crate::Error>().is_none() {
+                                                let msg = if let Some(message) = error.downcast_ref::<String>() {
+                                                    format!("Internal error: {}", message)
+                                                } else if let Some(message) = error.downcast_ref::<&str>() {
+                                                    format!("Internal error: {}", message)
+                                                } else {
+                                                    "Internal error".to_string()
+                                                };
+                                                log::error!("[POLLING] error: {}", msg);
+                                                let _error = crate::Error::Panic(msg);
+                                                // when the error is dropped, the on_error event will be triggered
+                                            }
+                                        }
+                                    }
                             }
                         } => {}
                         _ = stop.recv() => {
@@ -1143,10 +1152,10 @@ async fn poll(
     accounts: AccountStore,
     storage_file_path: PathBuf,
     account_options: AccountOptions,
-    is_mqtt_monitoring: bool,
+    should_sync: bool,
     automatic_output_consolidation: bool,
 ) -> crate::Result<()> {
-    let retried = if !is_mqtt_monitoring {
+    let retried = if should_sync {
         let synced_accounts = AccountsSynchronizer::new(accounts.clone(), storage_file_path, account_options)
             .execute()
             .await?;


### PR DESCRIPTION
# Description of change

The first polling iteration should perform a complete sync on the accounts even when using MQTT, since MQTT only picks up new data and the account syncing process can get past changes on all addresses.

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

CLI wallet.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
