### PR TITLE
feat(client): add `disabled` option to the node struct

### DIFF
--- a/.changes/node-disabled.md
+++ b/.changes/node-disabled.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": patch
+---
+
+Adds `disabled` flag on the `Node` object.

--- a/bindings/nodejs/lib/index.d.ts
+++ b/bindings/nodejs/lib/index.d.ts
@@ -155,11 +155,12 @@ export declare interface Node {
     username: string
     password: string
   }
+  disabled?: boolean
 }
 
 export declare interface ClientOptions {
   node?: NodeUrl | Node;
-  nodes?: string[];
+  nodes?: Array<NodeUrl | Node>;
   network?: string;
   quorumSize?: number;
   quorumThreshold?: number;

--- a/bindings/python/native/src/types/option.rs
+++ b/bindings/python/native/src/types/option.rs
@@ -42,6 +42,7 @@ impl From<RustNodeAuth> for NodeAuth {
 pub struct Node {
     url: String,
     auth: Option<NodeAuth>,
+    disabled: bool,
 }
 
 impl From<Node> for RustNode {
@@ -49,6 +50,7 @@ impl From<Node> for RustNode {
         Self {
             url: Url::parse(&node.url).expect("invalid url"),
             auth: node.auth.map(|a| a.into()),
+            disabled: node.disabled,
         }
     }
 }
@@ -58,6 +60,7 @@ impl From<RustNode> for Node {
         Self {
             url: node.url.as_str().to_string(),
             auth: node.auth.map(|auth| auth.into()),
+            disabled: node.disabled,
         }
     }
 }


### PR DESCRIPTION
# Description of change

Adds a `disabled` flag to ClientOptions > node.

## Links to any relevant issues

N/A

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have checked that new and existing unit tests pass locally with my changes
