### PR TITLE
fix(event): confirmation state change not firing when retry isn't needed

### DIFF
--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -797,7 +797,7 @@ impl AccountSynchronizer {
                         log::info!("[POLLING] message confirmation state changed: {:?}", message.id());
                         emit_confirmation_state_change(
                             &account_ref,
-                            &message,
+                            message.clone(),
                             message.confirmed().unwrap_or(false),
                             self.account_handle.account_options.persist_events,
                         )

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -227,7 +227,8 @@ impl AccountManagerBuilder {
 
         crate::storage::set(&storage_file_path, self.storage_encryption_key, storage).await;
 
-        let is_monitoring = Arc::new(AtomicBool::new(false));
+        // is_monitoring is set to false if an mqtt error happens, so we can initialize it with `true`.
+        let is_monitoring = Arc::new(AtomicBool::new(true));
 
         // with the stronghold storage feature, the accounts are loaded when the password is set
         #[cfg(feature = "stronghold-storage")]

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -580,7 +580,6 @@ impl AccountManager {
 
                             if !accounts.read().await.is_empty() {
                                 let should_sync = !(synced && is_monitoring.load(Ordering::Relaxed));
-                                // println!("synced {}, monitoring {}", synced, is_monitoring.load(Ordering::Relaxed));
                                 match AssertUnwindSafe(
                                     poll(
                                         sync_accounts_lock.clone(),

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -580,6 +580,7 @@ impl AccountManager {
 
                             if !accounts.read().await.is_empty() {
                                 let should_sync = !(synced && is_monitoring.load(Ordering::Relaxed));
+                                // println!("synced {}, monitoring {}", synced, is_monitoring.load(Ordering::Relaxed));
                                 match AssertUnwindSafe(
                                     poll(
                                         sync_accounts_lock.clone(),
@@ -1301,7 +1302,16 @@ async fn poll(
             let message = account.get_message_mut(&message_id).unwrap();
             if let Ok(metadata) = client.read().await.get_message().metadata(&message_id).await {
                 if let Some(ledger_inclusion_state) = metadata.ledger_inclusion_state {
-                    message.set_confirmed(Some(ledger_inclusion_state == LedgerInclusionStateDto::Included));
+                    let confirmed = ledger_inclusion_state == LedgerInclusionStateDto::Included;
+                    message.set_confirmed(Some(confirmed));
+                    let message = message.clone();
+                    crate::event::emit_confirmation_state_change(
+                        &account,
+                        message,
+                        confirmed,
+                        retried_data.account_handle.account_options.persist_events,
+                    )
+                    .await?;
                 }
             }
         }
@@ -1937,7 +1947,7 @@ mod tests {
                 (m3, true),
             ];
             for (message, change) in &confirmation_change_events {
-                emit_confirmation_state_change(&account, message, *change, true)
+                emit_confirmation_state_change(&account, message.clone(), *change, true)
                     .await
                     .unwrap();
             }

--- a/src/event.rs
+++ b/src/event.rs
@@ -425,7 +425,7 @@ pub(crate) async fn emit_transaction_event(
 /// Emits a transaction confirmation state change event.
 pub(crate) async fn emit_confirmation_state_change(
     account: &Account,
-    message: &Message,
+    message: Message,
     confirmed: bool,
     persist: bool,
 ) -> crate::Result<()> {
@@ -433,7 +433,7 @@ pub(crate) async fn emit_confirmation_state_change(
     let event = TransactionConfirmationChangeEvent {
         indexation_id: generate_indexation_id(),
         account_id: account.id().to_string(),
-        message: message.clone(),
+        message,
         confirmed,
     };
 
@@ -803,7 +803,7 @@ mod tests {
                 })
                 .await;
 
-                emit_confirmation_state_change(&account, &message, confirmed, true)
+                emit_confirmation_state_change(&account, message.clone(), confirmed, true)
                     .await
                     .unwrap();
             });

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -158,7 +158,7 @@ async fn process_output(
             let message = message.clone();
             crate::event::emit_confirmation_state_change(
                 &account,
-                &message,
+                message.clone(),
                 true,
                 account_handle.account_options.persist_events,
             )
@@ -285,7 +285,7 @@ async fn process_metadata(
 
             crate::event::emit_confirmation_state_change(
                 &account,
-                &message,
+                message.clone(),
                 confirmed,
                 account_handle.account_options.persist_events,
             )


### PR DESCRIPTION
# Description of change

There's a case where the confirmation state change event isn't firing. This PR fixes it.