### PR TITLE
refactor(account): separate address space for change addresses

### DIFF
--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -764,6 +764,14 @@ impl Account {
             .unwrap()
     }
 
+    /// Returns the most recent change address of the account.
+    pub(crate) fn latest_change_address(&self) -> Option<&Address> {
+        self.addresses
+            .iter()
+            .filter(|a| *a.internal())
+            .max_by_key(|a| a.key_index())
+    }
+
     fn latest_address_mut(&mut self) -> &mut Address {
         // the addresses list is never empty because we generate an address on the account creation
         self.addresses

--- a/src/address.rs
+++ b/src/address.rs
@@ -410,18 +410,11 @@ pub(crate) async fn get_new_address(account: &Account, metadata: GenerateAddress
 /// Gets an unused change address for the given account and address.
 pub(crate) async fn get_new_change_address(
     account: &Account,
-    address: &Address,
+    key_index: usize,
+    bech32_hrp: String,
     metadata: GenerateAddressMetadata,
 ) -> crate::Result<Address> {
-    let key_index = *address.key_index();
-    let iota_address = get_iota_address(
-        &account,
-        key_index,
-        true,
-        address.address().bech32_hrp().to_string(),
-        metadata,
-    )
-    .await?;
+    let iota_address = get_iota_address(&account, key_index, true, bech32_hrp, metadata).await?;
     let address = Address {
         address: iota_address,
         key_index,


### PR DESCRIPTION
Account address space is now clearly split in public and change addresses: we'll sync them separately and always keep the latest change address unused, and use it on the transfer instead of the old logic that involved matching index with the remainder, and using latest public.