### PR TITLE
use selected inputs

### DIFF
--- a/bindings/nodejs/examples/8-migration.js
+++ b/bindings/nodejs/examples/8-migration.js
@@ -75,7 +75,7 @@ async function run() {
           logFileName: 'iota-migration.log',
           // if the input is a spent address we do a bundle mining process which takes 10 minutes to reduce the amount 
           // of the parts of the private key which get revealed
-          mine: inputs.inputs[0].spent
+          mine: batch.inputs[0].spent
         })
         migrationBundleHashes.push(bundle.bundleHash)
       } catch (e) {

--- a/bindings/nodejs/examples/8-migration.js
+++ b/bindings/nodejs/examples/8-migration.js
@@ -71,7 +71,7 @@ async function run() {
     // create bundles with the inputs
     for (inputs of input_batches) {
       try {
-        const bundle = await manager.createMigrationBundle(seed, migrationData.inputs.map(input => input.index), {
+        const bundle = await manager.createMigrationBundle(seed, inputs.map(input => input.index), {
           logFileName: 'iota-migration.log',
           // if the input is a spent address we do a bundle mining process which takes 10 minutes to reduce the amount 
           // of the parts of the private key which get revealed

--- a/bindings/nodejs/examples/8-migration.js
+++ b/bindings/nodejs/examples/8-migration.js
@@ -69,9 +69,9 @@ async function run() {
 
     let input_batches = getMigrationBundles(migrationData.inputs)
     // create bundles with the inputs
-    for (inputs of input_batches) {
+    for (batch of input_batches) {
       try {
-        const bundle = await manager.createMigrationBundle(seed, inputs.map(input => input.index), {
+        const bundle = await manager.createMigrationBundle(seed, batch.inputs.map(input => input.index), {
           logFileName: 'iota-migration.log',
           // if the input is a spent address we do a bundle mining process which takes 10 minutes to reduce the amount 
           // of the parts of the private key which get revealed


### PR DESCRIPTION
# Description of change

The selected inputs weren't used, that works fine if it would only create a single bundle, but if getMigrationBundles() returns multiple input_batches we would use all inputs multiple times

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Couldn't test with multiple inputs

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
