### PR TITLE
feat(mqtt): sync all accounts involved in a message

### DIFF
--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -633,7 +633,7 @@ async fn perform_sync(
     })
 }
 
-#[derive(PartialEq)]
+#[derive(Clone, PartialEq)]
 pub(crate) enum AccountSynchronizeStep {
     SyncAddresses(Option<Vec<AddressWrapper>>),
     SyncMessages,

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -1,6 +1,7 @@
 // Copyright 2020 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::account::AccountSynchronizeStep;
 #[allow(unused_imports)]
 use crate::{
     account::{
@@ -189,11 +190,13 @@ impl AccountManagerBuilder {
 
         crate::storage::set(&storage_file_path, self.storage_encryption_key, storage).await;
 
+        let sync_accounts_lock = Arc::new(Mutex::new(()));
+
         // with the stronghold storage, the accounts are loaded when the password is set
         let (accounts, loaded_accounts) = if is_stronghold {
             (Default::default(), false)
         } else {
-            AccountManager::load_accounts(&storage_file_path, self.account_options)
+            AccountManager::load_accounts(&storage_file_path, self.account_options, sync_accounts_lock.clone())
                 .await
                 .map(|accounts| (accounts, true))
                 .unwrap_or_else(|_| (AccountStore::default(), false))
@@ -207,7 +210,7 @@ impl AccountManagerBuilder {
             polling_handle: None,
             generated_mnemonic: None,
             account_options: self.account_options,
-            sync_accounts_lock: Arc::new(Mutex::new(())),
+            sync_accounts_lock,
         };
 
         if !self.skip_polling {
@@ -301,7 +304,11 @@ impl AccountManager {
         AccountManagerBuilder::new()
     }
 
-    async fn load_accounts(storage_file_path: &Path, account_options: AccountOptions) -> crate::Result<AccountStore> {
+    async fn load_accounts(
+        storage_file_path: &Path,
+        account_options: AccountOptions,
+        sync_accounts_lock: Arc<Mutex<()>>,
+    ) -> crate::Result<AccountStore> {
         let parsed_accounts = Arc::new(RwLock::new(HashMap::new()));
 
         let accounts = crate::storage::get(&storage_file_path)
@@ -313,7 +320,12 @@ impl AccountManager {
         for account in accounts {
             parsed_accounts.write().await.insert(
                 account.id().clone(),
-                AccountHandle::new(account, parsed_accounts.clone(), account_options),
+                AccountHandle::new(
+                    account,
+                    parsed_accounts.clone(),
+                    account_options,
+                    sync_accounts_lock.clone(),
+                ),
             );
         }
 
@@ -417,7 +429,12 @@ impl AccountManager {
             .unwrap();
 
         if self.accounts.read().await.is_empty() {
-            let accounts = Self::load_accounts(&self.storage_path, self.account_options).await?;
+            let accounts = Self::load_accounts(
+                &self.storage_path,
+                self.account_options,
+                self.sync_accounts_lock.clone(),
+            )
+            .await?;
             self.loaded_accounts = true;
             {
                 let mut accounts_store = self.accounts.write().await;
@@ -446,7 +463,12 @@ impl AccountManager {
         crate::stronghold::load_snapshot(&stronghold_path, stronghold_password(password)).await?;
 
         if self.accounts.read().await.is_empty() {
-            let accounts = Self::load_accounts(&self.storage_path, self.account_options).await?;
+            let accounts = Self::load_accounts(
+                &self.storage_path,
+                self.account_options,
+                self.sync_accounts_lock.clone(),
+            )
+            .await?;
             self.loaded_accounts = true;
             {
                 let mut accounts_store = self.accounts.write().await;
@@ -632,6 +654,7 @@ impl AccountManager {
             self.accounts.clone(),
             self.storage_path.clone(),
             self.account_options,
+            self.sync_accounts_lock.clone(),
         ))
     }
 
@@ -970,10 +993,11 @@ pub struct AccountsSynchronizer {
     discover_accounts: bool,
     skip_change_addresses: bool,
     ran_account_discovery: bool,
+    steps: Option<Vec<AccountSynchronizeStep>>,
 }
 
 impl AccountsSynchronizer {
-    fn new(
+    pub(crate) fn new(
         mutex: Arc<Mutex<()>>,
         accounts: AccountStore,
         storage_file_path: PathBuf,
@@ -989,6 +1013,7 @@ impl AccountsSynchronizer {
             discover_accounts: true,
             skip_change_addresses: false,
             ran_account_discovery: false,
+            steps: None,
         }
     }
 
@@ -1016,6 +1041,14 @@ impl AccountsSynchronizer {
         self
     }
 
+    /// Sets the steps to run on the sync process.
+    /// By default it runs all steps (sync_addresses and sync_messages),
+    /// but the library can pick what to run here.
+    pub(crate) fn steps(mut self, steps: Vec<AccountSynchronizeStep>) -> Self {
+        self.steps.replace(steps);
+        self
+    }
+
     /// Syncs the accounts with the Tangle.
     pub async fn execute(&mut self) -> crate::Result<Vec<SyncedAccount>> {
         let accounts = self.accounts.clone();
@@ -1040,6 +1073,7 @@ impl AccountsSynchronizer {
             let skip_change_addresses = self.skip_change_addresses;
             for account_handle in accounts.values() {
                 let account_handle = account_handle.clone();
+                let steps = self.steps.clone();
                 tasks.push(async move {
                     tokio::spawn(async move {
                         let mut sync = account_handle.sync().await;
@@ -1051,6 +1085,9 @@ impl AccountsSynchronizer {
                         }
                         if let Some(limit) = gap_limit {
                             sync = sync.gap_limit(limit);
+                        }
+                        if let Some(steps) = steps {
+                            sync = sync.steps(steps);
                         }
                         let synced_data = sync.get_new_history().await?;
                         crate::Result::Ok((account_handle, synced_data))
@@ -1106,6 +1143,7 @@ impl AccountsSynchronizer {
                             &client_options,
                             Some(signer_type),
                             self.account_options,
+                            self.mutex.clone(),
                         )
                         .await
                     } else {
@@ -1283,15 +1321,17 @@ async fn poll(
             if let Ok(metadata) = client.read().await.get_message().metadata(&message_id).await {
                 if let Some(ledger_inclusion_state) = metadata.ledger_inclusion_state {
                     let confirmed = ledger_inclusion_state == LedgerInclusionStateDto::Included;
-                    message.set_confirmed(Some(confirmed));
-                    account.save_messages(vec![message.clone()]).await?;
-                    emit_confirmation_state_change(
-                        &account,
-                        message,
-                        confirmed,
-                        retried_data.account_handle.account_options.persist_events,
-                    )
-                    .await?;
+                    if message.confirmed() != &Some(confirmed) {
+                        message.set_confirmed(Some(confirmed));
+                        account.save_messages(vec![message.clone()]).await?;
+                        emit_confirmation_state_change(
+                            &account,
+                            message,
+                            confirmed,
+                            retried_data.account_handle.account_options.persist_events,
+                        )
+                        .await?;
+                    }
                 }
             }
         }
@@ -1309,6 +1349,7 @@ async fn discover_accounts(
     client_options: &ClientOptions,
     signer_type: Option<SignerType>,
     account_options: AccountOptions,
+    sync_accounts_lock: Arc<Mutex<()>>,
 ) -> crate::Result<Vec<(AccountHandle, SyncedAccountData)>> {
     let mut synced_accounts = vec![];
     let mut index = accounts.read().await.len();
@@ -1318,6 +1359,7 @@ async fn discover_accounts(
             accounts.clone(),
             storage_path.to_path_buf(),
             account_options,
+            sync_accounts_lock.clone(),
         )
         .skip_persistence()
         .index(index);

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -1896,9 +1896,13 @@ mod tests {
         crate::test_utils::with_account_manager(crate::test_utils::TestType::Storage, |mut manager, _| async move {
             crate::test_utils::AccountCreator::new(&manager).create().await;
             manager.set_storage_password("new-password").await.unwrap();
-            let account_store = super::AccountManager::load_accounts(manager.storage_path(), manager.account_options)
-                .await
-                .unwrap();
+            let account_store = super::AccountManager::load_accounts(
+                manager.storage_path(),
+                manager.account_options,
+                Default::default(),
+            )
+            .await
+            .unwrap();
             assert_eq!(account_store.read().await.len(), 1);
         })
         .await;

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -3,15 +3,16 @@
 
 use crate::{
     account::{AccountHandle, AccountSynchronizeStep},
+    account_manager::AccountsSynchronizer,
     address::{AddressOutput, AddressWrapper, IotaAddress},
     client::ClientOptions,
-    event::{emit_confirmation_state_change, emit_transaction_event, TransactionEventType},
     message::{Message, MessagePayload, TransactionEssence, TransactionInput, TransactionOutput},
 };
 
 use iota::{bee_rest_api::types::dtos::OutputDto, OutputResponse, Topic, TopicEvent};
+use tokio::sync::RwLock;
 
-use std::convert::TryInto;
+use std::{collections::HashMap, convert::TryInto, sync::Arc};
 
 /// Unsubscribe from all topics associated with the account.
 pub async fn unsubscribe(account_handle: AccountHandle) -> crate::Result<()> {
@@ -107,7 +108,7 @@ pub async fn monitor_address_balance(account_handle: AccountHandle, addresses: V
 }
 
 async fn process_output(payload: String, account_handle: AccountHandle) -> crate::Result<bool> {
-    let mut account = account_handle.write().await;
+    let account = account_handle.write().await;
 
     let output = serde_json::from_str::<OutputResponse>(&payload)?;
     let output_address: IotaAddress = match output.output.clone() {
@@ -122,6 +123,7 @@ async fn process_output(payload: String, account_handle: AccountHandle) -> crate
             return Ok(false);
         }
     };
+
     let address = match account
         .addresses()
         .iter()
@@ -133,106 +135,112 @@ async fn process_output(payload: String, account_handle: AccountHandle) -> crate
             return Ok(false);
         }
     };
-    let output = AddressOutput::from_output_response(output, address.bech32_hrp().to_string())?;
-    let (addresses_to_sync, message_data) = if output.is_spent {
-        (vec![address], None)
-    } else {
-        let (message, is_new) = match account.get_message(&output.message_id).await {
-            Some(mut message) => {
-                if !message.confirmed().unwrap_or(false) {
-                    message.set_confirmed(Some(true));
-                    account.save_messages(vec![message.clone()]).await?;
-                    (message, false)
-                } else {
-                    return Ok(false);
-                }
-            }
-            None => {
-                if let Ok(message) = crate::client::get_client(account.client_options())
-                    .await?
-                    .read()
-                    .await
-                    .get_message()
-                    .data(&output.message_id)
-                    .await
-                {
-                    let message = Message::from_iota_message(
-                        output.message_id,
-                        message,
-                        account_handle.accounts.clone(),
-                        account.id(),
-                        account.addresses(),
-                        account.client_options(),
-                    )
-                    .with_confirmed(Some(true))
-                    .finish()
-                    .await?;
-                    account.save_messages(vec![message.clone()]).await?;
-                    (message, true)
-                } else {
-                    return Ok(false);
-                }
-            }
-        };
 
-        let message_addresses = match message.payload() {
-            Some(MessagePayload::Transaction(tx)) => match tx.essence() {
-                TransactionEssence::Regular(essence) => {
-                    let output_addresses: Vec<AddressWrapper> = essence
-                        .outputs()
-                        .iter()
-                        .map(|output| match output {
-                            TransactionOutput::SignatureLockedDustAllowance(o) => o.address().clone(),
-                            TransactionOutput::SignatureLockedSingle(o) => o.address().clone(),
-                            _ => unimplemented!(),
-                        })
-                        .collect();
-                    let input_addresses: Vec<AddressWrapper> = essence
-                        .inputs()
-                        .iter()
-                        .map(|input| match input {
-                            TransactionInput::UTXO(i) => i.metadata.as_ref().map(|m| m.address.clone()),
-                            _ => unimplemented!(),
-                        })
-                        .flatten()
-                        .collect();
-                    let mut addresses = output_addresses;
-                    addresses.extend(input_addresses);
-                    addresses
-                }
-            },
-            _ => vec![],
-        };
-        (message_addresses, Some((message, is_new)))
+    let output = AddressOutput::from_output_response(output, address.bech32_hrp().to_string())?;
+    let message = match account.get_message(&output.message_id).await {
+        Some(message) => {
+            if !message.confirmed().unwrap_or(false) {
+                message
+            } else {
+                return Ok(false);
+            }
+        }
+        None => {
+            if let Ok(message) = crate::client::get_client(account.client_options())
+                .await?
+                .read()
+                .await
+                .get_message()
+                .data(&output.message_id)
+                .await
+            {
+                Message::from_iota_message(
+                    output.message_id,
+                    message,
+                    account_handle.accounts.clone(),
+                    account.id(),
+                    account.addresses(),
+                    account.client_options(),
+                )
+                .with_confirmed(Some(true))
+                .finish()
+                .await?
+            } else {
+                return Ok(false);
+            }
+        }
     };
 
-    drop(account);
-    let _ = account_handle
-        .sync()
-        .await
-        .steps(vec![AccountSynchronizeStep::SyncAddresses(Some(addresses_to_sync))])
-        .execute()
-        .await;
-    let account = account_handle.read().await;
+    let message_addresses = match message.payload() {
+        Some(MessagePayload::Transaction(tx)) => match tx.essence() {
+            TransactionEssence::Regular(essence) => {
+                let output_addresses: Vec<AddressWrapper> = essence
+                    .outputs()
+                    .iter()
+                    .map(|output| match output {
+                        TransactionOutput::SignatureLockedDustAllowance(o) => o.address().clone(),
+                        TransactionOutput::SignatureLockedSingle(o) => o.address().clone(),
+                        _ => unimplemented!(),
+                    })
+                    .collect();
+                let input_addresses: Vec<AddressWrapper> = essence
+                    .inputs()
+                    .iter()
+                    .map(|input| match input {
+                        TransactionInput::UTXO(i) => i.metadata.as_ref().map(|m| m.address.clone()),
+                        _ => unimplemented!(),
+                    })
+                    .flatten()
+                    .collect();
+                let mut addresses = output_addresses;
+                addresses.extend(input_addresses);
+                addresses
+            }
+        },
+        _ => vec![],
+    };
 
-    if let Some((message, is_new)) = message_data {
-        if is_new {
-            emit_transaction_event(
-                TransactionEventType::NewTransaction,
-                &account,
-                message.clone(),
-                account_handle.account_options.persist_events,
-            )
-            .await?;
-        } else {
-            emit_confirmation_state_change(
-                &account,
-                message.clone(),
-                true,
-                account_handle.account_options.persist_events,
-            )
-            .await?;
+    let message_is_internal = match message.payload() {
+        Some(MessagePayload::Transaction(tx)) => {
+            let TransactionEssence::Regular(essence) = tx.essence();
+            essence.internal()
         }
+        _ => false,
+    };
+
+    let storage_path = account.storage_path().clone();
+    let account_id = account.id().clone();
+    drop(account);
+
+    let mut accounts_to_sync = HashMap::new();
+
+    if message_is_internal {
+        for (account_id, account_handle) in account_handle.accounts.read().await.iter() {
+            if account_handle
+                .read()
+                .await
+                .addresses()
+                .iter()
+                .any(|a| message_addresses.contains(a.address()))
+            {
+                accounts_to_sync.insert(account_id.clone(), account_handle.clone());
+            }
+        }
+    } else {
+        accounts_to_sync.insert(account_id, account_handle.clone());
     }
+
+    // sync associated accounts
+    AccountsSynchronizer::new(
+        account_handle.sync_accounts_lock.clone(),
+        Arc::new(RwLock::new(accounts_to_sync)),
+        storage_path,
+        account_handle.account_options,
+    )
+    .skip_account_discovery()
+    .steps(vec![AccountSynchronizeStep::SyncAddresses(Some(message_addresses))])
+    .execute()
+    .await?;
+
     Ok(true)
 }


### PR DESCRIPTION
# Description of change

Syncing all accounts at once prevents delays on events when the transaction is internal.

## Links to any relevant issues

N/A

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

CLI wallet.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked that new and existing unit tests pass locally with my changes
