### PR TITLE
DOCS - use absolute image paths

### DIFF
--- a/documentation/docs/libraries/nodejs/examples.md
+++ b/documentation/docs/libraries/nodejs/examples.md
@@ -104,7 +104,7 @@ You can use the following example to generate a new address:
 ## Checking Balance
 Before we continue further, please visit the [IOTA testnet faucet service](https://faucet.testnet.chrysalis2.com/) and send to your testnet addresses some tokens.
 
-![IOTA Faucet Service](../../../static/img/libraries/screenshot_faucet.png)
+![IOTA Faucet Service](/img/libraries/screenshot_faucet.png)
 
 You can use the following example to generate a new database and account:
 

--- a/documentation/docs/libraries/overview.md
+++ b/documentation/docs/libraries/overview.md
@@ -25,4 +25,4 @@ The library is based on a [derivation for multiple accounts from a single seed](
 
 The following image illustrates the relationships between seed, accounts and addresses.  A single seed can contain multiple accounts.  Each account can also have multiple addresses which can be linked to users in your database. 
 
-![Seed, accounts and Addresses](../../static/img/libraries/accounts_addresses.svg)
+![Seed, accounts and Addresses](/img/libraries/accounts_addresses.svg)

--- a/documentation/docs/libraries/python/examples.md
+++ b/documentation/docs/libraries/python/examples.md
@@ -137,7 +137,7 @@ You can find detailed information about generating addresses at the [Developer G
 
 Before we continue further, please visit the [IOTA testnet faucet service](https://faucet.testnet.chrysalis2.com/) and send some tokens to your testnet addresses.
 
-![IOTA Faucet Service](../../../static/img/libraries/screenshot_faucet.png)
+![IOTA Faucet Service](/img/libraries/screenshot_faucet.png)
 
 You can use the following example to sync your accounts and retrieve their balances.
 

--- a/documentation/docs/overview.md
+++ b/documentation/docs/overview.md
@@ -5,4 +5,4 @@ The wallet library is a stateful package with a standardized interface for devel
 See the full specification [here](https://github.com/iotaledger/wallet.rs/blob/dev/specs/wallet-ENGINEERING-SPEC-0000.md).
 
 ## High Level Layered Overview
-![High Level Layered Overview](../static/img/overview/iota_layers_overview.svg)
+![High Level Layered Overview](/img/overview/iota_layers_overview.svg)

--- a/documentation/docs/specification.md
+++ b/documentation/docs/specification.md
@@ -276,7 +276,7 @@ What follows is an Entity Relationship Diagram (ERD)  that shows the logical rep
 
 A _storage adapter_ is required by the Rust layer to handle all the storage operations (read/write) from that layer. A generic storage adapter is defined in the [storage adapter section](#storage-adapter).  
 
-![Storage - Entity Relationship Diagram](../static/img/specs/erdIOTA.svg)
+![Storage - Entity Relationship Diagram](/img/specs/erdIOTA.svg)
 
 ## Storage Adapter
 
@@ -529,7 +529,7 @@ If you want to sync an account, you can use the following process:
 | ---------------- | ---------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | index            | ✘          | number  | Address index. By default the number of addresses stored for this account should be used as an index.                                                                                                                                                                                                       |
 | gap_limit        | ✘          | number  | Number of address indexes that are generated.                                                                                                                                                                                                                                                               |
-| skip_persistence | ✘          | boolean | Skips write to the database. This will be useful if a user wants to scan the Tangle for further addresses to find balance. You can find more details in the [snapshot transition feature](https://docs.iota.org/docs/wallets/0.1/trinity/how-to-guides/perform-a-snapshot-transition") provided by Trinity. |
+| skip_persistence | ✘          | boolean | Skips write to the database. This will be useful if a user wants to scan the Tangle for further addresses to find balance. You can find more details in the [snapshot transition feature](https://legacy.docs.iota.org/docs/wallets/0.1/trinity/how-to-guides/perform-a-snapshot-transition) provided by Trinity. |
 
 
 ##### Returns

--- a/documentation/docusaurus.config.js
+++ b/documentation/docusaurus.config.js
@@ -47,7 +47,7 @@ module.exports = {
           items: [
             {
               label: 'Welcome',
-              to: '/docs/',
+              to: '/docs/welcome',
             },
             {
               label: 'Overview',


### PR DESCRIPTION
# Description of change

* Updated all docs images to use absolute paths instead of relative so they can be integrated into the upcoming wiki
* Fixed broken links

## Type of change

- [ ] Documentation Fix

## How the change has been tested
Changes were tested on a local docs site. 


## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
