### PR TITLE
Remove double headlines

### DIFF
--- a/documentation/docs/libraries/nodejs/examples.mdx
+++ b/documentation/docs/libraries/nodejs/examples.mdx
@@ -1,4 +1,5 @@
 ---
+title: Examples
 description: Official IOTA Wallet Library Software Node.js examples.
 image: /img/logo/wallet_light.png
 keywords:
@@ -18,8 +19,6 @@ import send from  '!!raw-loader!./../../../../bindings/nodejs/examples/binding_e
 import backup from  '!!raw-loader!./../../../../bindings/nodejs/examples/binding_examples/5-backup.js';
 import restore from  '!!raw-loader!./../../../../bindings/nodejs/examples/binding_examples/6-restore.js';
 import events from  '!!raw-loader!./../../../../bindings/nodejs/examples/binding_examples/7-events.js';
-
-# Examples
 
 This section will guide you through several examples using the node.js binding of the `wallet.rs` library. You can also find the code for the examples in the `/bindings/nodejs/examples` folder in the [official GitHub repository](https://github.com/iotaledger/wallet.rs/tree/dev/bindings/nodejs/examples).
 

--- a/documentation/docs/libraries/python/examples.mdx
+++ b/documentation/docs/libraries/python/examples.mdx
@@ -1,4 +1,5 @@
 ---
+title: Examples
 description: Official IOTA Wallet Library Software Python examples.
 image: /img/logo/wallet_light.png
 keywords:
@@ -19,8 +20,6 @@ import backup from  '!!raw-loader!./../../../../bindings/python/examples/5_backu
 import restore from  '!!raw-loader!./../../../../bindings/python/examples/6_restore.py';
 import b_event_simple_event from  '!!raw-loader!./../../../../bindings/python/examples/7b_event_simple_event.py';
 import event_queue from  '!!raw-loader!./../../../../bindings/python/examples/7_event_queue.py';
-
-# Examples
 
 This section will guide you through several examples using the python binding of the `wallet.rs` library. You can also find the code for the examples in the `/bindings/python/examples` folder in the [official GitHub repository](https://github.com/iotaledger/wallet.rs/tree/dev/bindings/python/examples).
 

--- a/documentation/docs/libraries/rust/examples.mdx
+++ b/documentation/docs/libraries/rust/examples.mdx
@@ -1,4 +1,5 @@
 ---
+title: Examples
 description: Official IOTA Wallet Library Software Rust examples.
 image: /img/logo/wallet_light.png
 keywords:
@@ -12,8 +13,6 @@ import CodeBlock from '@theme/CodeBlock';
 import transfer from  '!!raw-loader!./../../../../examples/transfer.rs';
 import logger from  '!!raw-loader!./../../../../examples/logger.rs';
 import event from  '!!raw-loader!./../../../../examples/event.rs';
-
-# Examples
 
 You can see the examples in the library's [examples directory](https://github.com/iotaledger/wallet.rs/tree/dev/examples).
 You can list all available examples by running the following command:


### PR DESCRIPTION
# Description of change

This PR removes double headlines in the libraries example docs.

![Screenshot_2](https://user-images.githubusercontent.com/53269239/137027902-b275e74f-08ca-492e-b499-8b7715030cba.jpg)

Choose a type of change, and delete any options that are not relevant.

- Documentation Fix

