### PR TITLE
Removed unnecessary exclusive access.

### DIFF
--- a/.changes/removedExclusiveAccess.md
+++ b/.changes/removedExclusiveAccess.md
@@ -1,5 +1,0 @@
----
-"wallet-message-handler": minor
----
-
-Removed exclusive access from `WalletMessageHandler.handle(&self, mut message: Message)`.

--- a/.changes/removedExclusiveAccess.md
+++ b/.changes/removedExclusiveAccess.md
@@ -1,0 +1,5 @@
+---
+"wallet-message-handler": minor
+---
+
+Removed exclusive access from `WalletMessageHandler.handle(&self, mut message: Message)`.

--- a/bindings/nodejs/native/src/classes/account_manager/mod.rs
+++ b/bindings/nodejs/native/src/classes/account_manager/mod.rs
@@ -236,7 +236,7 @@ declare_types! {
                 let guard = cx.lock();
                 let ref_ = &this.borrow(&guard).0;
                 crate::block_on(async move {
-                    let mut manager = ref_.write().await;
+                    let manager = ref_.write().await;
                     manager.set_storage_password(password).await
                 }).expect("error setting storage password");
             }
@@ -250,7 +250,7 @@ declare_types! {
                 let guard = cx.lock();
                 let ref_ = &this.borrow(&guard).0;
                 crate::block_on(async move {
-                    let mut manager = ref_.write().await;
+                    let manager = ref_.write().await;
                     manager.set_stronghold_password(password).await
                 }).expect("error setting stronghold password");
             }
@@ -277,7 +277,7 @@ declare_types! {
                 let this = cx.this();
                 let guard = cx.lock();
                 let ref_ = &this.borrow(&guard).0;
-                let mut manager = crate::block_on(ref_.write());
+                let manager = crate::block_on(ref_.write());
                 manager.generate_mnemonic().expect("failed to generate mnemonic")
             };
             Ok(cx.string(&mnemonic).upcast())
@@ -299,7 +299,7 @@ declare_types! {
                 let guard = cx.lock();
                 let ref_ = &this.borrow(&guard).0;
                 crate::block_on(async move {
-                    let mut manager = ref_.write().await;
+                    let manager = ref_.write().await;
                     manager.store_mnemonic(signer_type, mnemonic).await
                 }).expect("failed to store mnemonic");
             }
@@ -471,7 +471,7 @@ declare_types! {
                 let guard = cx.lock();
                 let ref_ = &this.borrow(&guard).0;
                 crate::block_on(async move {
-                    let mut manager = ref_.write().await;
+                    let manager = ref_.write().await;
                     manager.import_accounts(source, password).await
                 }).expect("error importing accounts");
             };

