### PR TITLE
fix(mqtt): sync instead of parsing message

### DIFF
--- a/src/address.rs
+++ b/src/address.rs
@@ -310,30 +310,6 @@ impl Address {
         AddressBuilder::new()
     }
 
-    pub(crate) fn handle_new_output(&mut self, output: AddressOutput) -> crate::Result<bool> {
-        if !self.outputs.values().any(|o| o == &output) {
-            let spent_existing_output = self.outputs.values_mut().find(|o| {
-                o.message_id == output.message_id
-                    && o.transaction_id == output.transaction_id
-                    && o.index == output.index
-                    && o.amount == output.amount
-                    && (!o.is_spent && output.is_spent)
-            });
-            if let Some(spent_existing_output) = spent_existing_output {
-                log::debug!("[ADDRESS] got spent of {:?}", spent_existing_output);
-                self.balance -= output.amount;
-                spent_existing_output.is_spent = true;
-            } else {
-                log::debug!("[ADDRESS] got new output {:?}", output);
-                self.balance += output.amount;
-                self.outputs.insert(output.id()?, output);
-            }
-            Ok(true)
-        } else {
-            Ok(false)
-        }
-    }
-
     /// Gets the list of outputs that aren't spent or pending.
     pub fn available_outputs(&self, account: &Account) -> Vec<&AddressOutput> {
         self.outputs

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -1,27 +1,11 @@
 // Copyright 2020 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    account::AccountHandle,
-    address::{AddressOutput, AddressWrapper, IotaAddress},
-    client::ClientOptions,
-    message::{Message, MessageType},
-};
+use crate::{account::AccountHandle, address::AddressWrapper, client::ClientOptions, message::MessageType};
 
-use iota::{
-    bee_rest_api::types::{
-        dtos::{LedgerInclusionStateDto, OutputDto},
-        responses::MessageMetadataResponse,
-    },
-    message::prelude::MessageId,
-    OutputResponse, Topic, TopicEvent,
-};
+use iota::{message::prelude::MessageId, Topic, TopicEvent};
 
