### PR TITLE
fix(manager): prevent `storage adapter not set` errors

### DIFF
--- a/.changes/storage-adapter-not-set-error.md
+++ b/.changes/storage-adapter-not-set-error.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": patch
+---
+
+Prevent `storage adapter not set` errors.

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -367,12 +367,6 @@ impl Clone for AccountManager {
 impl Drop for AccountManager {
     fn drop(&mut self) {
         self.stop_background_sync();
-        let storage_path = self.storage_path.clone();
-        thread::spawn(move || {
-            crate::block_on(crate::storage::remove(&storage_path));
-        })
-        .join()
-        .expect("failed to drop manager storage");
     }
 }
 


### PR DESCRIPTION
# Description of change

It's safe to remove the cleanup code since we reuse the db instance if two manager instances are created.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)