### PR TITLE
Tests: Save python testing time

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -186,7 +186,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.9]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
We test the Python 3.9 only to save the testing time and to reduce the Github Action loading, due to organization-wide concurrency limit.