### PR TITLE
fix: reverts first iteration polling logic 

### DIFF
--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -232,7 +232,7 @@ impl AccountManagerBuilder {
                     self.polling_interval,
                     self.account_options.automatic_output_consolidation,
                 )
-                .await?;
+                .await;
         }
 
         Ok(instance)
@@ -404,17 +404,11 @@ impl AccountManager {
     }
 
     /// Initialises the background polling and MQTT monitoring.
-    async fn start_background_sync(
-        &mut self,
-        polling_interval: Duration,
-        automatic_output_consolidation: bool,
-    ) -> crate::Result<()> {
+    async fn start_background_sync(&mut self, polling_interval: Duration, automatic_output_consolidation: bool) {
         Self::start_monitoring(self.accounts.clone()).await;
         let (stop_polling_sender, stop_polling_receiver) = broadcast_channel(1);
-        self.start_polling(polling_interval, stop_polling_receiver, automatic_output_consolidation)
-            .await?;
+        self.start_polling(polling_interval, stop_polling_receiver, automatic_output_consolidation);
         self.stop_polling_sender.replace(stop_polling_sender);
-        Ok(())
     }
 
     /// Stops the background polling and MQTT monitoring.
@@ -541,18 +535,17 @@ impl AccountManager {
     }
 
     /// Starts the polling mechanism.
-    async fn start_polling(
+    fn start_polling(
         &mut self,
         polling_interval: Duration,
         mut stop: BroadcastReceiver<()>,
         automatic_output_consolidation: bool,
-    ) -> crate::Result<()> {
+    ) {
         let storage_file_path = self.storage_path.clone();
         let accounts = self.accounts.clone();
         let account_options = self.account_options;
         let sync_accounts_lock = self.sync_accounts_lock.clone();
-        #[cfg(feature = "stronghold")]
-        let stronghold_snapshot_path = self.stronghold_snapshot_path().await?;
+
         let handle = thread::spawn(move || {
             let runtime = tokio::runtime::Builder::new_multi_thread()
                 .enable_all()
@@ -560,7 +553,7 @@ impl AccountManager {
                 .unwrap();
             runtime.block_on(async {
                 let mut interval = interval(polling_interval);
-                let mut did_full_sync = false;
+                let mut synced = false;
                 let mut discovered_accounts = false;
                 loop {
                     tokio::select! {
@@ -577,7 +570,7 @@ impl AccountManager {
                                         accounts.clone(),
                                         storage_file_path_,
                                         account_options,
-                                        !(did_full_sync && discovered_accounts),
+                                        !(synced && discovered_accounts),
                                         automatic_output_consolidation)
                                     )
                                     .catch_unwind()
@@ -587,25 +580,7 @@ impl AccountManager {
                                                 if response.ran_account_discovery {
                                                     discovered_accounts = true;
                                                 }
-                                                #[cfg(not(feature = "stronghold"))]
-                                                {
-                                                    if !did_full_sync {
-                                                        did_full_sync = response.synced_accounts_len > 0;
-                                                    }
-                                                }
-                                                #[cfg(feature = "stronghold")]
-                                                {
-                                                    if !did_full_sync {
-                                                        // safe to unwrap since we've checked that the hashmap isn't empty
-                                                        if accounts.read().await.values().next().unwrap().read().await.signer_type() == &SignerType::Stronghold {
-                                                            did_full_sync = response.synced_accounts_len > 0
-                                                                && matches!(
-                                                                    crate::stronghold::get_status(&stronghold_snapshot_path).await.snapshot,
-                                                                    crate::stronghold::SnapshotStatus::Unlocked(_)
-                                                                );
-                                                        }
-                                                    }
-                                                }
+                                                synced = response.synced_accounts_len > 0;
                                             }
                                         }
                                         Err(error) => {
@@ -634,7 +609,6 @@ impl AccountManager {
             });
         });
         self.polling_handle.replace(handle);
-        Ok(())
     }
 
     /// Stores a mnemonic for the given signer type.

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -570,7 +570,6 @@ impl AccountManager {
                                         accounts.clone(),
                                         storage_file_path_,
                                         account_options,
-                                        !(synced && discovered_accounts),
                                         automatic_output_consolidation)
                                     )
                                     .catch_unwind()
@@ -1303,16 +1302,11 @@ async fn poll(
     accounts: AccountStore,
     storage_file_path: PathBuf,
     account_options: AccountOptions,
-    first_iteration: bool,
     automatic_output_consolidation: bool,
 ) -> crate::Result<PollResponse> {
     let mut synchronizer =
         AccountsSynchronizer::new(sync_accounts_lock, accounts.clone(), storage_file_path, account_options);
-    if first_iteration {
-        synchronizer = synchronizer.address_index(0).gap_limit(10);
-    } else {
-        synchronizer = synchronizer.skip_account_discovery().skip_change_addresses();
-    }
+    synchronizer = synchronizer.skip_account_discovery().skip_change_addresses();
     let synced_accounts = synchronizer.execute().await?;
 
     log::debug!("[POLLING] synced accounts");


### PR DESCRIPTION
# Description of change

- Reverts polling logic. Full sync is not necessary through polling, provided we adjust the logic for generating change addresses (i.e. send remainder to latest unused change address).
- Full sync appears to interfere with the atomicity of balance updates.

Fixes #533 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Tested via Firefly on Mac.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
