### PR TITLE
Make input selection aware of dust

### DIFF
--- a/src/account/sync/input_selection.rs
+++ b/src/account/sync/input_selection.rs
@@ -25,9 +25,7 @@ pub fn select_input(target: u64, mut available_utxos: Vec<Input>) -> crate::Resu
     }
 
     // Not insufficient funds, but still not possible to create this transaction because it would create dust
-    if target != total_available_balance
-        && target as i64 > (total_available_balance as i64 - DUST_ALLOWANCE_VALUE as i64)
-    {
+    if target != total_available_balance && total_available_balance - target < DUST_ALLOWANCE_VALUE {
         return Err(crate::Error::DustError(format!(
             "Transaction would leave dust behind ({}i)",
             total_available_balance - target

--- a/src/account/sync/input_selection.rs
+++ b/src/account/sync/input_selection.rs
@@ -72,12 +72,7 @@ fn single_random_draw(target: u64, mut available_utxos: Vec<Input>) -> Vec<Input
             let value = address.balance;
             let old_sum = sum;
             sum += value;
-            if old_sum < target {
-                true
-            } else {
-                // Check that remaining value doesn't create dust
-                old_sum - target < DUST_ALLOWANCE_VALUE
-            }
+            old_sum < target || (old_sum - target < DUST_ALLOWANCE_VALUE && old_sum != target)
         })
         .collect()
 }


### PR DESCRIPTION
# Description of change

Check if selected inputs would leave dust behind and select more if that would be the case.
Create MAX_INPUT_SELECTION_TRIES so branch_and_bound doesn't take "forever" with many inputs

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tests

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
