### PR TITLE
fix(bindings/nodejs): Set rev to allow building from source

### DIFF
--- a/.changes/set-rev.md
+++ b/.changes/set-rev.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": patch
+---
+
+Set git repo and rev to allow JS bindings to be built from source

--- a/.github/workflows/covector-version-or-publish.yml
+++ b/.github/workflows/covector-version-or-publish.yml
@@ -26,6 +26,15 @@ jobs:
         run: |
           git config --global user.name "${{ github.event.pusher.name }}"
           git config --global user.email "${{ github.event.pusher.email }}"
+      
+      - name: Set wallet.rs repository in JS bindings
+        working-directory: bindings/nodejs/native
+        run: |
+          brew install dasel
+          dasel put object -f Cargo.toml '.dependencies.iota-wallet' -t string -t string git="https://github.com/iotaledger/wallet.rs" rev=$GITHUB_SHA
+          dasel put string -f Cargo.toml '.dependencies.iota-wallet.features.[]' stronghold
+          cat Cargo.toml
+
       - name: covector version or publish (publish when no change files present)
         uses: jbolda/covector/packages/action@covector-v0
         id: covector


### PR DESCRIPTION
# Description of change

When using `@iota/wallet` and building the bindings from source, the `path = “../../../“` set for `iota-wallet` causes an error since the rest of the repo is not present in the package. This PR changes the workflow so before publishing, we set `dependencies.iota-wallet` to the following:

```toml
[dependencies.iota-wallet]
    features = ["stronghold"]
    git = "https://github.com/iotaledger/wallet.rs"
    rev = "80f98ece39096a9808bd47c8c433525c3ae7399c"
```

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested locally

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
