### PR TITLE
add LedgerAddressGeneration event

### DIFF
--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -680,7 +680,7 @@ impl AccountHandle {
                 _ => false,
             };
             if ledger {
-                // Send address event so it can already be displayed and compared with the displayed one
+                // Send address event so it can be displayed before and then compared with the prompt on the ledger
                 emit_ledger_address_generation(&account, address.address().to_bech32()).await;
 
                 log::debug!("get_unused_address regenerate address so it's displayed on the ledger");

--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -1,6 +1,8 @@
 // Copyright 2020 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(any(feature = "ledger-nano", feature = "ledger-nano-simulator"))]
+use crate::event::{emit_ledger_address_generation, LedgerAddressGeneration};
 use crate::{
     account_manager::{AccountOptions, AccountStore},
     address::{Address, AddressBuilder, AddressOutput, AddressWrapper},
@@ -678,6 +680,9 @@ impl AccountHandle {
                 _ => false,
             };
             if ledger {
+                // Send address event so it can already be displayed and compared with the displayed one
+                emit_ledger_address_generation(&account, address.address().to_bech32()).await;
+
                 log::debug!("get_unused_address regenerate address so it's displayed on the ledger");
                 let regenrated_address = crate::address::get_address_with_index(
                     &account,

--- a/src/event.rs
+++ b/src/event.rs
@@ -90,6 +90,18 @@ pub struct AddressConsolidationNeeded {
     pub address: AddressWrapper,
 }
 
+#[cfg(any(feature = "ledger-nano", feature = "ledger-nano-simulator"))]
+/// Ledger generate address event data.
+#[derive(Clone, Debug, Getters, Serialize, Deserialize)]
+#[getset(get = "pub")]
+pub struct LedgerAddressGeneration {
+    #[serde(rename = "accountId")]
+    /// The associated account identifier.
+    pub account_id: String,
+    /// The transfer event type.
+    pub event: AddressData,
+}
+
 /// A transaction-related event data.
 #[derive(Clone, Debug, Getters, Serialize, Deserialize)]
 #[getset(get = "pub")]
@@ -137,11 +149,11 @@ pub struct TransactionReattachmentEvent {
     pub reattached_message_id: MessageId,
 }
 
-/// Remainder address event data.
+/// Address event data.
 #[derive(Clone, Debug, Getters, Serialize, Deserialize)]
 #[getset(get = "pub")]
 pub struct AddressData {
-    /// The remainder address.
+    /// The address.
     pub address: String,
 }
 
@@ -326,6 +338,16 @@ struct AddressConsolidationNeededHandler {
 #[cfg(any(feature = "ledger-nano", feature = "ledger-nano-simulator"))]
 event_handler_impl!(AddressConsolidationNeededHandler);
 
+#[cfg(any(feature = "ledger-nano", feature = "ledger-nano-simulator"))]
+struct LedgerAddressGenerationHandler {
+    id: EventId,
+    /// The on event callback.
+    on_event: Box<dyn Fn(&LedgerAddressGeneration) + Send>,
+}
+
+#[cfg(any(feature = "ledger-nano", feature = "ledger-nano-simulator"))]
+event_handler_impl!(LedgerAddressGenerationHandler);
+
 struct TransferProgressHandler {
     id: EventId,
     /// The on event callback.
@@ -351,6 +373,8 @@ type ErrorListeners = Arc<StdMutex<Vec<ErrorHandler>>>;
 type StrongholdStatusChangeListeners = Arc<Mutex<Vec<StrongholdStatusChangeEventHandler>>>;
 #[cfg(any(feature = "ledger-nano", feature = "ledger-nano-simulator"))]
 type AddressConsolidationNeededListeners = Arc<Mutex<Vec<AddressConsolidationNeededHandler>>>;
+#[cfg(any(feature = "ledger-nano", feature = "ledger-nano-simulator"))]
+type LedgerAddressGenerationListeners = Arc<Mutex<Vec<LedgerAddressGenerationHandler>>>;
 type TransferProgressListeners = Arc<Mutex<Vec<TransferProgressHandler>>>;
 type MigrationProgressListeners = Arc<Mutex<Vec<MigrationProgressHandler>>>;
 
@@ -408,6 +432,13 @@ fn stronghold_status_change_listeners() -> &'static StrongholdStatusChangeListen
 #[cfg(any(feature = "ledger-nano", feature = "ledger-nano-simulator"))]
 fn address_consolidation_needed_listeners() -> &'static AddressConsolidationNeededListeners {
     static LISTENERS: Lazy<AddressConsolidationNeededListeners> = Lazy::new(Default::default);
+    &LISTENERS
+}
+
+/// Gets address that will be generated with a prompt on the ledger.
+#[cfg(any(feature = "ledger-nano", feature = "ledger-nano-simulator"))]
+fn ledger_address_generation_listeners() -> &'static LedgerAddressGenerationListeners {
+    static LISTENERS: Lazy<LedgerAddressGenerationListeners> = Lazy::new(Default::default);
     &LISTENERS
 }
 
@@ -730,6 +761,40 @@ pub(crate) async fn emit_address_consolidation_needed(account: &Account, address
     let event = AddressConsolidationNeeded {
         account_id: account.id().to_string(),
         address,
+    };
+
+    for listener in listeners.deref() {
+        (listener.on_event)(&event);
+    }
+}
+
+/// Listen to `ledger address generation` events.
+#[cfg(any(feature = "ledger-nano", feature = "ledger-nano-simulator"))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "ledger-nano", feature = "ledger-nano-simulator"))))]
+pub async fn on_ledger_address_generation<F: Fn(&LedgerAddressGeneration) + Send + 'static>(cb: F) -> EventId {
+    let mut l = ledger_address_generation_listeners().lock().await;
+    let id = generate_event_id();
+    l.push(LedgerAddressGenerationHandler {
+        id,
+        on_event: Box::new(cb),
+    });
+    id
+}
+
+/// Removes the balance change listener associated with the given identifier.
+#[cfg(any(feature = "ledger-nano", feature = "ledger-nano-simulator"))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "ledger-nano", feature = "ledger-nano-simulator"))))]
+pub async fn remove_ledger_address_generation_listener(id: &EventId) {
+    remove_event_listener(id, ledger_address_generation_listeners()).await;
+}
+
+/// Emits a balance change event.
+#[cfg(any(feature = "ledger-nano", feature = "ledger-nano-simulator"))]
+pub(crate) async fn emit_ledger_address_generation(account: &Account, address: String) {
+    let listeners = ledger_address_generation_listeners().lock().await;
+    let event = LedgerAddressGeneration {
+        account_id: account.id().to_string(),
+        event: AddressData { address },
     };
 
     for listener in listeners.deref() {


### PR DESCRIPTION
# Description of change

Add an address generation event for ledger accounts so the address can be displayed in Firefly before the user accepts it on the ledger

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Generated an unused address and compared the address in the event with the one from the ledger

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
