### PR TITLE
fix(ci): Only build python wheels when relevant files change

### DIFF
--- a/.github/workflows/python_binding_publish.yml
+++ b/.github/workflows/python_binding_publish.yml
@@ -5,6 +5,12 @@ on:
     branches:
       - master
       - develop
+    paths:
+      - .github/workflows/python_binding_publish.yml
+      - bindings/python/**
+      - src/**
+      - Cargo.lock
+      - Cargo.toml
 
 jobs:
 


### PR DESCRIPTION
# Description of change

This will prevent builds from being created when unrelated files are changed (docs, Node.js or Java bindings, etc)

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

N/A

## Change checklist


- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
