### PR TITLE
feat(events): reintroduce message_ids on balance change event payload

### DIFF
--- a/.changes/balance-change-event-message-ids.md
+++ b/.changes/balance-change-event-message-ids.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": patch
+---
+
+Adds a `messageIds` field to the balance change event payload.

--- a/bindings/nodejs/lib/index.d.ts
+++ b/bindings/nodejs/lib/index.d.ts
@@ -182,6 +182,7 @@ export declare interface BalanceChangeEvent {
   indexationId: string
   accountId: string
   address: string
+  messageIds: string[]
   balanceChange: { spent: number, received: number }
 }
 

--- a/docs/libraries/nodejs/api_reference.md
+++ b/docs/libraries/nodejs/api_reference.md
@@ -178,7 +178,7 @@ Gets the persisted balance change events.
 | [skip]          | <code>number</code> | <code>0</code>    | The number of events to skip                                 |
 | [fromTimestamp] | <code>number</code> | <code>null</code> | Filter events that were stored after the given UTC timestamp |
 
-Event object: { indexationId: string, accountId: string, address: string, balanceChange: { spent: number, received: number } }
+Event object: { indexationId: string, accountId: string, address: string, messageIds: string[], balanceChange: { spent: number, received: number } }
 
 #### getBalanceChangeEventCount([fromTimestamp])
 

--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -711,7 +711,7 @@ impl AccountSynchronizer {
                     .collect::<Vec<Message>>();
 
                 // balance event
-                for (address_before_sync, before_sync_balance, _) in &addresses_before_sync {
+                for (address_before_sync, before_sync_balance, before_sync_outputs) in &addresses_before_sync {
                     let address_after_sync = account_ref
                         .addresses()
                         .iter()
@@ -725,9 +725,18 @@ impl AccountSynchronizer {
                             address_after_sync.balance()
                         );
 
+                        let mut message_ids = Vec::new();
+                        // check new and updated outputs to find message ids
+                        for output in address_after_sync.outputs() {
+                            if !before_sync_outputs.contains(&output) {
+                                message_ids.push(output.message_id);
+                            }
+                        }
+
                         emit_balance_change(
                             &account_ref,
                             address_after_sync.address(),
+                            message_ids,
                             if address_after_sync.balance() > before_sync_balance {
                                 BalanceChange::received(address_after_sync.balance() - before_sync_balance)
                             } else {

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -1865,9 +1865,15 @@ mod tests {
                 BalanceChange::spent(3),
             ];
             for change in &change_events {
-                emit_balance_change(&account, account.latest_address().address(), change.clone(), true)
-                    .await
-                    .unwrap();
+                emit_balance_change(
+                    &account,
+                    account.latest_address().address(),
+                    vec![],
+                    change.clone(),
+                    true,
+                )
+                .await
+                .unwrap();
             }
             assert!(
                 manager.get_balance_change_event_count(None).await.unwrap() == change_events.len(),

--- a/src/event.rs
+++ b/src/event.rs
@@ -65,7 +65,9 @@ pub struct BalanceEvent {
     #[serde(with = "crate::serde::iota_address_serde")]
     pub address: AddressWrapper,
     /// The message id associated with the balance change.
-    /// Note that this is unreliable without [AccountManagerBuilder#with_sync_spent_outputs](struct.AccountManagerBuilder.html#method.with_sync_spent_outputs). ``
+    /// Note that this is unreliable without
+    /// [AccountManagerBuilder#with_sync_spent_outputs](struct.AccountManagerBuilder.html#method.
+    /// with_sync_spent_outputs). ``
     #[serde(rename = "messageIds", default)]
     pub message_ids: Vec<MessageId>,
     /// The balance change data.

--- a/src/event.rs
+++ b/src/event.rs
@@ -625,6 +625,7 @@ mod tests {
         emit_balance_change(
             &account,
             &crate::test_utils::generate_random_iota_address(),
+            vec![],
             BalanceChange::spent(5),
             true,
         )

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,7 +1,11 @@
 // Copyright 2020 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{account::Account, address::AddressWrapper, message::Message};
+use crate::{
+    account::Account,
+    address::AddressWrapper,
+    message::{Message, MessageId},
+};
 
 use getset::Getters;
 use once_cell::sync::Lazy;
@@ -60,6 +64,10 @@ pub struct BalanceEvent {
     /// The associated address.
     #[serde(with = "crate::serde::iota_address_serde")]
     pub address: AddressWrapper,
+    /// The message id associated with the balance change.
+    /// Note that this is unreliable without [AccountManagerBuilder#with_sync_spent_outputs](struct.AccountManagerBuilder.html#method.with_sync_spent_outputs). ``
+    #[serde(rename = "messageIds", default)]
+    pub message_ids: Vec<MessageId>,
     /// The balance change data.
     #[serde(rename = "balanceChange")]
     pub balance_change: BalanceChange,
@@ -303,6 +311,7 @@ pub async fn remove_balance_change_listener(id: &EventId) {
 pub(crate) async fn emit_balance_change(
     account: &Account,
     address: &AddressWrapper,
+    message_ids: Vec<MessageId>,
     balance_change: BalanceChange,
     persist: bool,
 ) -> crate::Result<()> {
@@ -311,6 +320,7 @@ pub(crate) async fn emit_balance_change(
         indexation_id: generate_indexation_id(),
         account_id: account.id().to_string(),
         address: address.clone(),
+        message_ids,
         balance_change,
     };
 

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -137,6 +137,7 @@ async fn process_output(
     crate::event::emit_balance_change(
         &account,
         &address_wrapper,
+        vec![message_id],
         if new_balance > old_balance {
             crate::event::BalanceChange::received(new_balance - old_balance)
         } else {


### PR DESCRIPTION
# Description of change

Add message_ids on the balance change event payload.

## Links to any relevant issues

N/A

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

N/A

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have checked that new and existing unit tests pass locally with my changes
