### PR TITLE
fix(manager): release storage on drop

### DIFF
--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -278,6 +278,12 @@ impl Clone for AccountManager {
 impl Drop for AccountManager {
     fn drop(&mut self) {
         self.stop_background_sync();
+        let storage_path = self.storage_path.clone();
+        thread::spawn(move || {
+            crate::block_on(crate::storage::remove(&storage_path));
+        })
+        .join()
+        .expect("failed to drop manager storage");
     }
 }
 

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -329,7 +329,8 @@ impl AccountManager {
     }
 
     pub(crate) async fn delete_internal(&self) -> crate::Result<()> {
-        let storage_id = crate::storage::remove(&self.storage_path).await;
+        // safe to unwrap: we know the storage exists
+        let storage_id = crate::storage::remove(&self.storage_path).await.unwrap();
 
         if self.storage_path.exists() {
             if self.storage_path.is_file() {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -318,10 +318,14 @@ pub(crate) async fn set<P: AsRef<Path>>(
     );
 }
 
-pub(crate) async fn remove(storage_path: &Path) -> String {
+pub(crate) async fn remove(storage_path: &Path) -> Option<String> {
     let mut instances = INSTANCES.get_or_init(Default::default).write().await;
     let storage = instances.remove(storage_path);
-    storage.unwrap().lock().await.id().to_string()
+    if let Some(s) = storage {
+        Some(s.lock().await.id().to_string())
+    } else {
+        None
+    }
 }
 
 pub(crate) async fn set_encryption_key(storage_path: &Path, encryption_key: [u8; 32]) -> crate::Result<()> {


### PR DESCRIPTION
# Description of change

RocksDB needs to be released on manager drop so another instance can use it.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

CLI wallet opening two manager instances on the same storage.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have checked that new and existing unit tests pass locally with my changes
