### PR TITLE
fix(ci): Install Clang on Windows when building Python wheels

### DIFF
--- a/.github/workflows/python_binding_publish.yml
+++ b/.github/workflows/python_binding_publish.yml
@@ -29,6 +29,17 @@ jobs:
     steps:
      - uses: actions/checkout@v2
 
+     - name: Install LLVM and Clang (Windows) # required for bindgen to work, see https://github.com/rust-lang/rust-bindgen/issues/1797
+       uses: KyleMayes/install-llvm-action@32c4866ebb71e0949e8833eb49beeebed48532bd
+       if: matrix.os == 'windows-latest'
+       with:
+        version: "11.0"
+        directory: ${{ runner.temp }}/llvm
+      
+     - name: Set LIBCLANG_PATH (Windows)
+       run: echo "LIBCLANG_PATH=$((gcm clang).source -replace "clang.exe")" >> $env:GITHUB_ENV
+       if: matrix.os == 'windows-latest'
+
      - uses: actions-rs/toolchain@v1
        with:
          toolchain: stable


### PR DESCRIPTION
# Description of change

The workflow to publish Python wheels is currently failing on Windows because Clang is not installed

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

N/A

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas