### PR TITLE
Fix AccountManager sync deadlock

### DIFF
--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -1478,12 +1478,14 @@ impl AccountsSynchronizer {
                     .await?;
                 }
             }
+            drop(account);
 
             let mut synced_account = SyncedAccount::from(account_handle.clone()).await;
             let mut updated_messages = new_messages;
             updated_messages.extend(confirmation_changed_messages);
             synced_account.messages = updated_messages;
 
+            let account = account_handle.read().await;
             synced_account.addresses = account
                 .addresses()
                 .iter()


### PR DESCRIPTION
# Description of change

Fixes a deadlock when syncing accounts caused by a contention between the background polling thread and the `AccountSynchronizer` when it attempts to clone an `AccountHandle`.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Run a code snippet that previously deadlocked 100% of the time when calling `AccountManager::sync_accounts()`, which now reliably returns.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have checked that new and existing unit tests pass locally with my changes
