### PR TITLE
refactor(message): detect internal txs, move value fields, fix balance

### DIFF
--- a/.changes/balance-internal-tx.md
+++ b/.changes/balance-internal-tx.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": patch
+---
+
+The `incoming` and `outgoing` account balances now ignores internal transactions.

--- a/.changes/message--value-refactor.md
+++ b/.changes/message--value-refactor.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": minor
+---
+
+Moved message fields `value`, `incoming`, `remainderValue` to the `RegularEssence` object.

--- a/bindings/nodejs/lib/index.d.ts
+++ b/bindings/nodejs/lib/index.d.ts
@@ -15,6 +15,10 @@ export declare interface RegularEssence {
   inputs: Input[];
   outputs: Output[];
   payload?: Payload[];
+  incoming: boolean;
+  internal: boolean;
+  value: number;
+  remainderValue: number;
 }
 
 export declare type Essence = {
@@ -72,8 +76,6 @@ export declare interface Message {
   nonce: number;
   confirmed?: boolean;
   broadcasted: boolean;
-  incoming: boolean;
-  value: number;
 }
 
 export declare interface Address {

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -924,10 +924,7 @@ wallet_message = {
     'timestamp': int,
     'nonce': int,
     'confirmed': bool (optional),
-    'broadcasted': bool,
-    'incoming': bool,
-    'value': int,
-    'remainder_value': int
+    'broadcasted': bool
 }
 ```
 
@@ -1009,6 +1006,10 @@ transaction_regular_essence = {
     'inputs': list[Input],
     'outputs': list[Output],
     'payload': Payload (optional),
+    'internal': bool,
+    'incoming': bool,
+    'value': int,
+    'remainder_value': int,
 }
 ```
 Please refer to [Input](#input), [Output](#output), and [Payload](#payload) for the details of these types.

--- a/bindings/python/native/src/classes/account.rs
+++ b/bindings/python/native/src/classes/account.rs
@@ -357,6 +357,8 @@ impl AccountInitialiser {
                 crate::block_on(to_rust_message(
                     msg,
                     "".to_string(),
+                    self.accounts.clone(),
+                    "",
                     &self.addresses,
                     &account_initialiser.client_options,
                 ))

--- a/bindings/python/native/src/classes/account_manager.rs
+++ b/bindings/python/native/src/classes/account_manager.rs
@@ -182,6 +182,7 @@ impl AccountManager {
         Ok(AccountInitialiser {
             account_initialiser: Some(self.account_manager.create_account(client_options.into())?),
             addresses: Default::default(),
+            accounts: self.account_manager.accounts().clone(),
         })
     }
 

--- a/bindings/python/native/src/types/account.rs
+++ b/bindings/python/native/src/types/account.rs
@@ -8,7 +8,9 @@ use iota_wallet::{
         AccountInitialiser as RustAccountInitialiser, AccountSynchronizer as RustAccountSynchronizer,
         SyncedAccount as RustSyncedAccount,
     },
-    account_manager::{AccountManager as RustAccountManager, AccountsSynchronizer as RustAccountsSynchronizer},
+    account_manager::{
+        AccountManager as RustAccountManager, AccountStore, AccountsSynchronizer as RustAccountsSynchronizer,
+    },
     address::Address as RustWalletAddress,
     message::Transfer as RustTransfer,
 };
@@ -24,6 +26,7 @@ pub struct AccountManager {
 pub struct AccountInitialiser {
     pub account_initialiser: Option<RustAccountInitialiser>,
     pub addresses: Vec<RustWalletAddress>,
+    pub accounts: AccountStore,
 }
 
 #[pyclass]

--- a/bindings/python/native/src/types/message.rs
+++ b/bindings/python/native/src/types/message.rs
@@ -20,6 +20,7 @@ use iota::{
 // use iota::MessageId as RustMessageId,
 use iota::{Address as IotaAddress, MessageId, TransactionId};
 use iota_wallet::{
+    account_manager::AccountStore,
     address::{
         Address as RustWalletAddress, AddressOutput as RustWalletAddressOutput, AddressWrapper as RustAddressWrapper,
         OutputKind as RustOutputKind,
@@ -122,12 +123,6 @@ pub struct WalletMessage {
     pub confirmed: Option<bool>,
     /// Whether the transaction is broadcasted or not.
     pub broadcasted: bool,
-    /// Whether the message represents an incoming transaction or not.
-    pub incoming: bool,
-    /// The message's value.
-    pub value: u64,
-    /// The message's remainder value sum.
-    pub remainder_value: u64,
 }
 
 impl TryFrom<RustWalletMessage> for WalletMessage {
@@ -187,9 +182,6 @@ impl TryFrom<RustWalletMessage> for WalletMessage {
             nonce: *msg.nonce(),
             confirmed: *msg.confirmed(),
             broadcasted: *msg.broadcasted(),
-            incoming: *msg.incoming(),
-            value: *msg.value(),
-            remainder_value: *msg.remainder_value(),
         })
     }
 }
@@ -252,6 +244,10 @@ impl TryFrom<RustWalletTransactionEssence> for Essence {
                 } else {
                     None
                 },
+                internal: essence.internal(),
+                incoming: essence.incoming(),
+                value: essence.value(),
+                remainder_value: essence.remainder_value(),
             }
             .into(),
         };
@@ -315,6 +311,8 @@ impl TryFrom<RustUnlockBlock> for UnlockBlock {
 pub async fn to_rust_message(
     msg: WalletMessage,
     bech32_hrp: String,
+    accounts: AccountStore,
+    account_id: &str,
     account_addresses: &[RustWalletAddress],
     client_options: &RustWalletClientOptions,
 ) -> Result<RustWalletMessage> {
@@ -324,7 +322,18 @@ pub async fn to_rust_message(
     }
     let id = MessageId::from_str(&msg.id)?;
     let payload = match msg.payload {
-        Some(payload) => Some(to_rust_payload(&id, payload, bech32_hrp, account_addresses, client_options).await?),
+        Some(payload) => Some(
+            to_rust_payload(
+                &id,
+                payload,
+                bech32_hrp,
+                accounts,
+                account_id,
+                account_addresses,
+                client_options,
+            )
+            .await?,
+        ),
         None => None,
     };
     Ok(RustWalletMessage {
@@ -337,9 +346,6 @@ pub async fn to_rust_message(
         nonce: msg.nonce,
         confirmed: msg.confirmed,
         broadcasted: msg.broadcasted,
-        incoming: msg.incoming,
-        value: msg.value,
-        remainder_value: msg.remainder_value,
     })
 }
 
@@ -456,6 +462,8 @@ pub async fn to_rust_payload(
     message_id: &MessageId,
     payload: Payload,
     bech32_hrp: Bech32HRP,
+    accounts: AccountStore,
+    account_id: &str,
     account_addresses: &[RustWalletAddress],
     client_options: &RustWalletClientOptions,
 ) -> Result<RustWalletPayload> {
@@ -473,6 +481,8 @@ pub async fn to_rust_payload(
         let metadata = RustWalletTransactionBuilderMetadata {
             id: message_id,
             bech32_hrp,
+            account_id,
+            accounts,
             account_addresses,
             client_options,
         };
@@ -559,6 +569,13 @@ pub struct RegularEssence {
     pub inputs: Vec<Input>,
     pub outputs: Vec<Output>,
     pub payload: Option<Payload>,
+    pub internal: bool,
+    /// Whether the transaction is incoming (received) or outgoing (sent).
+    pub incoming: bool,
+    /// The transaction's value.
+    pub value: u64,
+    /// The transaction's remainder value sum.
+    pub remainder_value: u64,
 }
 
 impl From<RegularEssence> for Essence {

--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -864,7 +864,7 @@ mod tests {
         account_manager::AccountManager,
         address::{Address, AddressBuilder, AddressOutput, OutputKind},
         client::ClientOptionsBuilder,
-        message::{Message, MessageType},
+        message::{Message, MessagePayload, MessageType, TransactionEssence},
     };
     use iota::{MessageId, TransactionId};
 
@@ -1066,7 +1066,13 @@ mod tests {
 
         assert_eq!(
             account_handle.read().await.balance().available,
-            balance - *unconfirmed_message.value()
+            balance
+                - if let Some(MessagePayload::Transaction(tx)) = unconfirmed_message.payload() {
+                    let TransactionEssence::Regular(essence) = tx.essence();
+                    essence.value()
+                } else {
+                    0
+                }
         );
     }
 

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -1613,7 +1613,8 @@ mod tests {
                         .with_network_id(0)
                         .finish()
                         .unwrap(),
-                    // dummy account
+                    Default::default(),
+                    "",
                     &[crate::test_utils::generate_random_address()],
                     &ClientOptionsBuilder::new().build().unwrap(),
                 )

--- a/src/message.rs
+++ b/src/message.rs
@@ -362,7 +362,7 @@ pub struct TransactionRegularEssence {
     outputs: Box<[TransactionOutput]>,
     payload: Option<Payload>,
     internal: bool,
-    incoming: bool,
+    pub(crate) incoming: bool,
     value: u64,
     #[serde(rename = "remainderValue")]
     remainder_value: u64,
@@ -637,7 +637,7 @@ impl MessageTransactionPayload {
         &self.essence
     }
 
-    fn essence_mut(&mut self) -> &mut TransactionEssence {
+    pub(crate) fn essence_mut(&mut self) -> &mut TransactionEssence {
         &mut self.essence
     }
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    account_manager::AccountStore,
     address::{Address, AddressOutput, AddressWrapper, IotaAddress},
     client::ClientOptions,
     event::{emit_transfer_progress, TransferProgressType},
@@ -360,6 +361,11 @@ pub struct TransactionRegularEssence {
     inputs: Box<[TransactionInput]>,
     outputs: Box<[TransactionOutput]>,
     payload: Option<Payload>,
+    internal: bool,
+    incoming: bool,
+    value: u64,
+    #[serde(rename = "remainderValue")]
+    remainder_value: u64,
 }
 
 impl TransactionRegularEssence {
@@ -376,6 +382,26 @@ impl TransactionRegularEssence {
     /// Gets the transaction chained payload.
     pub fn payload(&self) -> &Option<Payload> {
         &self.payload
+    }
+
+    /// Whether the transaction is between the mnemonic accounts or not.
+    pub fn internal(&self) -> bool {
+        self.internal
+    }
+
+    /// Whether the transaction is incoming or outgoing.
+    pub fn incoming(&self) -> bool {
+        self.incoming
+    }
+
+    /// The transactions's value.
+    pub fn value(&self) -> u64 {
+        self.value
+    }
+
+    /// The transactions's remainder value sum.
+    pub fn remainder_value(&self) -> u64 {
+        self.remainder_value
     }
 }
 
@@ -529,11 +555,53 @@ impl TransactionRegularEssence {
             }
         }
 
-        Ok(Self {
+        let mut value = 0;
+        let mut remainder_value = 0;
+        for output in &outputs {
+            let (output_value, remainder) = match output {
+                TransactionOutput::SignatureLockedSingle(o) => (o.amount, o.remainder),
+                TransactionOutput::SignatureLockedDustAllowance(o) => (o.amount, false),
+                TransactionOutput::Treasury(o) => (o.amount(), false),
+            };
+            if remainder {
+                remainder_value += output_value;
+            } else {
+                value += output_value;
+            }
+        }
+
+        let mut essence = Self {
             inputs: inputs.into_boxed_slice(),
             outputs: outputs.into_boxed_slice(),
             payload: regular_essence.payload().clone(),
-        })
+            internal: false,
+            incoming: false,
+            value,
+            remainder_value,
+        };
+
+        let sent = essence.inputs().iter().any(|i| match i {
+            TransactionInput::UTXO(input) => match input.metadata {
+                Some(ref input_metadata) => metadata
+                    .account_addresses
+                    .iter()
+                    .any(|a| &input_metadata.address == a.address()),
+                None => false,
+            },
+            _ => false,
+        });
+
+        let is_internal = is_internal(
+            &essence,
+            metadata.accounts.clone(),
+            metadata.account_id,
+            metadata.account_addresses,
+        )
+        .await;
+        essence.internal = is_internal;
+        essence.incoming = !sent;
+
+        Ok(essence)
     }
 }
 
@@ -649,13 +717,6 @@ pub struct Message {
     /// Whether the transaction is broadcasted or not.
     #[getset(set = "pub")]
     pub broadcasted: bool,
-    /// Whether the message represents an incoming transaction or not.
-    pub incoming: bool,
-    /// The message's value.
-    pub value: u64,
-    /// The message's remainder value sum.
-    #[serde(rename = "remainderValue")]
-    pub remainder_value: u64,
 }
 
 impl Message {
@@ -704,10 +765,71 @@ impl PartialOrd for Message {
     }
 }
 
+fn transaction_inputs_belongs_to_account(essence: &TransactionRegularEssence, account_addresses: &[Address]) -> bool {
+    return essence.inputs().iter().all(|input| {
+        if let TransactionInput::UTXO(i) = input {
+            if let Some(metadata) = &i.metadata {
+                return account_addresses
+                    .iter()
+                    .any(|address| address.address() == &metadata.address);
+            }
+        }
+        false
+    });
+}
+
+fn transaction_outputs_belongs_to_account(essence: &TransactionRegularEssence, account_addresses: &[Address]) -> bool {
+    return essence.outputs().iter().all(|output| {
+        let output_address = match output {
+            TransactionOutput::SignatureLockedDustAllowance(o) => o.address(),
+            TransactionOutput::SignatureLockedSingle(o) => o.address(),
+            _ => unimplemented!(),
+        };
+        return account_addresses
+            .iter()
+            .any(|address| address.address() == output_address);
+    });
+}
+
+async fn is_internal(
+    essence: &TransactionRegularEssence,
+    accounts: AccountStore,
+    account_id: &str,
+    account_addresses: &[Address],
+) -> bool {
+    let mut inputs_belongs_to_account = false;
+    let mut outputs_belongs_to_account = false;
+    for (id, account_handle) in accounts.read().await.iter() {
+        if id == account_id {
+            if !inputs_belongs_to_account {
+                inputs_belongs_to_account = transaction_inputs_belongs_to_account(&essence, &account_addresses);
+            }
+            if !outputs_belongs_to_account {
+                outputs_belongs_to_account = transaction_outputs_belongs_to_account(&essence, &account_addresses);
+            }
+        } else {
+            let account = account_handle.read().await;
+            if !inputs_belongs_to_account {
+                inputs_belongs_to_account = transaction_inputs_belongs_to_account(&essence, account.addresses());
+            }
+            if !outputs_belongs_to_account {
+                outputs_belongs_to_account = transaction_outputs_belongs_to_account(&essence, &account_addresses);
+            }
+        }
+
+        if inputs_belongs_to_account && outputs_belongs_to_account {
+            return true;
+        }
+    }
+    false
+}
+
 #[doc(hidden)]
 pub struct TransactionBuilderMetadata<'a> {
     pub id: &'a MessageId,
     pub bech32_hrp: String,
+    pub accounts: AccountStore,
+    pub account_id: &'a str,
     pub account_addresses: &'a [Address],
     pub client_options: &'a ClientOptions,
 }
@@ -715,6 +837,8 @@ pub struct TransactionBuilderMetadata<'a> {
 pub(crate) struct MessageBuilder<'a> {
     id: MessageId,
     iota_message: IotaMessage,
+    accounts: AccountStore,
+    account_id: &'a str,
     account_addresses: &'a [Address],
     confirmed: Option<bool>,
     bech32_hrp: String,
@@ -725,6 +849,8 @@ impl<'a> MessageBuilder<'a> {
     pub fn new(
         id: MessageId,
         iota_message: IotaMessage,
+        accounts: AccountStore,
+        account_id: &'a str,
         account_addresses: &'a [Address],
         bech32_hrp: String,
         client_options: &'a ClientOptions,
@@ -732,6 +858,8 @@ impl<'a> MessageBuilder<'a> {
         Self {
             id,
             iota_message,
+            accounts,
+            account_id,
             account_addresses,
             confirmed: None,
             bech32_hrp,
@@ -754,6 +882,8 @@ impl<'a> MessageBuilder<'a> {
                     &TransactionBuilderMetadata {
                         id: &self.id,
                         bech32_hrp: self.bech32_hrp.clone(),
+                        accounts: self.accounts.clone(),
+                        account_id: self.account_id,
                         account_addresses: &self.account_addresses,
                         client_options: &self.client_options,
                     },
@@ -762,37 +892,6 @@ impl<'a> MessageBuilder<'a> {
             ),
             None => None,
         };
-
-        let mut value = 0;
-        let mut remainder_value = 0;
-        let mut sent = false;
-        if let Some(MessagePayload::Transaction(tx)) = &payload {
-            let TransactionEssence::Regular(essence) = tx.essence();
-
-            sent = essence.inputs().iter().any(|i| match i {
-                TransactionInput::UTXO(input) => match input.metadata {
-                    Some(ref input_metadata) => self
-                        .account_addresses
-                        .iter()
-                        .any(|a| &input_metadata.address == a.address()),
-                    None => false,
-                },
-                _ => false,
-            });
-
-            for output in essence.outputs() {
-                let (amount, remainder) = match output {
-                    TransactionOutput::SignatureLockedSingle(o) => (o.amount, o.remainder),
-                    TransactionOutput::SignatureLockedDustAllowance(o) => (o.amount, false),
-                    _ => (0, false),
-                };
-                if remainder {
-                    remainder_value += amount;
-                } else {
-                    value += amount;
-                }
-            }
-        }
 
         let message = Message {
             id: self.id,
@@ -804,9 +903,6 @@ impl<'a> MessageBuilder<'a> {
             nonce: self.iota_message.nonce(),
             confirmed: self.confirmed,
             broadcasted: true,
-            incoming: !sent,
-            value,
-            remainder_value,
         };
         Ok(message)
     }
@@ -816,12 +912,16 @@ impl Message {
     pub(crate) fn from_iota_message<'a>(
         id: MessageId,
         iota_message: IotaMessage,
+        accounts: AccountStore,
+        account_id: &'a str,
         account_addresses: &'a [Address],
         client_options: &'a ClientOptions,
     ) -> MessageBuilder<'a> {
         MessageBuilder::new(
             id,
             iota_message,
+            accounts,
+            account_id,
             account_addresses,
             account_addresses
                 .iter()

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -173,11 +173,17 @@ async fn process_output(
                 .data(&message_id)
                 .await
             {
-                let message =
-                    Message::from_iota_message(message_id, message, account.addresses(), account.client_options())
-                        .with_confirmed(Some(true))
-                        .finish()
-                        .await?;
+                let message = Message::from_iota_message(
+                    message_id,
+                    message,
+                    account_handle.accounts.clone(),
+                    account.id(),
+                    account.addresses(),
+                    account.client_options(),
+                )
+                .with_confirmed(Some(true))
+                .finish()
+                .await?;
                 crate::event::emit_transaction_event(
                     crate::event::TransactionEventType::NewTransaction,
                     &account,


### PR DESCRIPTION
# Description of change

- Mark transaction as internal
- Do not compute `incoming` and `outgoing` balance for internal transaction
- Move `value`, `remainder_value`, `incoming` fields from Message to TransactionRegularEssence

## Links to any relevant issues

N/A

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

CLI wallet.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have checked that new and existing unit tests pass locally with my changes
