### PR TITLE
refactor(event): split balance change events on message id

### DIFF
--- a/.changes/balance-change-event-message-ids.md
+++ b/.changes/balance-change-event-message-ids.md
@@ -2,4 +2,4 @@
 "nodejs-binding": patch
 ---
 
-Adds a `messageIds` field to the balance change event payload.
+Adds a `messageId` field to the balance change event payload.

--- a/bindings/nodejs/lib/index.d.ts
+++ b/bindings/nodejs/lib/index.d.ts
@@ -184,7 +184,7 @@ export declare interface BalanceChangeEvent {
   indexationId: string
   accountId: string
   address: string
-  messageIds: string[]
+  messageId?: string
   balanceChange: { spent: number, received: number }
 }
 

--- a/docs/libraries/nodejs/api_reference.md
+++ b/docs/libraries/nodejs/api_reference.md
@@ -178,7 +178,7 @@ Gets the persisted balance change events.
 | [skip]          | <code>number</code> | <code>0</code>    | The number of events to skip                                 |
 | [fromTimestamp] | <code>number</code> | <code>null</code> | Filter events that were stored after the given UTC timestamp |
 
-Event object: { indexationId: string, accountId: string, address: string, messageIds: string[], balanceChange: { spent: number, received: number } }
+Event object: { indexationId: string, accountId: string, address: string, message?: string, balanceChange: { spent: number, received: number } }
 
 #### getBalanceChangeEventCount([fromTimestamp])
 

--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -731,7 +731,8 @@ impl AccountSynchronizer {
                         );
 
                         let mut output_change_balance = 0;
-                        let mut emitted_event = false; // we use this flag in case the new balance is 0
+                        // we use this flag in case the new balance is 0
+                        let mut emitted_event = false;
                         // check new and updated outputs to find message ids
                         for output in address_after_sync.outputs() {
                             if !before_sync_outputs.contains(&output) {
@@ -761,9 +762,13 @@ impl AccountSynchronizer {
                                 address_after_sync.address(),
                                 None,
                                 if address_after_sync.balance() > before_sync_balance {
-                                    BalanceChange::received(address_after_sync.balance() - before_sync_balance - output_change_balance)
+                                    BalanceChange::received(
+                                        address_after_sync.balance() - before_sync_balance - output_change_balance,
+                                    )
                                 } else {
-                                    BalanceChange::spent(before_sync_balance - output_change_balance - address_after_sync.balance())
+                                    BalanceChange::spent(
+                                        before_sync_balance - output_change_balance - address_after_sync.balance(),
+                                    )
                                 },
                                 self.account_handle.account_options.persist_events,
                             )

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -1871,15 +1871,9 @@ mod tests {
                 BalanceChange::spent(3),
             ];
             for change in &change_events {
-                emit_balance_change(
-                    &account,
-                    account.latest_address().address(),
-                    vec![],
-                    change.clone(),
-                    true,
-                )
-                .await
-                .unwrap();
+                emit_balance_change(&account, account.latest_address().address(), None, change.clone(), true)
+                    .await
+                    .unwrap();
             }
             assert!(
                 manager.get_balance_change_event_count(None).await.unwrap() == change_events.len(),

--- a/src/event.rs
+++ b/src/event.rs
@@ -65,11 +65,11 @@ pub struct BalanceEvent {
     #[serde(with = "crate::serde::iota_address_serde")]
     pub address: AddressWrapper,
     /// The message id associated with the balance change.
-    /// Note that this is unreliable without
+    /// Note that this might be `None` without
     /// [AccountManagerBuilder#with_sync_spent_outputs](struct.AccountManagerBuilder.html#method.
-    /// with_sync_spent_outputs). ``
-    #[serde(rename = "messageIds", default)]
-    pub message_ids: Vec<MessageId>,
+    /// with_sync_spent_outputs).
+    #[serde(rename = "messageId")]
+    pub message_id: Option<MessageId>,
     /// The balance change data.
     #[serde(rename = "balanceChange")]
     pub balance_change: BalanceChange,
@@ -313,7 +313,7 @@ pub async fn remove_balance_change_listener(id: &EventId) {
 pub(crate) async fn emit_balance_change(
     account: &Account,
     address: &AddressWrapper,
-    message_ids: Vec<MessageId>,
+    message_id: Option<MessageId>,
     balance_change: BalanceChange,
     persist: bool,
 ) -> crate::Result<()> {
@@ -322,7 +322,7 @@ pub(crate) async fn emit_balance_change(
         indexation_id: generate_indexation_id(),
         account_id: account.id().to_string(),
         address: address.clone(),
-        message_ids,
+        message_id,
         balance_change,
     };
 
@@ -628,7 +628,7 @@ mod tests {
                 emit_balance_change(
                     &account,
                     &crate::test_utils::generate_random_iota_address(),
-                    vec![],
+                    None,
                     BalanceChange::spent(5),
                     true,
                 )

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -137,7 +137,7 @@ async fn process_output(
     crate::event::emit_balance_change(
         &account,
         &address_wrapper,
-        vec![message_id],
+        Some(message_id),
         if new_balance > old_balance {
             crate::event::BalanceChange::received(new_balance - old_balance)
         } else {


### PR DESCRIPTION
# Description of change

Refactor the balance change event so each event is associated with a single message id.

## Links to any relevant issues

N/A

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

CLI wallet.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have checked that new and existing unit tests pass locally with my changes
