### PR TITLE
feat(backup): allow file path as destination for custom filenames

### DIFF
--- a/.changes/backup-to-file.md
+++ b/.changes/backup-to-file.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": patch
+---
+
+Backup destination can now be a path to a file instead of a directory, allowing custom filenames.

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -762,7 +762,10 @@ impl AccountManager {
     #[cfg_attr(docsrs, doc(cfg(any(feature = "sqlite-storage", feature = "stronghold-storage"))))]
     pub async fn backup<P: AsRef<Path>>(&self, destination: P) -> crate::Result<PathBuf> {
         let destination = destination.as_ref().to_path_buf();
-        if !(destination.is_dir() || destination.parent().map(|parent| parent.is_dir()).unwrap_or_default()) {
+        // destination can't be an existing file, a non-existing directory or a file in a non-existing directory
+        if destination.is_file()
+            || !(destination.is_dir() || destination.parent().map(|parent| parent.is_dir()).unwrap_or_default())
+        {
             return Err(crate::Error::InvalidBackupDestination);
         }
 

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -762,15 +762,12 @@ impl AccountManager {
     #[cfg_attr(docsrs, doc(cfg(any(feature = "sqlite-storage", feature = "stronghold-storage"))))]
     pub async fn backup<P: AsRef<Path>>(&self, destination: P) -> crate::Result<PathBuf> {
         let destination = destination.as_ref().to_path_buf();
-        if !(destination.is_dir() && destination.exists()) {
+        if !(destination.is_dir() || destination.parent().map(|parent| parent.is_dir()).unwrap_or_default()) {
             return Err(crate::Error::InvalidBackupDestination);
         }
 
         #[allow(unused_variables)]
-        let (storage_path, backup_entire_directory) = (
-            &self.storage_path,
-            cfg!(feature = "stronghold") && cfg!(feature = "sqlite-storage"),
-        );
+        let storage_path = self.storage_path.clone();
 
         // if we're using SQLite for storage and stronghold for seed,
         // we'll backup only the stronghold file, copying SQLite data to its snapshot
@@ -778,10 +775,10 @@ impl AccountManager {
             feature = "sqlite-storage",
             any(feature = "stronghold", feature = "stronghold-storage")
         ))]
-        let (storage_path, backup_entire_directory) = {
+        let storage_path = {
             let storage_id = crate::storage::get(&self.storage_path).await?.lock().await.id();
             // if we're actually using the SQLite storage adapter
-            let storage_path = if storage_id == crate::storage::sqlite::STORAGE_ID {
+            if storage_id == crate::storage::sqlite::STORAGE_ID {
                 // create a account manager to setup the stronghold storage for the backup
                 let _ = Self::builder()
                     .with_storage(
@@ -804,16 +801,16 @@ impl AccountManager {
                 self.storage_folder.join(STRONGHOLD_FILENAME)
             } else {
                 self.storage_path.clone()
-            };
-            (storage_path, false)
+            }
         };
 
         if storage_path.exists() {
-            let destination = if backup_entire_directory {
-                backup_dir(&self.storage_folder, &destination)?;
-                destination
-            } else if let Some(filename) = storage_path.file_name() {
-                let destination = destination.join(backup_filename(filename.to_str().unwrap()));
+            let destination = if let Some(filename) = storage_path.file_name() {
+                let destination = if destination.is_dir() {
+                    destination.join(backup_filename(filename.to_str().unwrap()))
+                } else {
+                    destination
+                };
                 let res = fs::copy(storage_path, &destination);
 
                 // if we're using SQLite for storage and stronghold for seed,
@@ -1424,40 +1421,6 @@ async fn retry_unconfirmed_transactions(synced_accounts: &[SyncedAccount]) -> cr
     Ok(retried_messages)
 }
 
-fn backup_dir<U: AsRef<Path>, V: AsRef<Path>>(from: U, to: V) -> Result<(), std::io::Error> {
-    let mut stack = Vec::new();
-    stack.push(PathBuf::from(from.as_ref()));
-
-    let output_root = PathBuf::from(to.as_ref());
-    let input_root = PathBuf::from(from.as_ref()).components().count();
-
-    while let Some(working_path) = stack.pop() {
-        let src: PathBuf = working_path.components().skip(input_root).collect();
-
-        let dest = if src.components().count() == 0 {
-            output_root.clone()
-        } else {
-            output_root.join(&src)
-        };
-        if fs::metadata(&dest).is_err() {
-            fs::create_dir_all(&dest)?;
-        }
-
-        for entry in fs::read_dir(working_path)? {
-            let entry = entry?;
-            let path = entry.path();
-            if path.is_dir() {
-                stack.push(path);
-            } else if let Some(filename) = path.file_name() {
-                let dest_path = dest.join(backup_filename(filename.to_str().unwrap()));
-                fs::copy(&path, &dest_path)?;
-            }
-        }
-    }
-
-    Ok(())
-}
-
 fn backup_filename(original: &str) -> String {
     let date = Local::now();
     format!(
@@ -1481,6 +1444,7 @@ mod tests {
         message::Message,
     };
     use iota::{Ed25519Address, IndexationPayload, MessageBuilder, MessageId, Parents, Payload, TransactionId};
+    use std::path::PathBuf;
 
     #[tokio::test]
     async fn store_accounts() {
@@ -1854,10 +1818,10 @@ mod tests {
 
     #[tokio::test]
     async fn backup_and_restore_storage_already_exists() {
-        let backup_path = "./backup/account-exists";
-        let _ = std::fs::remove_dir_all(backup_path);
-        std::fs::create_dir_all(backup_path).unwrap();
         crate::test_utils::with_account_manager(crate::test_utils::TestType::Storage, |mut manager, _| async move {
+            let backup_path = PathBuf::from("./backup/account-exists");
+            let _ = std::fs::remove_dir_all(&backup_path);
+            std::fs::create_dir_all(&backup_path).unwrap();
             // first we'll create an example account
             let address = crate::test_utils::generate_random_iota_address();
             let address = AddressBuilder::new()
@@ -1872,25 +1836,18 @@ mod tests {
                 .create()
                 .await;
 
-            let backup_path = manager.backup(backup_path).await.unwrap();
-            let backup_file_path = if backup_path.is_dir() {
-                std::fs::read_dir(backup_path).unwrap().next().unwrap().unwrap().path()
-            } else {
-                backup_path
-            };
+            let backup_file_path = backup_path.join("wallet.bk");
+            let backup_path = manager.backup(&backup_file_path).await.unwrap();
+            assert_eq!(backup_path, backup_file_path);
 
             #[cfg(any(feature = "stronghold", feature = "stronghold-storage"))]
-            let response = manager.import_accounts(backup_file_path, "password".to_string()).await;
+            let response = manager.import_accounts(&backup_file_path, "password".to_string()).await;
 
             #[cfg(not(any(feature = "stronghold", feature = "stronghold-storage")))]
-            let response = manager.import_accounts(backup_file_path).await;
+            let response = manager.import_accounts(&backup_file_path).await;
 
             assert!(response.is_err());
-            let err = response.unwrap_err();
-            assert_eq!(
-                err.to_string(),
-                "failed to restore backup: storage file already exists".to_string()
-            );
+            assert!(matches!(response.unwrap_err(), crate::Error::StorageExists));
         })
         .await;
     }

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -762,10 +762,7 @@ impl AccountManager {
     #[cfg_attr(docsrs, doc(cfg(any(feature = "sqlite-storage", feature = "stronghold-storage"))))]
     pub async fn backup<P: AsRef<Path>>(&self, destination: P) -> crate::Result<PathBuf> {
         let destination = destination.as_ref().to_path_buf();
-        // destination can't be an existing file, a non-existing directory or a file in a non-existing directory
-        if destination.is_file()
-            || !(destination.is_dir() || destination.parent().map(|parent| parent.is_dir()).unwrap_or_default())
-        {
+        if !(destination.is_dir() || destination.parent().map(|parent| parent.is_dir()).unwrap_or_default()) {
             return Err(crate::Error::InvalidBackupDestination);
         }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -113,7 +113,7 @@ pub enum Error {
     #[error("provided backup path isn't a valid file")]
     InvalidBackupFile,
     /// Backup `destination` argument is invalid
-    #[error("backup destination must be a directory and it must exist")]
+    #[error("backup destination must be an existing directory or a file on an existing directory")]
     InvalidBackupDestination,
     /// the storage adapter isn't set
     #[error("the storage adapter isn't set; use the AccountManagerBuilder's `with_storage` method or one of the default storages with the crate features `sqlite-storage` and `stronghold-storage`.")]


### PR DESCRIPTION
# Description of change

Allow backup destination path to be a file path. Useful for setting custom filenames for multi manager setups.

## Links to any relevant issues

N/A

## Type of change

- Enhancement (a non-breaking change which adds functionality)
- 
## How the change has been tested

Unit test.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
