### PR TITLE
Ledger/display address and add event with PreparedTransactionData 

### DIFF
--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -665,7 +665,36 @@ impl AccountHandle {
             .execute()
             .await?;
         // safe to clone since the `sync` guarantees a latest unused address
-        Ok(self.latest_address().await)
+        let address = self.latest_address().await;
+        // regenerate address for ledger accounts
+        #[cfg(any(feature = "ledger-nano", feature = "ledger-nano-simulator"))]
+        {
+            let account = self.read().await;
+            let ledger = match account.signer_type() {
+                #[cfg(feature = "ledger-nano")]
+                SignerType::LedgerNano => true,
+                #[cfg(feature = "ledger-nano-simulator")]
+                SignerType::LedgerNanoSimulator => true,
+                _ => false,
+            };
+            if ledger {
+                log::debug!("get_unused_address regenerate address so it's displayed on the ledger");
+                let regenrated_address = crate::address::get_address_with_index(
+                    &account,
+                    *address.key_index(),
+                    account.bech32_hrp(),
+                    GenerateAddressMetadata {
+                        syncing: false,
+                        network: account.network(),
+                    },
+                )
+                .await?;
+                if address.address().inner != regenrated_address.address().inner {
+                    return Err(crate::Error::WrongLedgerSeedError);
+                }
+            }
+        }
+        Ok(address)
     }
 
     /// Syncs the latest address with the Tangle and determines whether it's unused or not.

--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -280,10 +280,15 @@ async fn sync_address_list(
             });
         }
         let results = futures::future::try_join_all(tasks).await?;
+        let mut inserted_remainder_address = false;
         for res in results {
             let (messages, address) = res?;
             if !address.outputs().is_empty() || return_all_addresses {
                 found_addresses.push(address);
+            } else if !inserted_remainder_address {
+                // We want to insert one unused address to have an unused remainder address
+                found_addresses.push(address);
+                inserted_remainder_address = true;
             }
             found_messages.extend(messages);
         }

--- a/src/event.rs
+++ b/src/event.rs
@@ -137,6 +137,18 @@ pub struct TransactionReattachmentEvent {
     pub reattached_message_id: MessageId,
 }
 
+/// Transaction reattachment event data.
+#[derive(Clone, Debug, Getters, Serialize, Deserialize)]
+#[getset(get = "pub")]
+pub struct PreparedTransactionData {
+    /// Transaction inputs. (address, amount)
+    pub inputs: Vec<(String, u64)>,
+    /// Transaction outputs. (address, amount, remainder)
+    pub outputs: Vec<(String, u64, bool)>,
+    /// The indexation data.
+    pub data: Option<String>,
+}
+
 /// Transfer event type.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(tag = "type")]
@@ -147,6 +159,8 @@ pub enum TransferProgressType {
     SelectingInputs,
     /// Generating remainder value deposit address.
     GeneratingRemainderDepositAddress,
+    /// Prepared transaction.
+    PreparedTransaction(PreparedTransactionData),
     /// Signing the transaction.
     SigningTransaction,
     /// Performing PoW.


### PR DESCRIPTION
# Description of change

Display new receive and remainder address with ledger accounts so the user can verify them
Also added PreparedTransactionData event

## Links to any relevant issues

https://github.com/iotaledger/firefly/issues/1238

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Generated new addresses and saw the prompt on the ledger

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
