### PR TITLE
refactor(account): default alias starts at 1

### DIFF
--- a/.changes/default-account-alias.md
+++ b/.changes/default-account-alias.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": patch
+---
+
+The default account alias now starts at index 1.

--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -181,7 +181,7 @@ impl AccountInitialiser {
     pub async fn initialise(mut self) -> crate::Result<AccountHandle> {
         let accounts = self.accounts.read().await;
 
-        let alias = self.alias.unwrap_or_else(|| format!("Account {}", accounts.len()));
+        let alias = self.alias.unwrap_or_else(|| format!("Account {}", accounts.len() + 1));
         let signer_type = self.signer_type.ok_or(crate::Error::AccountInitialiseRequiredField(
             crate::error::AccountInitialiseRequiredField::SignerType,
         ))?;

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -406,12 +406,6 @@ impl AccountManager {
         is_monitoring.store(Self::_start_monitoring(accounts).await.is_ok(), Ordering::Relaxed);
     }
 
-    #[cfg(test)]
-    async fn _start_monitoring(_accounts: AccountStore) -> crate::Result<()> {
-        Ok(())
-    }
-
-    #[cfg(not(test))]
     async fn _start_monitoring(accounts: AccountStore) -> crate::Result<()> {
         for account in accounts.read().await.values() {
             crate::monitor::monitor_account_addresses_balance(account.clone()).await?;

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -38,6 +38,16 @@ pub async fn unsubscribe(account_handle: AccountHandle) -> crate::Result<()> {
     Ok(())
 }
 
+#[cfg(test)]
+async fn subscribe_to_topic<C: Fn(&TopicEvent) + Send + Sync + 'static>(
+    _client_options: &ClientOptions,
+    _topic: String,
+    _handler: C,
+) -> crate::Result<()> {
+    Ok(())
+}
+
+#[cfg(not(test))]
 async fn subscribe_to_topic<C: Fn(&TopicEvent) + Send + Sync + 'static>(
     client_options: &ClientOptions,
     topic: String,


### PR DESCRIPTION
# Description of change

Default account alias should start at 1 since that's better for UX.

## Links to any relevant issues

N/A

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
