### PR TITLE
fix(manager): `accounts` reference management on AccountHandle, closes #510

### DIFF
--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -1705,7 +1705,7 @@ mod tests {
                         .with_network_id(0)
                         .finish()
                         .unwrap(),
-                    Default::default(),
+                    super::AccountStore::new(Default::default()),
                     "",
                     &[crate::test_utils::generate_random_address()],
                     &ClientOptionsBuilder::new().build().unwrap(),
@@ -1928,7 +1928,9 @@ mod tests {
         crate::test_utils::with_account_manager(crate::test_utils::TestType::Storage, |mut manager, _| async move {
             crate::test_utils::AccountCreator::new(&manager).create().await;
             manager.set_storage_password("new-password").await.unwrap();
-            let account_store = super::AccountManager::load_accounts(
+            let account_store = super::AccountStore::new(Default::default());
+            super::AccountManager::load_accounts(
+                &account_store,
                 manager.storage_path(),
                 manager.account_options,
                 Default::default(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@ pub fn get_ledger_status(is_simulator: bool) -> LedgerStatus {
 mod test_utils {
     use super::{
         account::AccountHandle,
-        account_manager::AccountManager,
+        account_manager::{AccountManager, AccountStore},
         address::{Address, AddressBuilder, AddressWrapper},
         client::ClientOptionsBuilder,
         message::{Message, MessagePayload, TransactionBuilderMetadata, TransactionEssence},
@@ -475,7 +475,7 @@ mod test_utils {
                 id: &id,
                 bech32_hrp,
                 account_id: "",
-                accounts: Default::default(),
+                accounts: AccountStore::new(Default::default()),
                 account_addresses: &[],
                 client_options: &ClientOptionsBuilder::new().build().unwrap(),
             };

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     account::{AccountHandle, AccountSynchronizeStep},
-    account_manager::AccountsSynchronizer,
+    account_manager::{AccountStore, AccountsSynchronizer},
     address::{AddressOutput, AddressWrapper, IotaAddress},
     client::ClientOptions,
     message::{Message, MessagePayload, TransactionEssence, TransactionInput, TransactionOutput},
@@ -236,7 +236,7 @@ async fn process_output(payload: String, account_handle: AccountHandle) -> crate
     // sync associated accounts
     AccountsSynchronizer::new(
         account_handle.sync_accounts_lock.clone(),
-        Arc::new(RwLock::new(accounts_to_sync)),
+        AccountStore::new(Arc::new(RwLock::new(accounts_to_sync))),
         storage_path,
         account_handle.account_options,
     )


### PR DESCRIPTION
# Description of change

Fixes dummy `accounts` reference on read AccountHandle.

## Links to any relevant issues

#510

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
