### PR TITLE
manager accept same client options as the account

### DIFF
--- a/.changes/setClientOptions.md
+++ b/.changes/setClientOptions.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": patch
+---
+
+Accept client options only with url instead of node object also for the manager.

--- a/bindings/nodejs/native/src/classes/account_manager/mod.rs
+++ b/bindings/nodejs/native/src/classes/account_manager/mod.rs
@@ -464,7 +464,7 @@ declare_types! {
 
         method setClientOptions(mut cx) {
             let client_options = cx.argument::<JsValue>(0)?;
-            let client_options = neon_serde::from_value(&mut cx, client_options)?;
+            let client_options: ClientOptionsDto = neon_serde::from_value(&mut cx, client_options)?;
 
             {
                 let this = cx.this();
@@ -472,7 +472,7 @@ declare_types! {
                 let ref_ = &this.borrow(&guard).0;
                 crate::block_on(async move {
                     let manager = ref_.read().await;
-                    manager.set_client_options(client_options).await
+                    manager.set_client_options(client_options.into()).await
                 }).expect("failed to update client options");
             }
 


### PR DESCRIPTION
# Description of change

The manager accepted only client options like 
```JS
    manager.setClientOptions({
        node: { url: "https://api.lb-0.h.migration5.iotatestmigration.net/" },
        localPow: true,
    })
```
with this PR it also accepts them the same way as the account with just the node url
```JS
    manager.setClientOptions({
        node: "https://api.lb-0.h.migration5.iotatestmigration.net/",
        localPow: true,
    })
```

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Set client options with example

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
