### PR TITLE
Improve syncing

### DIFF
--- a/.changes/syncing.md
+++ b/.changes/syncing.md
@@ -1,0 +1,6 @@
+---
+"nodejs-binding": patch
+---
+
+Send sync requests in chunks to prevent timeouts, make background sync not blocking the whole time.
+Changed polling interval to wait after each sync operations, so it doesn't start immediately if the syncing takes longer than the polling interval.

--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -595,7 +595,6 @@ async fn perform_sync(
                     options,
                 )
                 .await?;
-                drop(account);
                 let mut found_addresses = found_public_addresses;
                 found_addresses.extend(found_change_addresses);
                 messages.extend(synced_messages);

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -45,7 +45,7 @@ use tokio::{
         broadcast::{channel as broadcast_channel, Receiver as BroadcastReceiver, Sender as BroadcastSender},
         Mutex, RwLock,
     },
-    time::interval,
+    time::sleep,
 };
 use zeroize::Zeroize;
 
@@ -744,13 +744,11 @@ impl AccountManager {
                 .build()
                 .unwrap();
             runtime.block_on(async {
-                let mut interval = interval(polling_interval);
                 let mut synced = false;
                 let mut discovered_accounts = false;
                 loop {
                     tokio::select! {
                         _ = async {
-                            interval.tick().await;
 
                             let storage_file_path_ = storage_file_path.clone();
                             let account_options = account_options;
@@ -773,6 +771,8 @@ impl AccountManager {
                                                 }
                                                 synced = response.synced_accounts_len > 0;
                                             }
+                                            // wait polling_interval so it doesn't start syncing immediately again
+                                            sleep(polling_interval).await;
                                         }
                                         Err(error) => {
                                             // if the error isn't a crate::Error type
@@ -787,6 +787,8 @@ impl AccountManager {
                                                 log::error!("[POLLING] error: {}", msg);
                                                 let _error = crate::Error::Panic(msg);
                                                 // when the error is dropped, the on_error event will be triggered
+                                                // wait polling_interval so it doesn't start syncing immediately again
+                                                sleep(polling_interval).await;
                                             }
                                         }
                                     }


### PR DESCRIPTION
# Description of change

Split the requests so not all are executed at the same time, which leads to timeouts when we have thousands of addresses
Send sync requests in chunks to prevent timeouts, make background sync not blocking the whole time.
Changed polling interval to wait after each sync operations, so it doesn't start immediately if the syncing takes longer than the polling interval.



## Links to any relevant issues

Fixes #632 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Synced an account with 10k addresses

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