-use std::{
-    convert::TryInto,
-    str::FromStr,
-    sync::{atomic::AtomicBool, Arc},
-};
+use std::sync::{atomic::AtomicBool, Arc};
 
 /// Unsubscribe from all topics associated with the account.
 pub async fn unsubscribe(account_handle: AccountHandle) -> crate::Result<()> {
@@ -106,14 +90,9 @@ pub async fn monitor_address_balance(account_handle: AccountHandle, addresses: V
         move |topic_event| {
             log::info!("[MQTT] got {:?}", topic_event);
             if account_handle.is_mqtt_enabled() {
-                let topic_event = topic_event.clone();
-                let client_options = client_options.clone();
                 let account_handle = account_handle.clone();
-
                 crate::spawn(async move {
-                    if let Err(e) = process_output(topic_event.payload.clone(), account_handle, client_options).await {
-                        log::error!("[MQTT] error processing output: {:?}", e);
-                    }
+                    let _ = account_handle.sync().await.execute().await;
                 });
             } else {
                 log::info!("[MQTT] event ignored because account disabled mqtt");
@@ -121,148 +100,6 @@ pub async fn monitor_address_balance(account_handle: AccountHandle, addresses: V
         },
     )
     .await
-}
-
-async fn process_output(
-    payload: String,
-    account_handle: AccountHandle,
-    client_options: ClientOptions,
-) -> crate::Result<()> {
-    let output: OutputResponse = serde_json::from_str(&payload)?;
-    let output_address: IotaAddress = match output.output.clone() {
-        OutputDto::SignatureLockedSingle(output) => {
-            (&output.address).try_into().map_err(|_| crate::Error::InvalidAddress)?
-        }
-        OutputDto::SignatureLockedDustAllowance(output) => {
-            (&output.address).try_into().map_err(|_| crate::Error::InvalidAddress)?
-        }
-        _ => {
-            log::debug!("[MQTT] ignoring output type");
-            return Ok(());
-        }
-    };
-    let mut account = account_handle.write().await;
-    let address = match account
-        .addresses()
-        .iter()
-        .find(|address| address.address().as_ref() == &output_address)
-    {
-        Some(address) => address.address().clone(),
-        None => {
-            log::debug!("[MQTT] address not found");
-            return Ok(());
-        }
-    };
-
-    let latest_address = account.latest_address().address().clone();
-    let address_wrapper = account
-        .addresses()
-        .iter()
-        .find(|a| a.address() == &address)
-        .unwrap()
-        .address()
-        .clone();
-    let address_output = AddressOutput::from_output_response(output, address_wrapper.bech32_hrp().to_string())?;
-    let message_id = *address_output.message_id();
-
-    let (old_balance, new_balance) = {
-        let address_to_update = account
-            .addresses_mut()
-            .iter_mut()
-            .find(|a| a.address() == &address)
-            .unwrap();
-        let old_balance = *address_to_update.balance();
-        let handled = address_to_update.handle_new_output(address_output)?;
-        if !handled {
-            // output was already handled; ignore this process
-            log::debug!("[MQTT] output already handled");
-            return Ok(());
-        }
-        let new_balance = *address_to_update.balance();
-        (old_balance, new_balance)
-    };
-
-    let client_options_ = client_options.clone();
-
-    if address_wrapper == latest_address {
-        // we ignore errors in case stronghold is locked
-        // because it's more important to process the event
-        let _ = account_handle.generate_address_internal(&mut account).await;
-    }
-
-    match account.messages_mut().iter().position(|m| m.id() == &message_id) {
-        Some(message_index) => {
-            let message = &mut account.messages_mut()[message_index];
-            if !message.confirmed().unwrap_or(false) {
-                message.set_confirmed(Some(true));
-                let message = message.clone();
-                log::info!("[MQTT] message confirmed: {:?}", message.id());
-                crate::event::emit_confirmation_state_change(
-                    &account,
-                    message.clone(),
-                    true,
-                    account_handle.account_options.persist_events,
-                )
-                .await?;
-                account.save().await?;
-            }
-        }
-        None => {
-            if let Ok(message) = crate::client::get_client(&client_options_, Some(account_handle.is_monitoring.clone()))
-                .await?
-                .read()
-                .await
-                .get_message()
-                .data(&message_id)
-                .await
-            {
-                let message = Message::from_iota_message(
-                    message_id,
-                    message,
-                    account_handle.accounts.clone(),
-                    account.id(),
-                    account.addresses(),
-                    account.client_options(),
-                )
-                .with_confirmed(Some(true))
-                .finish()
-                .await?;
-                log::info!("[MQTT] new transaction: {:?}", message.id());
-                crate::event::emit_transaction_event(
-                    crate::event::TransactionEventType::NewTransaction,
-                    &account,
-                    message.clone(),
-                    account_handle.account_options.persist_events,
-                )
-                .await?;
-                account.messages_mut().push(message);
-                account.save().await?;
-            }
-        }
-    }
-
-    let balance_change = if new_balance > old_balance {
-        crate::event::BalanceChange::received(new_balance - old_balance)
-    } else {
-        crate::event::BalanceChange::spent(old_balance - new_balance)
-    };
-    log::info!(
-        "[MQTT] balance change on {} {:?}",
-        address_wrapper.to_bech32(),
-        balance_change
-    );
-    crate::event::emit_balance_change(
-        &account,
-        &address_wrapper,
-        Some(message_id),
-        balance_change,
-        account_handle.account_options.persist_events,
-    )
-    .await?;
-
-    account.save().await?;
-
-    Ok(())
 }
 
 /// Monitor the account's unconfirmed messages for confirmation state change.
@@ -294,12 +131,9 @@ pub async fn monitor_confirmation_state_change(account_handle: AccountHandle, me
         move |topic_event| {
             log::info!("[MQTT] got {:?}", topic_event);
             if account_handle.is_mqtt_enabled() {
-                let topic_event = topic_event.clone();
                 let account_handle = account_handle.clone();
                 crate::spawn(async move {
-                    if let Err(e) = process_metadata(topic_event.payload.clone(), account_handle).await {
-                        log::error!("[MQTT] error processing metadata: {:?}", e);
-                    }
+                    let _ = account_handle.sync().await.execute().await;
                 });
             } else {
                 log::info!("[MQTT] event ignored because account disabled mqtt");
@@ -307,35 +141,4 @@ pub async fn monitor_confirmation_state_change(account_handle: AccountHandle, me
         },
     )
     .await
-}
-
-async fn process_metadata(payload: String, account_handle: AccountHandle) -> crate::Result<()> {
-    let metadata: MessageMetadataResponse = serde_json::from_str(&payload)?;
-    let message_id = MessageId::from_str(&metadata.message_id)?;
-
-    if let Some(inclusion_state) = metadata.ledger_inclusion_state {
-        let confirmed = inclusion_state == LedgerInclusionStateDto::Included;
-        let mut account = account_handle.write().await;
-        let messages = account.messages_mut();
-        let message = messages.iter_mut().find(|m| m.id() == &message_id).unwrap();
-        if message.confirmed().is_none() || confirmed != message.confirmed().unwrap() {
-            let message_ = message.clone();
-            message.set_confirmed(Some(confirmed));
-            account.save().await?;
-
-            log::info!(
-                "[MQTT] confirmation state change: {:?} - confirmed: {}",
-                message_.id(),
-                confirmed
-            );
-            crate::event::emit_confirmation_state_change(
-                &account,
-                message_,
-                confirmed,
-                account_handle.account_options.persist_events,
-            )
-            .await?;
-        }
-    }
-    Ok(())
 }


### PR DESCRIPTION
# Description of change

Prevents synchronization issues when MQTT is subscribed to only some of the topics.
