### PR TITLE
fix(mqtt): properly guard against race conditions with syncing

### DIFF
--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -1129,6 +1129,18 @@ impl AccountsSynchronizer {
 
     /// Syncs the accounts with the Tangle.
     pub async fn execute(self) -> crate::Result<Vec<SyncedAccount>> {
+        let accounts = self.accounts.clone();
+        for account_handle in accounts.read().await.values() {
+            account_handle.disable_mqtt();
+        }
+        let result = self.execute_internal().await;
+        for account_handle in accounts.read().await.values() {
+            account_handle.enable_mqtt();
+        }
+        result
+    }
+
+    async fn execute_internal(self) -> crate::Result<Vec<SyncedAccount>> {
         let _lock = self.mutex.lock().await;
 
         let mut tasks = Vec::new();


### PR DESCRIPTION
# Description of change

Block MQTT message handlers from running until sync accounts finishes.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Firefly!

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have checked that new and existing unit tests pass locally with my changes
