### PR TITLE
feat(events): add `reattached_message_id` on reattachment event

### DIFF
--- a/.changes/reattachment-event.md
+++ b/.changes/reattachment-event.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": patch
+---
+
+Adds `reattachedMessageId` field on the reattachment event payload.

--- a/bindings/python/native/src/classes/account_manager.rs
+++ b/bindings/python/native/src/classes/account_manager.rs
@@ -297,9 +297,13 @@ event_getters_impl!(
     get_transaction_confirmation_event_count
 );
 event_getters_impl!(
+    TransactionReattachmentEvent,
+    get_reattachment_events,
+    get_reattachment_event_count
+);
+event_getters_impl!(
     TransactionEvent,
     get_new_transaction_events,
     get_new_transaction_event_count
 );
-event_getters_impl!(TransactionEvent, get_reattachment_events, get_reattachment_event_count);
 event_getters_impl!(TransactionEvent, get_broadcast_events, get_broadcast_event_count);

--- a/bindings/python/native/src/types/event.rs
+++ b/bindings/python/native/src/types/event.rs
@@ -7,7 +7,7 @@ use dict_derive::{FromPyObject as DeriveFromPyObject, IntoPyObject as DeriveInto
 use iota_wallet::event::{
     BalanceChange as WalletBalanceChange, BalanceEvent as WalletBalanceEvent,
     TransactionConfirmationChangeEvent as WalletTransactionConfirmationChangeEvent,
-    TransactionEvent as WalletTransactionEvent,
+    TransactionEvent as WalletTransactionEvent, TransactionReattachmentEvent as WalletTransactionReattachmentEvent,
 };
 
 use std::convert::{TryFrom, TryInto};
@@ -72,7 +72,7 @@ impl TryFrom<WalletTransactionEvent> for TransactionEvent {
 pub struct TransactionConfirmationChangeEvent {
     /// Associated account.
     account_id: String,
-    /// The address.
+    /// The associated message.
     message: WalletMessage,
     /// Confirmed flag.
     confirmed: bool,
@@ -85,6 +85,27 @@ impl TryFrom<WalletTransactionConfirmationChangeEvent> for TransactionConfirmati
             account_id: value.account_id,
             message: value.message.try_into()?,
             confirmed: value.confirmed,
+        })
+    }
+}
+
+#[derive(Debug, DeriveFromPyObject, DeriveIntoPyObject)]
+pub struct TransactionReattachmentEvent {
+    /// Associated account.
+    account_id: String,
+    /// The reattachment message.
+    message: WalletMessage,
+    /// The id of the message that was reattached.
+    reattached_message_id: MessageId,
+}
+
+impl TryFrom<WalletTransactionReattachmentEvent> for TransactionReattachmentEvent {
+    type Error = Error;
+    fn try_from(value: WalletTransactionReattachmentEvent) -> Result<Self, Self::Error> {
+        Ok(Self {
+            account_id: value.account_id,
+            message: value.message.try_into()?,
+            reattached_message_id: value.reattached_message_id,
         })
     }
 }

--- a/bindings/python/native/src/types/event.rs
+++ b/bindings/python/native/src/types/event.rs
@@ -96,7 +96,7 @@ pub struct TransactionReattachmentEvent {
     /// The reattachment message.
     message: WalletMessage,
     /// The id of the message that was reattached.
-    reattached_message_id: MessageId,
+    reattached_message_id: String,
 }
 
 impl TryFrom<WalletTransactionReattachmentEvent> for TransactionReattachmentEvent {
@@ -105,7 +105,7 @@ impl TryFrom<WalletTransactionReattachmentEvent> for TransactionReattachmentEven
         Ok(Self {
             account_id: value.account_id,
             message: value.message.try_into()?,
-            reattached_message_id: value.reattached_message_id,
+            reattached_message_id: value.reattached_message_id.to_string(),
         })
     }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -13,7 +13,7 @@ pub mod stronghold;
 
 use crate::{
     account::Account,
-    event::{BalanceEvent, TransactionConfirmationChangeEvent, TransactionEvent},
+    event::{BalanceEvent, TransactionConfirmationChangeEvent, TransactionEvent, TransactionReattachmentEvent},
 };
 
 use chrono::Utc;
@@ -267,7 +267,7 @@ event_manager_impl!(
     get_new_transaction_event_count
 );
 event_manager_impl!(
-    TransactionEvent,
+    TransactionReattachmentEvent,
     reattachment_indexation,
     "iota-wallet-tx-reattachment-events",
     save_reattachment_event,


### PR DESCRIPTION
# Description of change

Include reattached message id on reattachment events.

## Links to any relevant issues

N/A

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

CLI wallet, unit tests.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