--- a/docs/libraries/rust/examples.md
+++ b/docs/libraries/rust/examples.md
@@ -10,7 +10,7 @@ cargo run --example transfer # execute the `transfer` example
 
 Create an account manager and set an password:
 ```rust
-let mut manager = AccountManager::builder().finish().await.unwrap();
+let manager = AccountManager::builder().finish().await.unwrap();
 
 manager.set_stronghold_password("password").await.unwrap();
 manager.store_mnemonic(SignerType::Stronghold, None).await.unwrap();

--- a/examples/account_operations.rs
+++ b/examples/account_operations.rs
@@ -7,7 +7,7 @@ use iota_wallet::{
 
 #[tokio::main]
 async fn main() -> iota_wallet::Result<()> {
-    let mut manager = AccountManager::builder().finish().await.unwrap();
+    let manager = AccountManager::builder().finish().await.unwrap();
     manager.set_stronghold_password("password").await.unwrap();
     manager.store_mnemonic(SignerType::Stronghold, None).await.unwrap();
 

--- a/examples/backup_and_restore.rs
+++ b/examples/backup_and_restore.rs
@@ -5,7 +5,7 @@ use iota_wallet::{account_manager::AccountManager, client::ClientOptionsBuilder,
 
 #[tokio::main]
 async fn main() -> iota_wallet::Result<()> {
-    let mut manager = AccountManager::builder().finish().await.unwrap();
+    let manager = AccountManager::builder().finish().await.unwrap();
     manager.set_stronghold_password("password").await.unwrap();
     manager.store_mnemonic(SignerType::Stronghold, None).await.unwrap();
 

--- a/examples/consolidation.rs
+++ b/examples/consolidation.rs
@@ -30,7 +30,7 @@ async fn main() -> Result<()> {
     let _ = fs::remove_dir_all(storage_path);
 
     // setup the account manager
-    let mut manager = AccountManager::builder()
+    let manager = AccountManager::builder()
         .with_storage(storage_path, None)?
         .with_output_consolidation_threshold(OUTPUT_CONSOLIDATION_THRESHOLD)
         .with_automatic_output_consolidation_disabled()

--- a/examples/event.rs
+++ b/examples/event.rs
@@ -12,7 +12,7 @@ use std::str::FromStr;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let mut manager = AccountManager::builder().finish().await?;
+    let manager = AccountManager::builder().finish().await?;
     manager.set_stronghold_password("password").await?;
     manager.store_mnemonic(SignerType::Stronghold, None).await?;
 

--- a/examples/event.rs
+++ b/examples/event.rs
@@ -1,0 +1,75 @@
+// Copyright 2020 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! cargo run --example event --release
+
+use iota_wallet::{
+    account_manager::AccountManager, address::Address, client::ClientOptionsBuilder, event::on_balance_change,
+    message::MessageId, signing::SignerType, Result,
+};
+use serde::Deserialize;
+use std::str::FromStr;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let mut manager = AccountManager::builder().finish().await?;
+    manager.set_stronghold_password("password").await?;
+    manager.store_mnemonic(SignerType::Stronghold, None).await?;
+
+    // first we'll create an example account and store it
+    let client_options = ClientOptionsBuilder::new()
+        .with_node("https://api.lb-0.testnet.chrysalis2.com")?
+        .build()?;
+
+    let account = manager
+        .create_account(client_options)?
+        .alias("alias")
+        .initialise()
+        .await?;
+
+    // Possible events are: on_balance_change, on_broadcast, on_confirmation_state_change, on_error,
+    // on_migration_progress, on_new_transaction, on_reattachment, on_stronghold_status_change,
+    // on_transfer_progress,
+    on_balance_change(move |event| {
+        println!("BalanceEvent: {:?}", event);
+        println!("Press enter to exit");
+    })
+    .await;
+
+    let address = account.generate_address().await?;
+    println!("Requesting funds from the faucet to {}", address.address().to_bech32());
+    get_funds(&address).await?;
+
+    // Wait for event before exit
+    let mut exit = String::new();
+    std::io::stdin().read_line(&mut exit).unwrap();
+    Ok(())
+}
+
+#[derive(Deserialize)]
+struct FaucetMessageResponse {
+    id: String,
+}
+
+#[derive(Deserialize)]
+struct FaucetResponse {
+    data: FaucetMessageResponse,
+}
+
+async fn get_funds(address: &Address) -> Result<MessageId> {
+    // use the faucet to get funds on the address
+    let response = reqwest::get(&format!(
+        "https://faucet.testnet.chrysalis2.com/api?address={}",
+        address.address().to_bech32()
+    ))
+    .await
+    .unwrap()
+    .json::<FaucetResponse>()
+    .await
+    .unwrap();
+    let faucet_message_id = MessageId::from_str(&response.data.id)?;
+
+    println!("Got funds from faucet, message id: {:?}", faucet_message_id);
+
+    Ok(faucet_message_id)
+}

--- a/examples/event.rs
+++ b/examples/event.rs
@@ -13,7 +13,6 @@ use std::str::FromStr;
 #[tokio::main]
 async fn main() -> Result<()> {
     let manager = AccountManager::builder().finish().await?;
-
     manager.set_stronghold_password("password").await?;
     manager.store_mnemonic(SignerType::Stronghold, None).await?;
 
@@ -74,4 +73,3 @@ async fn get_funds(address: &Address) -> Result<MessageId> {
 
     Ok(faucet_message_id)
 }
-

--- a/examples/logger.rs
+++ b/examples/logger.rs
@@ -17,7 +17,7 @@ async fn main() -> iota_wallet::Result<()> {
     let config = LoggerConfig::build().with_output(output_config).finish();
     logger_init(config).unwrap();
 
-    let mut manager = AccountManager::builder()
+    let manager = AccountManager::builder()
         .with_storage("./backup", None)?
         .with_skip_polling()
         .finish()

--- a/examples/migration.rs
+++ b/examples/migration.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 
 #[tokio::main]
 async fn main() -> iota_wallet::Result<()> {
-    let mut manager = AccountManager::builder().finish().await.unwrap();
+    let manager = AccountManager::builder().finish().await.unwrap();
     manager.set_stronghold_password("password").await.unwrap();
     manager.store_mnemonic(SignerType::Stronghold, None).await.unwrap();
 

--- a/examples/transfer.rs
+++ b/examples/transfer.rs
@@ -8,7 +8,7 @@ use std::num::NonZeroU64;
 
 #[tokio::main]
 async fn main() -> iota_wallet::Result<()> {
-    let mut manager = AccountManager::builder().finish().await.unwrap();
+    let manager = AccountManager::builder().finish().await.unwrap();
     manager.set_stronghold_password("password").await.unwrap();
     manager.store_mnemonic(SignerType::Stronghold, None).await.unwrap();
 

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -826,7 +826,7 @@ impl AccountManager {
         if let Some(mut mnemonic) = self
             .generated_mnemonic
             .lock()
-            .expect("generated_mnemonic mutex lock failed.")
+            .map_err(|_| crate::Error::PoisonError)?
             .take()
         {
             mnemonic.zeroize();
@@ -843,7 +843,7 @@ impl AccountManager {
             .map_err(|e| crate::Error::MnemonicEncode(format!("{:?}", e)))?;
         self.generated_mnemonic
             .lock()
-            .expect("generated_mnemonic mutex lock failed.")
+            .map_err(|_| crate::Error::PoisonError)?
             .replace(mnemonic.clone());
         Ok(mnemonic)
     }
@@ -860,7 +860,7 @@ impl AccountManager {
         if let Some(generated_mnemonic) = self
             .generated_mnemonic
             .lock()
-            .expect("generated_mnemonic mutex lock failed.")
+            .map_err(|_| crate::Error::PoisonError)?
             .as_ref()
         {
             if generated_mnemonic != mnemonic.as_ref() {

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -27,7 +27,10 @@ use std::{
     ops::{Deref, Range},
     panic::AssertUnwindSafe,
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex as StdMutex,
+    },
     thread,
     time::Duration,
 };
@@ -255,12 +258,12 @@ impl AccountManagerBuilder {
         };
         let mut instance = AccountManager {
             storage_folder: self.storage_folder,
-            loaded_accounts,
+            loaded_accounts: AtomicBool::new(loaded_accounts),
             storage_path: storage_file_path,
             accounts,
             stop_polling_sender: None,
             polling_handle: None,
-            generated_mnemonic: None,
+            generated_mnemonic: StdMutex::new(None),
             account_options: self.account_options,
             sync_accounts_lock,
             cached_migration_data: Default::default(),
@@ -330,7 +333,7 @@ type CachedMigrationBundle = (Vec<BundledTransaction>, AddressWrapper, u64);
 #[derive(Getters)]
 pub struct AccountManager {
     storage_folder: PathBuf,
-    loaded_accounts: bool,
+    loaded_accounts: AtomicBool,
     /// the path to the storage.
     #[getset(get = "pub")]
     storage_path: PathBuf,
@@ -339,7 +342,7 @@ pub struct AccountManager {
     accounts: AccountStore,
     stop_polling_sender: Option<BroadcastSender<()>>,
     polling_handle: Option<thread::JoinHandle<()>>,
-    generated_mnemonic: Option<String>,
+    generated_mnemonic: StdMutex<Option<String>>,
     account_options: AccountOptions,
     sync_accounts_lock: Arc<Mutex<()>>,
     cached_migration_data: Mutex<HashMap<u64, CachedMigrationData>>,
@@ -354,12 +357,12 @@ impl Clone for AccountManager {
     fn clone(&self) -> Self {
         Self {
             storage_folder: self.storage_folder.clone(),
-            loaded_accounts: self.loaded_accounts,
+            loaded_accounts: AtomicBool::new(self.loaded_accounts.load(Ordering::SeqCst)),
             storage_path: self.storage_path.clone(),
             accounts: self.accounts.clone(),
             stop_polling_sender: self.stop_polling_sender.clone(),
             polling_handle: None,
-            generated_mnemonic: None,
+            generated_mnemonic: StdMutex::new(None),
             account_options: self.account_options,
             sync_accounts_lock: self.sync_accounts_lock.clone(),
             cached_migration_data: Default::default(),
@@ -590,7 +593,7 @@ impl AccountManager {
 
     // error out if the storage is encrypted
     fn check_storage_encryption(&self) -> crate::Result<()> {
-        if self.loaded_accounts {
+        if self.loaded_accounts.load(Ordering::SeqCst) {
             Ok(())
         } else {
             Err(crate::Error::StorageIsEncrypted)
@@ -635,7 +638,7 @@ impl AccountManager {
     }
 
     /// Sets the password for the stored accounts.
-    pub async fn set_storage_password<P: AsRef<str>>(&mut self, password: P) -> crate::Result<()> {
+    pub async fn set_storage_password<P: AsRef<str>>(&self, password: P) -> crate::Result<()> {
         let key = storage_password_to_encryption_key(password.as_ref());
         // safe to unwrap because the storage is always defined at this point
         crate::storage::set_encryption_key(&self.storage_path, key)
@@ -650,7 +653,7 @@ impl AccountManager {
                 self.sync_accounts_lock.clone(),
             )
             .await?;
-            self.loaded_accounts = true;
+            self.loaded_accounts.store(true, Ordering::SeqCst);
             crate::spawn(Self::start_monitoring(self.accounts.clone()));
         } else {
             // save the accounts and messages again to reencrypt with the new key
@@ -666,7 +669,7 @@ impl AccountManager {
     }
 
     /// Sets the stronghold password.
-    pub async fn set_stronghold_password<P: Into<String>>(&mut self, password: P) -> crate::Result<()> {
+    pub async fn set_stronghold_password<P: Into<String>>(&self, password: P) -> crate::Result<()> {
         let stronghold_path = if crate::storage::get(&self.storage_path).await.unwrap().lock().await.id()
             == crate::storage::stronghold::STORAGE_ID
         {
@@ -684,7 +687,7 @@ impl AccountManager {
                 self.sync_accounts_lock.clone(),
             )
             .await?;
-            self.loaded_accounts = true;
+            self.loaded_accounts.store(true, Ordering::SeqCst);
             crate::spawn(Self::start_monitoring(self.accounts.clone()));
         }
 
@@ -807,7 +810,7 @@ impl AccountManager {
 
     /// Stores a mnemonic for the given signer type.
     /// If the mnemonic is not provided, we'll generate one.
-    pub async fn store_mnemonic(&mut self, signer_type: SignerType, mnemonic: Option<String>) -> crate::Result<()> {
+    pub async fn store_mnemonic(&self, signer_type: SignerType, mnemonic: Option<String>) -> crate::Result<()> {
         let mnemonic = match mnemonic {
             Some(m) => {
                 self.verify_mnemonic(&m)?;
@@ -820,7 +823,12 @@ impl AccountManager {
         let mut signer = signer.lock().await;
         signer.store_mnemonic(&self.storage_path, mnemonic).await?;
 
-        if let Some(mut mnemonic) = self.generated_mnemonic.take() {
+        if let Some(mut mnemonic) = self
+            .generated_mnemonic
+            .lock()
+            .expect("generated_mnemonic mutex lock failed.")
+            .take()
+        {
             mnemonic.zeroize();
         }
 
@@ -828,25 +836,33 @@ impl AccountManager {
     }
 
     /// Generates a new mnemonic.
-    pub fn generate_mnemonic(&mut self) -> crate::Result<String> {
+    pub fn generate_mnemonic(&self) -> crate::Result<String> {
         let mut entropy = [0u8; 32];
         crypto::utils::rand::fill(&mut entropy).map_err(|e| crate::Error::MnemonicEncode(format!("{:?}", e)))?;
         let mnemonic = crypto::keys::bip39::wordlist::encode(&entropy, &crypto::keys::bip39::wordlist::ENGLISH)
             .map_err(|e| crate::Error::MnemonicEncode(format!("{:?}", e)))?;
-        self.generated_mnemonic.replace(mnemonic.clone());
+        self.generated_mnemonic
+            .lock()
+            .expect("generated_mnemonic mutex lock failed.")
+            .replace(mnemonic.clone());
         Ok(mnemonic)
     }
 
     /// Checks is the mnemonic is valid. If a mnemonic was generated with `generate_mnemonic()`, the mnemonic here
     /// should match the generated.
-    pub fn verify_mnemonic<S: AsRef<str>>(&mut self, mnemonic: S) -> crate::Result<()> {
+    pub fn verify_mnemonic<S: AsRef<str>>(&self, mnemonic: S) -> crate::Result<()> {
         // first we check if the mnemonic is valid to give meaningful errors
         crypto::keys::bip39::wordlist::verify(mnemonic.as_ref(), &crypto::keys::bip39::wordlist::ENGLISH)
             // TODO: crypto::bip39::wordlist::Error should impl Display
             .map_err(|e| crate::Error::InvalidMnemonic(format!("{:?}", e)))?;
 
         // then we check if the provided mnemonic matches the mnemonic generated with `generate_mnemonic`
-        if let Some(generated_mnemonic) = &self.generated_mnemonic {
+        if let Some(generated_mnemonic) = self
+            .generated_mnemonic
+            .lock()
+            .expect("generated_mnemonic mutex lock failed.")
+            .as_ref()
+        {
             if generated_mnemonic != mnemonic.as_ref() {
                 return Err(crate::Error::InvalidMnemonic(
                     "doesn't match the generated mnemonic".to_string(),
@@ -999,11 +1015,7 @@ impl AccountManager {
     }
 
     /// Import backed up accounts.
-    pub async fn import_accounts<S: AsRef<Path>>(
-        &mut self,
-        source: S,
-        stronghold_password: String,
-    ) -> crate::Result<()> {
+    pub async fn import_accounts<S: AsRef<Path>>(&self, source: S, stronghold_password: String) -> crate::Result<()> {
         let source = source.as_ref();
         if source.is_dir() || !source.exists() {
             return Err(crate::Error::InvalidBackupFile);
@@ -1016,7 +1028,7 @@ impl AccountManager {
 
         fs::create_dir_all(&self.storage_folder)?;
 
-        let mut stronghold_manager = Self::builder()
+        let stronghold_manager = Self::builder()
             .with_storage(source.parent().unwrap(), None)
             .unwrap() // safe to unwrap - password is None
             .with_storage_file_name(
@@ -2107,7 +2119,7 @@ mod tests {
 
     #[tokio::test]
     async fn backup_and_restore_storage_already_exists() {
-        crate::test_utils::with_account_manager(crate::test_utils::TestType::Storage, |mut manager, _| async move {
+        crate::test_utils::with_account_manager(crate::test_utils::TestType::Storage, |manager, _| async move {
             let backup_path = PathBuf::from("./backup/account-exists");
             let _ = std::fs::remove_dir_all(&backup_path);
             std::fs::create_dir_all(&backup_path).unwrap();
@@ -2138,7 +2150,7 @@ mod tests {
 
     #[tokio::test]
     async fn storage_password_reencrypt() {
-        crate::test_utils::with_account_manager(crate::test_utils::TestType::Storage, |mut manager, _| async move {
+        crate::test_utils::with_account_manager(crate::test_utils::TestType::Storage, |manager, _| async move {
             crate::test_utils::AccountCreator::new(&manager).create().await;
             manager.set_storage_password("new-password").await.unwrap();
             let account_store = super::AccountStore::new(Default::default());

--- a/src/actor/mod.rs
+++ b/src/actor/mod.rs
@@ -72,7 +72,7 @@ impl WalletMessageHandler {
     }
 
     /// Handles a message.
-    pub async fn handle(&mut self, mut message: Message) {
+    pub async fn handle(&self, mut message: Message) {
         let response: Result<ResponseType> = match message.message_type_mut() {
             MessageType::RemoveAccount(account_id) => {
                 convert_async_panics(|| async { self.remove_account(account_id).await }).await
@@ -305,7 +305,7 @@ impl WalletMessageHandler {
         Ok(ResponseType::BackupSuccessful)
     }
 
-    async fn restore_backup(&mut self, backup_path: &str, password: String) -> Result<ResponseType> {
+    async fn restore_backup(&self, backup_path: &str, password: String) -> Result<ResponseType> {
         self.account_manager.import_accounts(backup_path, password).await?;
         Ok(ResponseType::BackupRestored)
     }
@@ -483,13 +483,13 @@ impl WalletMessageHandler {
         Ok(ResponseType::ReadAccounts(accounts_))
     }
 
-    async fn set_storage_password(&mut self, password: &str) -> Result<ResponseType> {
+    async fn set_storage_password(&self, password: &str) -> Result<ResponseType> {
         self.account_manager.set_storage_password(password).await?;
         Ok(ResponseType::StoragePasswordSet)
     }
 
     #[cfg(feature = "stronghold")]
-    async fn set_stronghold_password(&mut self, password: &str) -> Result<ResponseType> {
+    async fn set_stronghold_password(&self, password: &str) -> Result<ResponseType> {
         self.account_manager.set_stronghold_password(password).await?;
         Ok(ResponseType::StrongholdPasswordSet)
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -216,6 +216,9 @@ pub enum Error {
     /// Spent addresses must be the only input in a bundle.
     #[error("can't create migration bundle: the bundle has more than one input and one of them are spent")]
     SpentAddressOnBundle,
+    /// Mutex lock failed.
+    #[error("Mutex lock failed")]
+    PoisonError,
 }
 
 impl Drop for Error {
@@ -354,6 +357,7 @@ impl serde::Serialize for Error {
             Self::InputNotFound => serialize_variant(self, serializer, "InputNotFound"),
             Self::EmptyInputList => serialize_variant(self, serializer, "EmptyInputList"),
             Self::SpentAddressOnBundle => serialize_variant(self, serializer, "SpentAddressOnBundle"),
+            Self::PoisonError => serialize_variant(self, serializer, "PoisonError"),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,7 +213,7 @@ mod test_utils {
             }
         };
 
-        let mut manager = AccountManager::builder()
+        let manager = AccountManager::builder()
             .with_storage(storage_path, None)
             .unwrap()
             .with_skip_polling()
@@ -309,7 +309,7 @@ mod test_utils {
                 }
             };
 
-            let mut manager = manager_builder.with_skip_polling().finish().await.unwrap();
+            let manager = manager_builder.with_skip_polling().finish().await.unwrap();
 
             #[cfg(feature = "stronghold")]
             manager.set_stronghold_password("password").await.unwrap();


### PR DESCRIPTION
# Description of change

Removed the exclusive access from `WalletMessageHandler.handle` function and added AtomicBool and Mutex to the unguarded `AccountManager` fields. This way we can call it simultaneously from different `tokio` tasks. This was needed so that Firefly can send multiple simultaneous messages.

## Links to any relevant issues

Fixes issue #556.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
