### PR TITLE
chore(events): emit transaction events before balance changes

### DIFF
--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -885,16 +885,6 @@ impl AccountSynchronizer {
                     &confirmation_changed_messages,
                 )
                 .await?;
-                for balance_change_event in events.balance_change_events {
-                    emit_balance_change(
-                        &account,
-                        &balance_change_event.address,
-                        balance_change_event.message_id,
-                        balance_change_event.balance_change,
-                        persist_events,
-                    )
-                    .await?;
-                }
                 for message in events.new_transaction_events {
                     emit_transaction_event(TransactionEventType::NewTransaction, &account, message, persist_events)
                         .await?;
@@ -904,6 +894,16 @@ impl AccountSynchronizer {
                         &account,
                         confirmation_change_event.message,
                         confirmation_change_event.confirmed,
+                        persist_events,
+                    )
+                    .await?;
+                }
+                for balance_change_event in events.balance_change_events {
+                    emit_balance_change(
+                        &account,
+                        &balance_change_event.address,
+                        balance_change_event.message_id,
+                        balance_change_event.balance_change,
                         persist_events,
                     )
                     .await?;

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -1290,16 +1290,6 @@ impl AccountsSynchronizer {
                     &confirmation_changed_messages,
                 )
                 .await?;
-                for balance_change_event in events.balance_change_events {
-                    emit_balance_change(
-                        &account,
-                        &balance_change_event.address,
-                        balance_change_event.message_id,
-                        balance_change_event.balance_change,
-                        persist_events,
-                    )
-                    .await?;
-                }
                 for message in events.new_transaction_events {
                     emit_transaction_event(TransactionEventType::NewTransaction, &account, message, persist_events)
                         .await?;
@@ -1309,6 +1299,16 @@ impl AccountsSynchronizer {
                         &account,
                         confirmation_change_event.message,
                         confirmation_change_event.confirmed,
+                        persist_events,
+                    )
+                    .await?;
+                }
+                for balance_change_event in events.balance_change_events {
+                    emit_balance_change(
+                        &account,
+                        &balance_change_event.address,
+                        balance_change_event.message_id,
+                        balance_change_event.balance_change,
                         persist_events,
                     )
                     .await?;


### PR DESCRIPTION
# Description of change

This will simplify event handling since that way users know they have the latest messages when handling to the balance change event (and can use the message id on the event payload).