### PR TITLE
fix(sync): initial address index should be the max on internal addresses

### DIFF
--- a/.changes/fix-change-address-syncing.md
+++ b/.changes/fix-change-address-syncing.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": patch
+---
+
+Fixes `account.sync` generating a change address on each call.

--- a/examples/account_operations.rs
+++ b/examples/account_operations.rs
@@ -25,17 +25,17 @@ async fn main() -> iota_wallet::Result<()> {
     // update alias
     account.set_alias("the new alias").await?;
     // get unspent addresses
-    let _ = account.list_unspent_addresses();
+    let _ = account.list_unspent_addresses().await;
     // get spent addresses
-    let _ = account.list_spent_addresses();
+    let _ = account.list_spent_addresses().await;
     // get all addresses
-    let _ = account.addresses();
+    let _ = account.addresses().await;
 
     // generate a new unused address
     let _ = account.generate_address().await?;
 
     // list messages
-    let _ = account.list_messages(5, 0, Some(MessageType::Failed));
+    let _ = account.list_messages(5, 0, Some(MessageType::Failed)).await?;
 
     Ok(())
 }

--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -539,8 +539,21 @@ async fn perform_sync(
             } else {
                 let (found_public_addresses, mut messages) =
                     sync_addresses(&account, false, address_index, gap_limit, options).await?;
-                let (found_change_addresses, synced_messages) =
-                    sync_addresses(&account, true, address_index, gap_limit, options).await?;
+                let (found_change_addresses, synced_messages) = sync_addresses(
+                    &account,
+                    true,
+                    account
+                        .addresses()
+                        .iter()
+                        .filter(|a| *a.internal())
+                        .map(|a| a.key_index())
+                        .max()
+                        .copied()
+                        .unwrap_or_default(),
+                    gap_limit,
+                    options,
+                )
+                .await?;
                 let mut found_addresses = found_public_addresses;
                 found_addresses.extend(found_change_addresses);
                 messages.extend(synced_messages);


### PR DESCRIPTION
# Description of change

If we sync using initial index = `latest public address index`, we end up saving unused change addresses where we don't need to. This PR solves it.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

With the account_operations example.