### PR TITLE
fix: Use windows UTF8 version of rocksdb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1955,8 +1955,7 @@ dependencies = [
 [[package]]
 name = "librocksdb-sys"
 version = "6.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5da125e1c0f22c7cae785982115523a0738728498547f415c9054cb17c7e89f9"
+source = "git+https://github.com/obany/rust-rocksdb?rev=9ab27f60f9e1b1cf40b61e3bb85ca794c0e08beb#9ab27f60f9e1b1cf40b61e3bb85ca794c0e08beb"
 dependencies = [
  "bindgen",
  "cc",
@@ -2904,9 +2903,8 @@ dependencies = [
 
 [[package]]
 name = "rocksdb"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d83c02c429044d58474eaf5ae31e062d0de894e21125b47437ec0edc1397e6"
+version = "0.16.0"
+source = "git+https://github.com/obany/rust-rocksdb?rev=9ab27f60f9e1b1cf40b61e3bb85ca794c0e08beb#9ab27f60f9e1b1cf40b61e3bb85ca794c0e08beb"
 dependencies = [
  "libc",
  "librocksdb-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1955,7 +1955,7 @@ dependencies = [
 [[package]]
 name = "librocksdb-sys"
 version = "6.17.3"
-source = "git+https://github.com/obany/rust-rocksdb?rev=9ab27f60f9e1b1cf40b61e3bb85ca794c0e08beb#9ab27f60f9e1b1cf40b61e3bb85ca794c0e08beb"
+source = "git+https://github.com/iotaledger/rust-rocksdb?rev=70f2a53529ecc1853a2c025cec7f9d00bd50352c#70f2a53529ecc1853a2c025cec7f9d00bd50352c"
 dependencies = [
  "bindgen",
  "cc",
@@ -2904,7 +2904,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.16.0"
-source = "git+https://github.com/obany/rust-rocksdb?rev=9ab27f60f9e1b1cf40b61e3bb85ca794c0e08beb#9ab27f60f9e1b1cf40b61e3bb85ca794c0e08beb"
+source = "git+https://github.com/iotaledger/rust-rocksdb?rev=70f2a53529ecc1853a2c025cec7f9d00bd50352c#70f2a53529ecc1853a2c025cec7f9d00bd50352c"
 dependencies = [
  "libc",
  "librocksdb-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ thiserror = "1.0"
 tokio = { version = "1.3", features = ["macros", "sync", "time", "rt", "rt-multi-thread"] }
 url = { version = "2.2", features = ["serde"] }
 rand = "0.8"
-rocksdb = { version = "0.15", default-features = false, features = ["lz4"] }
+rocksdb = { git="https://github.com/obany/rust-rocksdb", rev = "9ab27f60f9e1b1cf40b61e3bb85ca794c0e08beb", default-features = false, features = ["lz4"] }
 zeroize = { version = "1.2", features = ["zeroize_derive"] }
 
 # stronghold

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ thiserror = "1.0"
 tokio = { version = "1.3", features = ["macros", "sync", "time", "rt", "rt-multi-thread"] }
 url = { version = "2.2", features = ["serde"] }
 rand = "0.8"
-rocksdb = { git="https://github.com/obany/rust-rocksdb", rev = "9ab27f60f9e1b1cf40b61e3bb85ca794c0e08beb", default-features = false, features = ["lz4"] }
+rocksdb = { git="https://github.com/iotaledger/rust-rocksdb", rev = "70f2a53529ecc1853a2c025cec7f9d00bd50352c", default-features = false, features = ["lz4"] }
 zeroize = { version = "1.2", features = ["zeroize_derive"] }
 
 # stronghold


### PR DESCRIPTION
# Description of change

The rust rocksdb version does not have UTF8 configuration enabled, this PR updated the `rust-rocksdb` and `rocksdb` packages to include UTF8 support.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on windows with Firefly using UTF8 characters in paths.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
