### PR TITLE
fix(manager): reuse existing rocksdb instances

### DIFF
--- a/.changes/rocksdb-lock.md
+++ b/.changes/rocksdb-lock.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": patch
+---
+
+Reuse RocksDB storage instances.


### PR DESCRIPTION
RocksDB has a lock on each instance so we need to reuse them if a manager with the same storage already exists.