### PR TITLE
verify mnemonic for additional generated accounts

### DIFF
--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -1,8 +1,6 @@
 // Copyright 2020 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(any(feature = "ledger-nano", feature = "ledger-nano-simulator"))]
-use crate::event::emit_ledger_address_generation;
 use crate::{
     account_manager::{AccountOptions, AccountStore},
     address::{Address, AddressBuilder, AddressOutput, AddressWrapper},
@@ -12,6 +10,8 @@ use crate::{
     signing::{GenerateAddressMetadata, SignerType},
     storage::{MessageIndexation, MessageQueryFilter},
 };
+#[cfg(any(feature = "ledger-nano", feature = "ledger-nano-simulator"))]
+use crate::{client::ClientOptionsBuilder, event::emit_ledger_address_generation};
 
 use iota_client::NodeInfoWrapper;
 
@@ -261,7 +261,7 @@ impl AccountInitialiser {
             last_synced_at: None,
             addresses: self.addresses,
             client_options: self.client_options,
-            storage_path: self.storage_path,
+            storage_path: self.storage_path.clone(),
             skip_persistence: self.skip_persistence,
             cached_messages: Default::default(),
         };
@@ -343,7 +343,102 @@ impl AccountInitialiser {
                 address
             }
         };
-
+        // store first address for the first ledger account so we can verify that the correct mnemonic is used when a
+        // new account is created
+        #[cfg(any(feature = "ledger-nano", feature = "ledger-nano-simulator"))]
+        if account.index == 0 {
+            match signer_type {
+                #[cfg(feature = "ledger-nano")]
+                SignerType::LedgerNano => {
+                    crate::storage::get(&self.storage_path)
+                        .await
+                        .unwrap()
+                        .lock()
+                        .await
+                        .save_first_ledger_address(&address.inner)
+                        .await?;
+                    log::debug!("[LEDGERADDRESS] saved first address {:?}", &address.inner);
+                }
+                #[cfg(feature = "ledger-nano-simulator")]
+                SignerType::LedgerNanoSimulator => {
+                    crate::storage::get(&self.storage_path)
+                        .await
+                        .unwrap()
+                        .lock()
+                        .await
+                        .save_first_ledger_address(&address.inner)
+                        .await?;
+                    log::debug!("[LEDGERADDRESS] saved first address {:?}", &address.inner);
+                }
+                _ => {}
+            }
+        } else {
+            let signer = crate::signing::get_signer(account.signer_type()).await;
+            let mut signer = signer.lock().await;
+            let first_address = signer
+                // dummy account with index 0 so we can generate the correct address
+                .generate_address(
+                    &Account {
+                        id: "account_for_first_ledger_address".to_string(),
+                        signer_type: signer_type.clone(),
+                        index: 0,
+                        alias: "account_for_first_ledger_address".to_string(),
+                        created_at: Local::now(),
+                        last_synced_at: None,
+                        addresses: vec![],
+                        client_options: ClientOptionsBuilder::new().build().unwrap(),
+                        storage_path: PathBuf::new(),
+                        skip_persistence: true,
+                        cached_messages: Arc::new(Mutex::new(HashMap::new())),
+                    },
+                    0,
+                    false,
+                    GenerateAddressMetadata {
+                        syncing: true,
+                        network: account.network(),
+                    },
+                )
+                .await?;
+            log::debug!("[LEDGERADDRESS] generated first address {:?}", first_address);
+            match signer_type {
+                #[cfg(feature = "ledger-nano")]
+                SignerType::LedgerNano => {
+                    // generate address from first account to validate mnemonic
+                    if let Ok(first_account_first_address) = crate::storage::get(&self.storage_path)
+                        .await
+                        .unwrap()
+                        .lock()
+                        .await
+                        .get_first_ledger_address()
+                        .await
+                    {
+                        log::debug!("[LEDGERADDRESS] read first address {:?}", first_account_first_address);
+                        if first_account_first_address != first_address {
+                            return Err(crate::Error::WrongLedgerSeedError);
+                        }
+                    }
+                }
+                #[cfg(feature = "ledger-nano-simulator")]
+                SignerType::LedgerNanoSimulator =>
+                // generate address from first account to validate mnemonic
+                {
+                    if let Ok(first_account_first_address) = crate::storage::get(&self.storage_path)
+                        .await
+                        .unwrap()
+                        .lock()
+                        .await
+                        .get_first_ledger_address()
+                        .await
+                    {
+                        log::debug!("[LEDGERADDRESS] read first address {:?}", first_account_first_address);
+                        if first_account_first_address != first_address {
+                            return Err(crate::Error::WrongLedgerSeedError);
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
         let mut digest = [0; 32];
         let raw = match address.as_ref() {
             iota_client::bee_message::address::Address::Ed25519(a) => a.as_ref().to_vec(),

--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -373,36 +373,36 @@ impl AccountInitialiser {
                 _ => {}
             }
         } else {
-            let signer = crate::signing::get_signer(account.signer_type()).await;
-            let mut signer = signer.lock().await;
-            let first_address = signer
-                // dummy account with index 0 so we can generate the correct address
-                .generate_address(
-                    &Account {
-                        id: "account_for_first_ledger_address".to_string(),
-                        signer_type: signer_type.clone(),
-                        index: 0,
-                        alias: "account_for_first_ledger_address".to_string(),
-                        created_at: Local::now(),
-                        last_synced_at: None,
-                        addresses: vec![],
-                        client_options: ClientOptionsBuilder::new().build().unwrap(),
-                        storage_path: PathBuf::new(),
-                        skip_persistence: true,
-                        cached_messages: Arc::new(Mutex::new(HashMap::new())),
-                    },
-                    0,
-                    false,
-                    GenerateAddressMetadata {
-                        syncing: true,
-                        network: account.network(),
-                    },
-                )
-                .await?;
-            log::debug!("[LEDGERADDRESS] generated first address {:?}", first_address);
             match signer_type {
                 #[cfg(feature = "ledger-nano")]
                 SignerType::LedgerNano => {
+                    let signer = crate::signing::get_signer(&SignerType::LedgerNano).await;
+                    let mut signer = signer.lock().await;
+                    let first_address = signer
+                        // dummy account with index 0 so we can generate the correct address
+                        .generate_address(
+                            &Account {
+                                id: "account_for_first_ledger_address".to_string(),
+                                signer_type: signer_type.clone(),
+                                index: 0,
+                                alias: "account_for_first_ledger_address".to_string(),
+                                created_at: Local::now(),
+                                last_synced_at: None,
+                                addresses: vec![],
+                                client_options: ClientOptionsBuilder::new().build().unwrap(),
+                                storage_path: PathBuf::new(),
+                                skip_persistence: true,
+                                cached_messages: Arc::new(Mutex::new(HashMap::new())),
+                            },
+                            0,
+                            false,
+                            GenerateAddressMetadata {
+                                syncing: true,
+                                network: account.network(),
+                            },
+                        )
+                        .await?;
+                    log::debug!("[LEDGERADDRESS] generated first address {:?}", first_address);
                     // generate address from first account to validate mnemonic
                     if let Ok(first_account_first_address) = crate::storage::get(&self.storage_path)
                         .await
@@ -422,6 +422,33 @@ impl AccountInitialiser {
                 SignerType::LedgerNanoSimulator =>
                 // generate address from first account to validate mnemonic
                 {
+                    let signer = crate::signing::get_signer(&SignerType::LedgerNanoSimulator).await;
+                    let mut signer = signer.lock().await;
+                    let first_address = signer
+                        // dummy account with index 0 so we can generate the correct address
+                        .generate_address(
+                            &Account {
+                                id: "account_for_first_ledger_address".to_string(),
+                                signer_type: signer_type.clone(),
+                                index: 0,
+                                alias: "account_for_first_ledger_address".to_string(),
+                                created_at: Local::now(),
+                                last_synced_at: None,
+                                addresses: vec![],
+                                client_options: ClientOptionsBuilder::new().build().unwrap(),
+                                storage_path: PathBuf::new(),
+                                skip_persistence: true,
+                                cached_messages: Arc::new(Mutex::new(HashMap::new())),
+                            },
+                            0,
+                            false,
+                            GenerateAddressMetadata {
+                                syncing: true,
+                                network: account.network(),
+                            },
+                        )
+                        .await?;
+                    log::debug!("[LEDGERADDRESS] generated first address {:?}", first_address);
                     if let Ok(first_account_first_address) = crate::storage::get(&self.storage_path)
                         .await
                         .unwrap()

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -229,6 +229,23 @@ impl StorageManager {
         Ok(())
     }
 
+    #[cfg(any(feature = "ledger-nano", feature = "ledger-nano-simulator"))]
+    // used for ledger accounts to verify that the same menmonic is used for all accounts
+    pub async fn save_first_ledger_address(
+        &mut self,
+        address: &iota_client::bee_message::address::Address,
+    ) -> crate::Result<()> {
+        self.storage.set("FIRST_LEDGER_ADDRESS", address).await?;
+        Ok(())
+    }
+
+    #[cfg(any(feature = "ledger-nano", feature = "ledger-nano-simulator"))]
+    pub async fn get_first_ledger_address(&self) -> crate::Result<iota_client::bee_message::address::Address> {
+        let address: iota_client::bee_message::address::Address =
+            serde_json::from_str(&self.storage.get("FIRST_LEDGER_ADDRESS").await?)?;
+        Ok(address)
+    }
+
     pub async fn remove_account(&mut self, key: &str) -> crate::Result<()> {
         let index = AccountIndexation { key: key.to_string() };
         if let Some(index) = self.account_indexation.iter().position(|i| i == &index) {


### PR DESCRIPTION
# Description of change

Verify mnemonic for new accounts, without this check one could create one account, change the ledger words/connect another ledger with another mnemonic and create another account

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Created an account in Firefly, received funds to the first account, changed the mnemonic and tried to create a second account (didn't work). Changed the mnemonic back to the same one as for the first account and creating another account worked

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
