### PR TITLE
Fix ledger features usage so it works with a single feature

### DIFF
--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -2030,7 +2030,7 @@ mod tests {
                     .finish(),
             )
             .await;
-        assert_eq!(res.is_err(), true);
+        assert!(res.is_err());
         match res.unwrap_err() {
             crate::Error::DustError(_) => {}
             _ => panic!("unexpected response"),

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -1714,7 +1714,16 @@ async fn consolidate_outputs_if_needed(
         {
             let account = synced.account_handle.read().await;
             let signer_type = account.signer_type();
-            if signer_type == &SignerType::LedgerNano || signer_type == &SignerType::LedgerNanoSimulator {
+            let mut ledger_or_simulator = false;
+            #[cfg(feature = "ledger-nano")]
+            if signer_type == &SignerType::LedgerNano {
+                ledger_or_simulator = true;
+            }
+            #[cfg(feature = "ledger-nano-simulator")]
+            if signer_type == &SignerType::LedgerNanoSimulator {
+                ledger_or_simulator = true;
+            }
+            if ledger_or_simulator {
                 let addresses = synced.account_handle.output_consolidation_addresses().await?;
                 for address in addresses {
                     crate::event::emit_address_consolidation_needed(&account, address).await;

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -1862,7 +1862,7 @@ mod tests {
             .alias(alias)
             .initialise()
             .await;
-        assert_eq!(second_create_response.is_err(), true);
+        assert!(second_create_response.is_err());
         match second_create_response.unwrap_err() {
             crate::Error::AccountAliasAlreadyExists => {}
             _ => panic!("unexpected create account response; expected AccountAliasAlreadyExists"),

--- a/src/address.rs
+++ b/src/address.rs
@@ -478,7 +478,7 @@ mod tests {
                 .unwrap(),
             address.address(),
         );
-        assert_eq!(response, false);
+        assert!(!response);
     }
 
     #[tokio::test]
@@ -494,6 +494,6 @@ mod tests {
                 .unwrap(),
             &address,
         );
-        assert_eq!(response, true);
+        assert!(response);
     }
 }

--- a/src/stronghold.rs
+++ b/src/stronghold.rs
@@ -696,7 +696,7 @@ mod tests {
 
                 std::thread::sleep(Duration::from_millis(interval * 3));
                 let res = super::get_record(&snapshot_path, "passwordexpires").await;
-                assert_eq!(res.is_err(), true);
+                assert!(res.is_err());
                 let error = res.unwrap_err();
                 if let super::Error::PasswordNotSet = error {
                     let status = super::get_status(&snapshot_path).await;
@@ -748,12 +748,12 @@ mod tests {
 
                 let id = "actionkeepspassword1".to_string();
                 let res = super::get_record(&snapshot_path, &id).await;
-                assert_eq!(res.is_ok(), true);
+                assert!(res.is_ok());
 
                 std::thread::sleep(interval * 2);
 
                 let res = super::get_record(&snapshot_path, &id).await;
-                assert_eq!(res.is_err(), true);
+                assert!(res.is_err());
                 if let super::Error::PasswordNotSet = res.unwrap_err() {
                     let status = super::get_status(&snapshot_path).await;
                     if let super::SnapshotStatus::Unlocked(_) = status.snapshot {


### PR DESCRIPTION
# Description of change

We can't check `SignerType::LedgerNano || signer_type == &SignerType::LedgerNanoSimulator` in a single line because each variant is only enabled when the feature for it is enabled, so without this change one always needs to enable both ledger features at the same time, otherwise it won't compile

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Compiled with a single feature

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
