### PR TITLE
fix(manager): save accounts imported from stronghold file

### DIFF
--- a/.changes/fix-import-accounts.md
+++ b/.changes/fix-import-accounts.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": patch
+---
+
+Fixes backup import when using the SQLite database.

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -871,6 +871,7 @@ impl AccountManager {
                     account_handle.write().await.set_storage_path(self.storage_path.clone());
                 }
                 self.accounts = stronghold_manager.accounts.clone();
+                self.set_stronghold_password(stronghold_password.clone()).await?;
                 for account in self.accounts.read().await.values() {
                     account.write().await.save().await?;
                 }

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -871,6 +871,9 @@ impl AccountManager {
                     account_handle.write().await.set_storage_path(self.storage_path.clone());
                 }
                 self.accounts = stronghold_manager.accounts.clone();
+                for account in self.accounts.read().await.values() {
+                    account.write().await.save().await?;
+                }
             }
             #[cfg(not(any(feature = "stronghold", feature = "stronghold-storage")))]
             return Err(crate::Error::InvalidBackupFile);


### PR DESCRIPTION
# Description of change

Fixes backup import when using the SQLite database. 

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

CLI wallet.
