### PR TITLE
fix: improve client instance management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1473,7 +1473,7 @@ dependencies = [
 [[package]]
 name = "iota-client"
 version = "0.5.0-alpha.3"
-source = "git+https://github.com/iotaledger/iota.rs?rev=fb672067425ba8412e595eae52f52cf7236da220#fb672067425ba8412e595eae52f52cf7236da220"
+source = "git+https://github.com/iotaledger/iota.rs?rev=b3c6016b5f6bb28701cfed7a8ee768bbf476a8cc#b3c6016b5f6bb28701cfed7a8ee768bbf476a8cc"
 dependencies = [
  "async-trait",
  "bee-common 0.3.1-alpha (git+https://github.com/iotaledger/bee.git?branch=dev)",
@@ -1501,7 +1501,7 @@ dependencies = [
 [[package]]
 name = "iota-core"
 version = "0.2.0-alpha.3"
-source = "git+https://github.com/iotaledger/iota.rs?rev=fb672067425ba8412e595eae52f52cf7236da220#fb672067425ba8412e595eae52f52cf7236da220"
+source = "git+https://github.com/iotaledger/iota.rs?rev=b3c6016b5f6bb28701cfed7a8ee768bbf476a8cc#b3c6016b5f6bb28701cfed7a8ee768bbf476a8cc"
 dependencies = [
  "bee-common 0.3.1-alpha (git+https://github.com/iotaledger/bee.git?rev=c42171ff33c80cc2efb183e244dc79b7f58d9ac4)",
  "bee-message",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_repr = "0.1"
 once_cell = "1.5"
-iota-core = { git = "https://github.com/iotaledger/iota.rs", rev = "fb672067425ba8412e595eae52f52cf7236da220", features = ["mqtt"] }
+iota-core = { git = "https://github.com/iotaledger/iota.rs", rev = "b3c6016b5f6bb28701cfed7a8ee768bbf476a8cc", features = ["mqtt"] }
 bee-common = { git = "https://github.com/iotaledger/bee.git", branch = "dev" }
 url = { version = "2.2", features = [ "serde" ] }
 tokio = { version = "1.3", features = ["macros", "sync", "time", "rt", "rt-multi-thread"] }

--- a/bindings/nodejs/native/Cargo.lock
+++ b/bindings/nodejs/native/Cargo.lock
@@ -1356,7 +1356,7 @@ dependencies = [
 [[package]]
 name = "iota-client"
 version = "0.5.0-alpha.3"
-source = "git+https://github.com/iotaledger/iota.rs?rev=fb672067425ba8412e595eae52f52cf7236da220#fb672067425ba8412e595eae52f52cf7236da220"
+source = "git+https://github.com/iotaledger/iota.rs?rev=b3c6016b5f6bb28701cfed7a8ee768bbf476a8cc#b3c6016b5f6bb28701cfed7a8ee768bbf476a8cc"
 dependencies = [
  "async-trait",
  "bee-common 0.3.1-alpha (git+https://github.com/iotaledger/bee.git?branch=dev)",
@@ -1384,7 +1384,7 @@ dependencies = [
 [[package]]
 name = "iota-core"
 version = "0.2.0-alpha.3"
-source = "git+https://github.com/iotaledger/iota.rs?rev=fb672067425ba8412e595eae52f52cf7236da220#fb672067425ba8412e595eae52f52cf7236da220"
+source = "git+https://github.com/iotaledger/iota.rs?rev=b3c6016b5f6bb28701cfed7a8ee768bbf476a8cc#b3c6016b5f6bb28701cfed7a8ee768bbf476a8cc"
 dependencies = [
  "bee-common 0.3.1-alpha (git+https://github.com/iotaledger/bee.git?rev=c42171ff33c80cc2efb183e244dc79b7f58d9ac4)",
  "bee-message",

--- a/bindings/nodejs/native/Cargo.toml
+++ b/bindings/nodejs/native/Cargo.toml
@@ -17,7 +17,7 @@ neon-build = "=0.4.0"
 [dependencies]
 neon = "=0.4.0"
 iota-wallet = { path = "../../../", version = "0.1.0", features = ["stronghold", "stronghold-storage", "sqlite-storage"] }
-iota-core = { git = "https://github.com/iotaledger/iota.rs", rev = "fb672067425ba8412e595eae52f52cf7236da220", features = ["mqtt"] }
+iota-core = { git = "https://github.com/iotaledger/iota.rs", rev = "b3c6016b5f6bb28701cfed7a8ee768bbf476a8cc", features = ["mqtt"] }
 serde = "1.0"
 serde_json = "1.0"
 serde_repr = "0.1"

--- a/bindings/python/native/Cargo.lock
+++ b/bindings/python/native/Cargo.lock
@@ -1454,7 +1454,7 @@ dependencies = [
 [[package]]
 name = "iota-client"
 version = "0.5.0-alpha.3"
-source = "git+https://github.com/iotaledger/iota.rs?rev=fb672067425ba8412e595eae52f52cf7236da220#fb672067425ba8412e595eae52f52cf7236da220"
+source = "git+https://github.com/iotaledger/iota.rs?rev=b3c6016b5f6bb28701cfed7a8ee768bbf476a8cc#b3c6016b5f6bb28701cfed7a8ee768bbf476a8cc"
 dependencies = [
  "async-trait",
  "bee-common 0.3.1-alpha (git+https://github.com/iotaledger/bee.git?branch=dev)",
@@ -1482,7 +1482,7 @@ dependencies = [
 [[package]]
 name = "iota-core"
 version = "0.2.0-alpha.3"
-source = "git+https://github.com/iotaledger/iota.rs?rev=fb672067425ba8412e595eae52f52cf7236da220#fb672067425ba8412e595eae52f52cf7236da220"
+source = "git+https://github.com/iotaledger/iota.rs?rev=b3c6016b5f6bb28701cfed7a8ee768bbf476a8cc#b3c6016b5f6bb28701cfed7a8ee768bbf476a8cc"
 dependencies = [
  "bee-common 0.3.1-alpha (git+https://github.com/iotaledger/bee.git?rev=c42171ff33c80cc2efb183e244dc79b7f58d9ac4)",
  "bee-message",

--- a/bindings/python/native/Cargo.toml
+++ b/bindings/python/native/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 iota-wallet = { path = "../../../", version = "0.1.0", features = ["stronghold", "stronghold-storage", "sqlite-storage", "ledger-nano", "ledger-nano-simulator"] }
-iota-core = { git = "https://github.com/iotaledger/iota.rs", rev = "fb672067425ba8412e595eae52f52cf7236da220", features = ["mqtt"] }
+iota-core = { git = "https://github.com/iotaledger/iota.rs", rev = "b3c6016b5f6bb28701cfed7a8ee768bbf476a8cc", features = ["mqtt"] }
 chrono = "0.4"
 serde_json = "1.0"
 serde = "1.0"

--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -532,7 +532,7 @@ impl AccountHandle {
         let handle = self.clone();
         crate::spawn(async move {
             // ignore errors because we fallback to the polling system
-            let _ = crate::monitor::monitor_address_balance(handle, &address).await;
+            let _ = crate::monitor::monitor_address_balance(handle, vec![address]).await;
         });
     }
 

--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -1598,9 +1598,9 @@ async fn perform_transfer(
 
     for address in addresses_to_watch {
         // ignore errors because we fallback to the polling system
-        let _ = crate::monitor::monitor_address_balance(account_handle.clone(), &address).await;
+        let _ = crate::monitor::monitor_address_balance(account_handle.clone(), vec![address]).await;
     }
-    crate::monitor::monitor_confirmation_state_change(account_handle.clone(), message_id).await;
+    crate::monitor::monitor_confirmation_state_change(account_handle.clone(), vec![message_id]).await;
 
     Ok(message)
 }

--- a/src/address.rs
+++ b/src/address.rs
@@ -310,7 +310,7 @@ impl Address {
         AddressBuilder::new()
     }
 
-    pub(crate) fn handle_new_output(&mut self, output: AddressOutput) -> crate::Result<()> {
+    pub(crate) fn handle_new_output(&mut self, output: AddressOutput) -> crate::Result<bool> {
         if !self.outputs.values().any(|o| o == &output) {
             let spent_existing_output = self.outputs.values_mut().find(|o| {
                 o.message_id == output.message_id
@@ -328,8 +328,10 @@ impl Address {
                 self.balance += output.amount;
                 self.outputs.insert(output.id()?, output);
             }
+            Ok(true)
+        } else {
+            Ok(false)
         }
-        Ok(())
     }
 
     /// Gets the list of outputs that aren't spent or pending.

--- a/src/client.rs
+++ b/src/client.rs
@@ -127,6 +127,11 @@ pub(crate) async fn get_client(
     Ok(client.clone())
 }
 
+/// Drops all clients.
+pub async fn drop_all() {
+    instances().lock().await.clear();
+}
+
 /// The options builder for a client connected to multiple nodes.
 pub struct ClientOptionsBuilder {
     nodes: Vec<Node>,

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -3,18 +3,25 @@
 
 use crate::{
     account::AccountHandle,
-    address::{AddressOutput, AddressWrapper},
+    address::{AddressOutput, AddressWrapper, IotaAddress},
     client::ClientOptions,
     message::{Message, MessageType},
 };
 
 use iota::{
-    bee_rest_api::types::{dtos::LedgerInclusionStateDto, responses::MessageMetadataResponse},
+    bee_rest_api::types::{
+        dtos::{LedgerInclusionStateDto, OutputDto},
+        responses::MessageMetadataResponse,
+    },
     message::prelude::MessageId,
     OutputResponse, Topic, TopicEvent,
 };
 
-use std::sync::{atomic::AtomicBool, Arc};
+use std::{
+    convert::TryInto,
+    str::FromStr,
+    sync::{atomic::AtomicBool, Arc},
+};
 
 /// Unsubscribe from all topics associated with the account.
 pub async fn unsubscribe(account_handle: AccountHandle) -> crate::Result<()> {
@@ -39,18 +46,18 @@ pub async fn unsubscribe(account_handle: AccountHandle) -> crate::Result<()> {
 }
 
 #[cfg(test)]
-async fn subscribe_to_topic<C: Fn(&TopicEvent) + Send + Sync + 'static>(
+async fn subscribe_to_topics<C: Fn(&TopicEvent) + Send + Sync + 'static>(
     _client_options: ClientOptions,
-    _topic: String,
+    _topic: Vec<Topic>,
     _is_monitoring: Arc<AtomicBool>,
     _handler: C,
 ) {
 }
 
 #[cfg(not(test))]
-async fn subscribe_to_topic<C: Fn(&TopicEvent) + Send + Sync + 'static>(
+async fn subscribe_to_topics<C: Fn(&TopicEvent) + Send + Sync + 'static>(
     client_options: ClientOptions,
-    topic: String,
+    topics: Vec<Topic>,
     is_monitoring: Arc<AtomicBool>,
     handler: C,
 ) {
@@ -59,7 +66,7 @@ async fn subscribe_to_topic<C: Fn(&TopicEvent) + Send + Sync + 'static>(
         let mut client = client.write().await;
         if client
             .subscriber()
-            .with_topic(Topic::new(topic)?)
+            .with_topics(topics)
             .subscribe(handler)
             .await
             .is_err()
@@ -73,33 +80,35 @@ async fn subscribe_to_topic<C: Fn(&TopicEvent) + Send + Sync + 'static>(
 /// Monitor account addresses for balance changes.
 pub async fn monitor_account_addresses_balance(account_handle: AccountHandle) {
     let account = account_handle.read().await;
-    for address in account.addresses() {
-        monitor_address_balance(account_handle.clone(), address.address()).await;
-    }
+    monitor_address_balance(
+        account_handle.clone(),
+        account.addresses().iter().map(|a| a.address().clone()).collect(),
+    )
+    .await;
 }
 
 /// Monitor address for balance changes.
-pub async fn monitor_address_balance(account_handle: AccountHandle, address: &AddressWrapper) {
+pub async fn monitor_address_balance(account_handle: AccountHandle, addresses: Vec<AddressWrapper>) {
     let client_options = account_handle.client_options().await;
     let client_options_ = client_options.clone();
-    let address = address.clone();
 
-    subscribe_to_topic(
+    subscribe_to_topics(
         client_options_,
-        format!("addresses/{}/outputs", address.to_bech32()),
+        // safe to unwrap: we know the topics are valid
+        addresses
+            .into_iter()
+            .map(|address| Topic::new(format!("addresses/{}/outputs", address.to_bech32())).unwrap())
+            .collect(),
         account_handle.is_monitoring.clone(),
         move |topic_event| {
             log::info!("[MQTT] got {:?}", topic_event);
             if account_handle.is_mqtt_enabled() {
                 let topic_event = topic_event.clone();
-                let address = address.clone();
                 let client_options = client_options.clone();
                 let account_handle = account_handle.clone();
 
                 crate::spawn(async move {
-                    if let Err(e) =
-                        process_output(topic_event.payload.clone(), account_handle, address, client_options).await
-                    {
+                    if let Err(e) = process_output(topic_event.payload.clone(), account_handle, client_options).await {
                         log::error!("[MQTT] error processing output: {:?}", e);
                     }
                 });
@@ -114,12 +123,32 @@ pub async fn monitor_address_balance(account_handle: AccountHandle, address: &Ad
 async fn process_output(
     payload: String,
     account_handle: AccountHandle,
-    address: AddressWrapper,
     client_options: ClientOptions,
 ) -> crate::Result<()> {
     let output: OutputResponse = serde_json::from_str(&payload)?;
-
+    let output_address: IotaAddress = match output.output.clone() {
+        OutputDto::SignatureLockedSingle(output) => {
+            (&output.address).try_into().map_err(|_| crate::Error::InvalidAddress)?
+        }
+        OutputDto::SignatureLockedDustAllowance(output) => {
+            (&output.address).try_into().map_err(|_| crate::Error::InvalidAddress)?
+        }
+        _ => {
+            return Ok(());
+        }
+    };
     let mut account = account_handle.write().await;
+    let address = match account
+        .addresses()
+        .iter()
+        .find(|address| address.address().as_ref() == &output_address)
+    {
+        Some(address) => address.address().clone(),
+        None => {
+            return Ok(());
+        }
+    };
+
     let latest_address = account.latest_address().address().clone();
     let address_wrapper = account
         .addresses()
@@ -138,7 +167,11 @@ async fn process_output(
             .find(|a| a.address() == &address)
             .unwrap();
         let old_balance = *address_to_update.balance();
-        address_to_update.handle_new_output(address_output)?;
+        let handled = address_to_update.handle_new_output(address_output)?;
+        if !handled {
+            // output was already handled; ignore this process
+            return Ok(());
+        }
         let new_balance = *address_to_update.balance();
         (old_balance, new_balance)
     };
@@ -229,18 +262,28 @@ async fn process_output(
 /// Monitor the account's unconfirmed messages for confirmation state change.
 pub async fn monitor_unconfirmed_messages(account_handle: AccountHandle) {
     let account = account_handle.read().await;
-    for message in account.list_messages(0, 0, Some(MessageType::Unconfirmed)) {
-        monitor_confirmation_state_change(account_handle.clone(), *message.id()).await;
-    }
+    monitor_confirmation_state_change(
+        account_handle.clone(),
+        account
+            .list_messages(0, 0, Some(MessageType::Unconfirmed))
+            .into_iter()
+            .map(|m| *m.id())
+            .collect(),
+    )
+    .await;
 }
 
 /// Monitor message for confirmation state.
-pub async fn monitor_confirmation_state_change(account_handle: AccountHandle, message_id: MessageId) {
+pub async fn monitor_confirmation_state_change(account_handle: AccountHandle, message_ids: Vec<MessageId>) {
     let client_options = account_handle.client_options().await;
 
-    subscribe_to_topic(
+    subscribe_to_topics(
         client_options,
-        format!("messages/{}/metadata", message_id.to_string()),
+        // safe to unwrap: we know the topics are valid
+        message_ids
+            .iter()
+            .map(|id| Topic::new(format!("messages/{}/metadata", id.to_string())).unwrap())
+            .collect(),
         account_handle.is_monitoring.clone(),
         move |topic_event| {
             log::info!("[MQTT] got {:?}", topic_event);
@@ -248,7 +291,7 @@ pub async fn monitor_confirmation_state_change(account_handle: AccountHandle, me
                 let topic_event = topic_event.clone();
                 let account_handle = account_handle.clone();
                 crate::spawn(async move {
-                    if let Err(e) = process_metadata(topic_event.payload.clone(), account_handle, message_id).await {
+                    if let Err(e) = process_metadata(topic_event.payload.clone(), account_handle).await {
                         log::error!("[MQTT] error processing metadata: {:?}", e);
                     }
                 });
@@ -260,8 +303,9 @@ pub async fn monitor_confirmation_state_change(account_handle: AccountHandle, me
     .await
 }
 
-async fn process_metadata(payload: String, account_handle: AccountHandle, message_id: MessageId) -> crate::Result<()> {
+async fn process_metadata(payload: String, account_handle: AccountHandle) -> crate::Result<()> {
     let metadata: MessageMetadataResponse = serde_json::from_str(&payload)?;
+    let message_id = MessageId::from_str(&metadata.message_id)?;
 
     if let Some(inclusion_state) = metadata.ledger_inclusion_state {
         let confirmed = inclusion_state == LedgerInclusionStateDto::Included;


### PR DESCRIPTION
# Description of change

Firefly is having some issues with client cleanup on logout. This PR enables a very basic API for that, but we'll improve it soon (the AccountManager will automatically drop the clients if possible).
Also, I've included a little improvement on MQTT logs / duplicated message check for now, but we should check where that issue comes from.