### PR TITLE
fix(ci): Do not build bindings for Node.js 15.x on Windows

### DIFF
--- a/.github/workflows/covector-version-or-publish.yml
+++ b/.github/workflows/covector-version-or-publish.yml
@@ -54,6 +54,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         node-version: ['10.x', '12.x', '14.x', '15.x']
+        exclude:
+            # Remove once neon is updated
+          - os: windows-latest
+            node-version: '15.x'
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
# Description of change

`neon` will not generate bindings for Node.js 15 on Windows until it is [updated to 0.5.3](https://github.com/neon-bindings/neon/blob/main/RELEASES.md#version-053)

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

N/A

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas