### PR TITLE
chore(bindings/nodejs): Fix backup example and types

### DIFF
--- a/bindings/nodejs/examples/5-backup.js
+++ b/bindings/nodejs/examples/5-backup.js
@@ -14,7 +14,7 @@ async function run() {
 
     manager.setStrongholdPassword(process.env.SH_PASSWORD)
 
-    let backup_path = await manager.backup("./backup")
+    let backup_path = await manager.backup("./backup", process.env.SH_PASSWORD)
     
     console.log('Backup path:', backup_path)
 }

--- a/bindings/nodejs/lib/index.d.ts
+++ b/bindings/nodejs/lib/index.d.ts
@@ -289,7 +289,7 @@ export declare class AccountManager {
   removeAccount(accountId: string | number): void
   syncAccounts(options?: SyncOptions): Promise<SyncedAccount[]>
   internalTransfer(fromAccount: Account, toAccount: Account, amount: number): Promise<Message>
-  backup(destination: string): string
+  backup(destination: string, password: string): string
   importAccounts(source: string, password: string): void
   isLatestAddressUnused(): Promise<boolean>
   setClientOptions(options: ClientOptions): void

--- a/bindings/nodejs/native/Cargo.lock
+++ b/bindings/nodejs/native/Cargo.lock
@@ -1824,8 +1824,7 @@ dependencies = [
 [[package]]
 name = "librocksdb-sys"
 version = "6.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5da125e1c0f22c7cae785982115523a0738728498547f415c9054cb17c7e89f9"
+source = "git+https://github.com/iotaledger/rust-rocksdb?rev=70f2a53529ecc1853a2c025cec7f9d00bd50352c#70f2a53529ecc1853a2c025cec7f9d00bd50352c"
 dependencies = [
  "bindgen",
  "cc",
@@ -2778,9 +2777,8 @@ dependencies = [
 
 [[package]]
 name = "rocksdb"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d83c02c429044d58474eaf5ae31e062d0de894e21125b47437ec0edc1397e6"
+version = "0.16.0"
+source = "git+https://github.com/iotaledger/rust-rocksdb?rev=70f2a53529ecc1853a2c025cec7f9d00bd50352c#70f2a53529ecc1853a2c025cec7f9d00bd50352c"
 dependencies = [
  "libc",
  "librocksdb-sys",


### PR DESCRIPTION
# Description of change

The backup example and type declaration did not reflect the `password` argument that was added to the `backup` API

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
- Chore

## How the change has been tested

```
node 1-create-account.js
node 5-backup.js
```

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code