### PR TITLE
feat(manager): add account discovery threshold

### DIFF
--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -235,7 +235,7 @@ impl AccountInitialiser {
             if latest_account.with_messages(|messages| messages.is_empty()).await
                 && latest_account.addresses().iter().all(|a| a.outputs.is_empty())
             {
-                return Err(crate::Error::LatestAccountIsEmpty);
+                // return Err(crate::Error::LatestAccountIsEmpty);
             }
         }
 

--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -233,7 +233,7 @@ impl AccountInitialiser {
             if latest_account.with_messages(|messages| messages.is_empty()).await
                 && latest_account.addresses().iter().all(|a| a.outputs.is_empty())
             {
-                // return Err(crate::Error::LatestAccountIsEmpty);
+                return Err(crate::Error::LatestAccountIsEmpty);
             }
         }
 

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -1386,6 +1386,7 @@ async fn poll(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn discover_accounts(
     accounts: AccountStore,
     threshold: usize,

--- a/src/actor/message.rs
+++ b/src/actor/message.rs
@@ -132,6 +132,9 @@ pub enum MessageType {
         /// The gap limit.
         #[serde(rename = "gapLimit")]
         gap_limit: Option<usize>,
+        /// Minimum number of accounts to check on discovery.
+        #[serde(rename = "accountDiscoveryThreshold")]
+        account_discovery_threshold: Option<usize>,
     },
     /// Reattach message.
     Reattach {
@@ -246,6 +249,7 @@ impl Serialize for MessageType {
             MessageType::SyncAccounts {
                 address_index: _,
                 gap_limit: _,
+                account_discovery_threshold: _,
             } => serializer.serialize_unit_variant("MessageType", 5, "SyncAccounts"),
             MessageType::Reattach {
                 account_id: _,


### PR DESCRIPTION
# Description of change

Implements `account_discovery_threshold` (`accountDiscoveryThreshold` field for actor consumers), an option on `AccountManager#sync_accounts` that determines the minimum number of accounts to check on account discovery (defaults to 1).

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

CLI wallet.