### PR TITLE
fix(sync): parse messages after all account addresses parsing

### DIFF
--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -27,7 +27,7 @@ use std::{
 };
 
 mod sync;
-pub(crate) use sync::{repost_message, AccountSynchronizeStep, RepostAction};
+pub(crate) use sync::{repost_message, AccountSynchronizeStep, RepostAction, SyncedAccountData};
 pub use sync::{AccountSynchronizer, SyncedAccount};
 
 const ACCOUNT_ID_PREFIX: &str = "wallet-account://";

--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -818,8 +818,10 @@ impl AccountSynchronizer {
         let return_value = match self.get_new_history().await {
             Ok(data) => {
                 self.account_handle.disable_mqtt();
-                let is_empty =
-                    data.messages.is_empty() && data.addresses.iter().all(|address| address.outputs().is_empty());
+                let is_empty = data
+                    .addresses
+                    .iter()
+                    .all(|address| *address.balance() == 0 && address.outputs().is_empty());
                 log::debug!("[SYNC] is empty: {}", is_empty);
                 let mut account = self.account_handle.write().await;
                 let messages_before_sync: Vec<(MessageId, Option<bool>)> =

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -1278,7 +1278,7 @@ impl AccountsSynchronizer {
             if *account.index() >= last_account_index {
                 last_account_index = *account.index();
                 last_account = Some((
-                    account.messages().is_empty() || account.addresses().iter().all(|addr| *addr.balance() == 0),
+                    account.messages().is_empty() && account.addresses().iter().all(|addr| *addr.balance() == 0),
                     account.client_options().clone(),
                     account.signer_type().clone(),
                 ));

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -1144,7 +1144,7 @@ impl AccountsSynchronizer {
                 let account_handle = account_handle.clone();
                 tasks.push(async move {
                     tokio::spawn(async move {
-                        let mut sync = account_handle.sync().await.skip_events();
+                        let mut sync = account_handle.sync().await;
                         if let Some(index) = address_index {
                             sync = sync.address_index(index);
                         }

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -1231,6 +1231,7 @@ impl AccountsSynchronizer {
                     let account_handle_ = account_handle.clone();
                     let mut account = account_handle_.write().await;
                     account.set_skip_persistence(false);
+                    account.set_addresses(synced_account_data.addresses.to_vec());
                     account.save().await?;
                     accounts.insert(account.id().clone(), account_handle.clone());
                     discovered_account_ids.push(account.id().clone());

--- a/src/event.rs
+++ b/src/event.rs
@@ -390,14 +390,14 @@ pub(crate) async fn emit_balance_change(
 pub(crate) async fn emit_transaction_event(
     event_type: TransactionEventType,
     account: &Account,
-    message: &Message,
+    message: Message,
     persist: bool,
 ) -> crate::Result<()> {
     let listeners = transaction_listeners().lock().await;
     let event = TransactionEvent {
         indexation_id: generate_indexation_id(),
         account_id: account.id().to_string(),
-        message: message.clone(),
+        message,
     };
 
     if persist {
@@ -732,7 +732,7 @@ mod tests {
                 })
                 .await;
 
-                emit_transaction_event(TransactionEventType::NewTransaction, &account, &message, true)
+                emit_transaction_event(TransactionEventType::NewTransaction, &account, message, true)
                     .await
                     .unwrap();
             });
@@ -778,7 +778,7 @@ mod tests {
                 })
                 .await;
 
-                emit_transaction_event(TransactionEventType::Broadcast, &account, &message, true)
+                emit_transaction_event(TransactionEventType::Broadcast, &account, message, true)
                     .await
                     .unwrap();
             });

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -187,7 +187,7 @@ async fn process_output(
                 crate::event::emit_transaction_event(
                     crate::event::TransactionEventType::NewTransaction,
                     &account,
-                    &message,
+                    message.clone(),
                     account_handle.account_options.persist_events,
                 )
                 .await?;


### PR DESCRIPTION
# Description of change

This prevents some synchronization issues where the `internal` message property is incorrectly defined as false because the other accounts aren't synced.

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

CLI wallet, Firefly. 

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked that new and existing unit tests pass locally with my changes
