### PR TITLE
fix: Stronghold snapshot removal

### DIFF
--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -747,7 +747,7 @@ impl AccountManager {
             let stronghold_snapshot_path = self.stronghold_snapshot_path_internal(&storage_id).await?;
 
             // We must check before removing in the case that a dev / user has initiated an
-            // AccountManager without eventually acquiring a mnemonic.
+            // AccountManager without eventually acquiring a Stronghold.
             if stronghold_snapshot_path.exists() && stronghold_snapshot_path.is_file() {
                 std::fs::remove_file(stronghold_snapshot_path)?;
             }

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -743,7 +743,14 @@ impl AccountManager {
         #[cfg(feature = "stronghold")]
         {
             crate::stronghold::unload_snapshot(&self.storage_path, false).await?;
-            std::fs::remove_file(self.stronghold_snapshot_path_internal(&storage_id).await?)?;
+
+            let stronghold_snapshot_path = self.stronghold_snapshot_path_internal(&storage_id).await?;
+
+            // We must check before removing in the case that a dev / user has initiated an
+            // AccountManager without eventually acquiring a mnemonic.
+            if stronghold_snapshot_path.exists() && stronghold_snapshot_path.is_file() {
+                std::fs::remove_file(stronghold_snapshot_path)?;
+            }
         }
 
         Ok(())


### PR DESCRIPTION
# Description of change

- Adds a fix to avoid an `IoError` when trying to delete the Stronghold snapshot file (if the user hasn't acquired a Stronghold for a profile yet)

## Links to any relevant issues

#785 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

1. In Firefly (on `fix/profile-deletion` branch*, also need dev tools), create a profile by entering a name and hitting "Continue"
a. If you want, you can double check that no `wallet.stronghold` file was created in the profile's directory
2. Go back to the profile selection page (this causes Firefly to delete the newly created profile folder + fix of deleting storage adapter in `wallet.rs`)
3. There should be an `IoError` in the dev tools console

\* This branch adds a fix where `wallet.rs`'s storage wasn't being deleted when a Firefly profile was, which caused problems on Windows platforms.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes