### PR TITLE
fix(sync): skip output message check when not syncing spent outputs

### DIFF
--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -729,22 +729,26 @@ impl AccountSynchronizer {
                             // we use this flag in case the new balance is 0
                             let mut emitted_event = false;
                             // check new and updated outputs to find message ids
-                            for output in address_after_sync.outputs() {
-                                if !before_sync_outputs.contains(&output) {
-                                    emit_balance_change(
-                                        &account_ref,
-                                        address_after_sync.address(),
-                                        Some(output.message_id),
-                                        if output.is_spent {
-                                            BalanceChange::spent(output.amount)
-                                        } else {
-                                            BalanceChange::received(output.amount)
-                                        },
-                                        self.account_handle.account_options.persist_events,
-                                    )
-                                    .await?;
-                                    output_change_balance += output.amount;
-                                    emitted_event = true;
+                            // note that this is unreliable if we're not syncing spent outputs,
+                            // since not all information are collected.
+                            if self.account_handle.account_options.sync_spent_outputs {
+                                for output in address_after_sync.outputs() {
+                                    if !before_sync_outputs.contains(&output) {
+                                        emit_balance_change(
+                                            &account_ref,
+                                            address_after_sync.address(),
+                                            Some(output.message_id),
+                                            if output.is_spent {
+                                                BalanceChange::spent(output.amount)
+                                            } else {
+                                                BalanceChange::received(output.amount)
+                                            },
+                                            self.account_handle.account_options.persist_events,
+                                        )
+                                        .await?;
+                                        output_change_balance += output.amount;
+                                        emitted_event = true;
+                                    }
                                 }
                             }
 


### PR DESCRIPTION
# Description of change

The output check on syncing balance change events isn't reliable when not syncing spent outputs, so we should skip it. This happens because we can get the absolute balance change, but we do not get individual spent outputs, so we can't compute each change individually.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

CLI wallet.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked that new and existing unit tests pass locally with my changes
