### PR TITLE
fix(mqtt): only emit confirmation event if message isn't confirmed

### DIFF
--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -1550,7 +1550,7 @@ async fn perform_transfer(
         // ignore errors because we fallback to the polling system
         let _ = crate::monitor::monitor_address_balance(account_handle.clone(), &address);
     }
-    crate::monitor::monitor_confirmation_state_change(account_handle.clone(), &message_id).await;
+    crate::monitor::monitor_confirmation_state_change(account_handle.clone(), message_id).await;
 
     Ok(message)
 }

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -219,23 +219,13 @@ async fn process_output(
 pub async fn monitor_unconfirmed_messages(account_handle: AccountHandle) {
     let account = account_handle.read().await;
     for message in account.list_messages(0, 0, Some(MessageType::Unconfirmed)) {
-        monitor_confirmation_state_change(account_handle.clone(), message.id()).await;
+        monitor_confirmation_state_change(account_handle.clone(), *message.id()).await;
     }
 }
 
 /// Monitor message for confirmation state.
-pub async fn monitor_confirmation_state_change(account_handle: AccountHandle, message_id: &MessageId) {
-    let (message, client_options) = {
-        let account = account_handle.read().await;
-        let message = account
-            .messages()
-            .iter()
-            .find(|message| message.id() == message_id)
-            .unwrap()
-            .clone();
-        (message, account.client_options().clone())
-    };
-    let message_id = *message_id;
+pub async fn monitor_confirmation_state_change(account_handle: AccountHandle, message_id: MessageId) {
+    let client_options = account_handle.client_options().await;
 
     subscribe_to_topic(
         client_options,
@@ -245,12 +235,9 @@ pub async fn monitor_confirmation_state_change(account_handle: AccountHandle, me
             log::info!("[MQTT] got {:?}", topic_event);
             if account_handle.is_mqtt_enabled() {
                 let topic_event = topic_event.clone();
-                let message = message.clone();
                 let account_handle = account_handle.clone();
                 crate::spawn(async move {
-                    if let Err(e) =
-                        process_metadata(topic_event.payload.clone(), account_handle, message_id, &message).await
-                    {
+                    if let Err(e) = process_metadata(topic_event.payload.clone(), account_handle, message_id).await {
                         log::error!("[MQTT] error processing metadata: {:?}", e);
                     }
                 });
@@ -262,31 +249,22 @@ pub async fn monitor_confirmation_state_change(account_handle: AccountHandle, me
     .await
 }
 
-async fn process_metadata(
-    payload: String,
-    account_handle: AccountHandle,
-    message_id: MessageId,
-    message: &Message,
-) -> crate::Result<()> {
+async fn process_metadata(payload: String, account_handle: AccountHandle, message_id: MessageId) -> crate::Result<()> {
     let metadata: MessageMetadataResponse = serde_json::from_str(&payload)?;
 
     if let Some(inclusion_state) = metadata.ledger_inclusion_state {
         let confirmed = inclusion_state == LedgerInclusionStateDto::Included;
+        let mut account = account_handle.write().await;
+        let messages = account.messages_mut();
+        let message = messages.iter_mut().find(|m| m.id() == &message_id).unwrap();
         if message.confirmed().is_none() || confirmed != message.confirmed().unwrap() {
-            let mut account = account_handle.write().await;
-
-            account
-                .do_mut(|account| {
-                    let messages = account.messages_mut();
-                    let account_message = messages.iter_mut().find(|m| m.id() == &message_id).unwrap();
-                    account_message.set_confirmed(Some(confirmed));
-                    Ok(())
-                })
-                .await?;
+            let message_ = message.clone();
+            message.set_confirmed(Some(confirmed));
+            account.save().await?;
 
             crate::event::emit_confirmation_state_change(
                 &account,
-                message.clone(),
+                message_,
                 confirmed,
                 account_handle.account_options.persist_events,
             )


### PR DESCRIPTION
# Description of change

Prevent duplicated confirmation change event on MQTT.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

CLI wallet.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have checked that new and existing unit tests pass locally with my changes
