### PR TITLE
feat(events): add `remainder` prop on balance change event

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -739,6 +739,26 @@ impl Message {
             }
         }
     }
+
+    pub(crate) fn is_remainder(&self, address: &AddressWrapper) -> Option<bool> {
+        if let Some(MessagePayload::Transaction(tx)) = &self.payload {
+            match tx.essence() {
+                TransactionEssence::Regular(essence) => {
+                    for output in essence.outputs() {
+                        let (output_address, remainder) = match output {
+                            TransactionOutput::SignatureLockedSingle(o) => (o.address(), o.remainder),
+                            TransactionOutput::SignatureLockedDustAllowance(o) => (o.address(), false),
+                            _ => unimplemented!(),
+                        };
+                        if output_address == address {
+                            return Some(remainder);
+                        }
+                    }
+                }
+            }
+        }
+        None
+    }
 }
 
 impl Hash for Message {

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -147,19 +147,6 @@ async fn process_output(
 
     let client_options_ = client_options.clone();
 
-    crate::event::emit_balance_change(
-        &account,
-        &address_wrapper,
-        Some(message_id),
-        if new_balance > old_balance {
-            crate::event::BalanceChange::received(new_balance - old_balance)
-        } else {
-            crate::event::BalanceChange::spent(old_balance - new_balance)
-        },
-        account_handle.account_options.persist_events,
-    )
-    .await?;
-
     if address_wrapper == latest_address {
         account_handle.generate_address_internal(&mut account).await?;
     }
@@ -208,6 +195,19 @@ async fn process_output(
             }
         }
     }
+
+    crate::event::emit_balance_change(
+        &account,
+        &address_wrapper,
+        Some(message_id),
+        if new_balance > old_balance {
+            crate::event::BalanceChange::received(new_balance - old_balance)
+        } else {
+            crate::event::BalanceChange::spent(old_balance - new_balance)
+        },
+        account_handle.account_options.persist_events,
+    )
+    .await?;
 
     account.save().await?;
 


### PR DESCRIPTION
# Description of change

Adds `remainder: Option<bool>` on the balance change event payload (indicates that the associated UTXO output is a remainder output).

## Links to any relevant issues

N/A

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

CLI wallet.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have checked that new and existing unit tests pass locally with my changes
