### PR TITLE
improve syncing speed and add logger example

### DIFF
--- a/.changes/syncing.md
+++ b/.changes/syncing.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": patch
+---
+
+Improve syncing speed.

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ book
 .vscode
 *.ipynb
 *.stronghold
+wallet.log

--- a/examples/logger.rs
+++ b/examples/logger.rs
@@ -1,0 +1,42 @@
+// Copyright 2020 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! cargo run --example logger --release
+
+use iota_client::common::logger::{logger_init, LoggerConfig, LoggerOutputConfigBuilder};
+use iota_wallet::account_manager::AccountManager;
+use log::LevelFilter;
+use std::time::Instant;
+
+#[tokio::main]
+async fn main() -> iota_wallet::Result<()> {
+    // Generates a wallet.log file with logs for debugging
+    let output_config = LoggerOutputConfigBuilder::new()
+        .name("wallet.log")
+        .level_filter(LevelFilter::Debug);
+    let config = LoggerConfig::build().with_output(output_config).finish();
+    logger_init(config).unwrap();
+
+    let mut manager = AccountManager::builder()
+        .with_storage("./backup", None)?
+        .with_skip_polling()
+        .finish()
+        .await?;
+    manager.set_stronghold_password("password").await?;
+
+    let account = manager.get_account("Alice").await?;
+
+    let now = Instant::now();
+    account.sync().await.execute().await?;
+    println!("Syncing took: {:.2?}", now.elapsed());
+
+    println!("Balance: {:?}", account.balance().await?);
+
+    let addresses = account.list_unspent_addresses().await?;
+    println!("Addresses: {}", addresses.len());
+
+    let address = account.generate_address().await?;
+    println!("Generated a new address: {:?}", address);
+
+    Ok(())
+}

--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -461,8 +461,7 @@ async fn sync_messages(
                         .iter()
                         .map(|(_, o)| o.is_spent)
                         .filter(|is_spent| !is_spent)
-                        .collect::<Vec<bool>>()
-                        .len();
+                        .count();
 
                     log::debug!(
                         "[SYNC] syncing messages and outputs for address {} index: {}, got balance: {}, known unspent outputs: {}",


### PR DESCRIPTION
# Description of change

Get address balance first and only call the outputs endpoint when the address balance is not 0 or we have outputs marked as unspent
Don't return addresses without outputs in the synced account

## Links to any relevant issues

Fixes https://github.com/iotaledger/wallet.rs/issues/635

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
