### PR TITLE
fix: Ledger error variant

### DIFF
--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -411,7 +411,7 @@ impl AccountInitialiser {
                     {
                         log::debug!("[LEDGERADDRESS] read first address {:?}", first_account_first_address);
                         if first_account_first_address != first_address {
-                            return Err(crate::Error::WrongLedgerSeedError);
+                            return Err(crate::Error::LedgerMnemonicMismatch);
                         }
                     }
                 }
@@ -455,7 +455,7 @@ impl AccountInitialiser {
                     {
                         log::debug!("[LEDGERADDRESS] read first address {:?}", first_account_first_address);
                         if first_account_first_address != first_address {
-                            return Err(crate::Error::WrongLedgerSeedError);
+                            return Err(crate::Error::LedgerMnemonicMismatch);
                         }
                     }
                 }
@@ -827,7 +827,7 @@ impl AccountHandle {
                 )
                 .await?;
                 if address.address().inner != regenerated_address.address().inner {
-                    return Err(crate::Error::WrongLedgerSeedError);
+                    return Err(crate::Error::LedgerMnemonicMismatch);
                 }
             }
         }

--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -1782,7 +1782,7 @@ async fn perform_transfer(
                             )
                             .await?;
                             if address.address().inner != regenerated_address.address().inner {
-                                return Err(crate::Error::WrongLedgerSeedError);
+                                return Err(crate::Error::LedgerMnemonicMismatch);
                             }
                         }
                     }

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -512,7 +512,7 @@ impl AccountManager {
             .await?;
             if first_address != ledger_first_address {
                 #[cfg(any(feature = "ledger-nano", feature = "ledger-nano-simulator"))]
-                return Err(crate::Error::WrongLedgerSeedError);
+                return Err(crate::Error::LedgerMnemonicMismatch);
             }
         }
         let bech32_address = first_address.address().to_bech32();

--- a/src/error.rs
+++ b/src/error.rs
@@ -171,8 +171,8 @@ pub enum Error {
     LedgerNetMismatch,
     /// Wrong ledger seed error
     #[cfg(any(feature = "ledger-nano", feature = "ledger-nano-simulator"))]
-    #[error("wrong ledger seed")]
-    WrongLedgerSeedError,
+    #[error("ledger mnemonic is mismatched")]
+    LedgerMnemonicMismatch,
     /// Account alias must be unique.
     #[error("can't create account: account alias already exists")]
     AccountAliasAlreadyExists,
@@ -361,7 +361,7 @@ impl serde::Serialize for Error {
             #[cfg(any(feature = "ledger-nano", feature = "ledger-nano-simulator"))]
             Self::LedgerNetMismatch => serialize_variant(self, serializer, "LedgerNetMismatch"),
             #[cfg(any(feature = "ledger-nano", feature = "ledger-nano-simulator"))]
-            Self::WrongLedgerSeedError => serialize_variant(self, serializer, "WrongLedgerSeedError"),
+            Self::LedgerMnemonicMismatch => serialize_variant(self, serializer, "LedgerMnemonicMismatch"),
             Self::AccountAliasAlreadyExists => serialize_variant(self, serializer, "AccountAliasAlreadyExists"),
             Self::DustError(_) => serialize_variant(self, serializer, "DustError"),
             Self::LeavingDustError(_) => serialize_variant(self, serializer, "LeavingDustError"),

--- a/src/signing/ledger.rs
+++ b/src/signing/ledger.rs
@@ -162,7 +162,7 @@ impl super::Signer for LedgerNanoSigner {
 
                     if let Some(first_address) = &first_public_address {
                         if first_address.address().inner != iota_address {
-                            return Err(crate::Error::WrongLedgerSeedError);
+                            return Err(crate::Error::LedgerMnemonicMismatch);
                         }
                     }
                     let mut address_pool = HashMap::new();


### PR DESCRIPTION
# Description of change

- Changes name of Ledger error variant: `WrongLedgerSeed` -> `LedgerMnemonicMismatch`
    - helps fix Firefly bug with more consistent error naming / mapping

## Links to any relevant issues

None

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on:

- MacOS (Catalina 10.15.7)

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas