### PR TITLE
fix: Use default target features for RocksDB SSE inclusion

### DIFF
--- a/.changes/rocksdb-sse-conditional.md
+++ b/.changes/rocksdb-sse-conditional.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": patch
+---
+
+Use default target features from `rustc` to determine SSE inclusion for RocksDB

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1768,7 +1768,7 @@ dependencies = [
 [[package]]
 name = "librocksdb-sys"
 version = "6.17.3"
-source = "git+https://github.com/iotaledger/rust-rocksdb?rev=e9af8f96ef66a54c67234143d93334a38032d61f#e9af8f96ef66a54c67234143d93334a38032d61f"
+source = "git+https://github.com/iotaledger/rust-rocksdb?rev=d2c579660e6c72ec1f14f0f2781cef5e3171d380#d2c579660e6c72ec1f14f0f2781cef5e3171d380"
 dependencies = [
  "bindgen",
  "cc",
@@ -2541,7 +2541,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.16.0"
-source = "git+https://github.com/iotaledger/rust-rocksdb?rev=e9af8f96ef66a54c67234143d93334a38032d61f#e9af8f96ef66a54c67234143d93334a38032d61f"
+source = "git+https://github.com/iotaledger/rust-rocksdb?rev=d2c579660e6c72ec1f14f0f2781cef5e3171d380#d2c579660e6c72ec1f14f0f2781cef5e3171d380"
 dependencies = [
  "libc",
  "librocksdb-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ thiserror = { version = "1.0.29", default-features = false }
 tokio = { version = "1.12.0", default-features = false, features = ["macros"]}
 url = { version = "2.2.2", default-features = false, features = ["serde"] }
 rand = { version = "0.8.4", default-features = false }
-rocksdb = { git="https://github.com/iotaledger/rust-rocksdb", rev = "e9af8f96ef66a54c67234143d93334a38032d61f", default-features = false, features = ["lz4"] }
+rocksdb = { git="https://github.com/iotaledger/rust-rocksdb", rev = "d2c579660e6c72ec1f14f0f2781cef5e3171d380", default-features = false, features = ["lz4"] }
 zeroize = { version = "1.2.0", default-features = false, features = ["zeroize_derive"] }
 
 # stronghold

--- a/bindings/java/native/Cargo.lock
+++ b/bindings/java/native/Cargo.lock
@@ -1990,7 +1990,7 @@ dependencies = [
 [[package]]
 name = "librocksdb-sys"
 version = "6.17.3"
-source = "git+https://github.com/iotaledger/rust-rocksdb?rev=e9af8f96ef66a54c67234143d93334a38032d61f#e9af8f96ef66a54c67234143d93334a38032d61f"
+source = "git+https://github.com/iotaledger/rust-rocksdb?rev=d2c579660e6c72ec1f14f0f2781cef5e3171d380#d2c579660e6c72ec1f14f0f2781cef5e3171d380"
 dependencies = [
  "bindgen 0.57.0",
  "cc",
@@ -2667,7 +2667,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.16.0"
-source = "git+https://github.com/iotaledger/rust-rocksdb?rev=e9af8f96ef66a54c67234143d93334a38032d61f#e9af8f96ef66a54c67234143d93334a38032d61f"
+source = "git+https://github.com/iotaledger/rust-rocksdb?rev=d2c579660e6c72ec1f14f0f2781cef5e3171d380#d2c579660e6c72ec1f14f0f2781cef5e3171d380"
 dependencies = [
  "libc",
  "librocksdb-sys",

--- a/bindings/nodejs/Cargo.lock
+++ b/bindings/nodejs/Cargo.lock
@@ -1597,7 +1597,7 @@ dependencies = [
 [[package]]
 name = "librocksdb-sys"
 version = "6.17.3"
-source = "git+https://github.com/iotaledger/rust-rocksdb?rev=e9af8f96ef66a54c67234143d93334a38032d61f#e9af8f96ef66a54c67234143d93334a38032d61f"
+source = "git+https://github.com/iotaledger/rust-rocksdb?rev=d2c579660e6c72ec1f14f0f2781cef5e3171d380#d2c579660e6c72ec1f14f0f2781cef5e3171d380"
 dependencies = [
  "bindgen",
  "cc",
@@ -2273,7 +2273,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.16.0"
-source = "git+https://github.com/iotaledger/rust-rocksdb?rev=e9af8f96ef66a54c67234143d93334a38032d61f#e9af8f96ef66a54c67234143d93334a38032d61f"
+source = "git+https://github.com/iotaledger/rust-rocksdb?rev=d2c579660e6c72ec1f14f0f2781cef5e3171d380#d2c579660e6c72ec1f14f0f2781cef5e3171d380"
 dependencies = [
  "libc",
  "librocksdb-sys",

--- a/bindings/python/native/Cargo.lock
+++ b/bindings/python/native/Cargo.lock
@@ -1795,7 +1795,7 @@ dependencies = [
 [[package]]
 name = "librocksdb-sys"
 version = "6.17.3"
-source = "git+https://github.com/iotaledger/rust-rocksdb?rev=e9af8f96ef66a54c67234143d93334a38032d61f#e9af8f96ef66a54c67234143d93334a38032d61f"
+source = "git+https://github.com/iotaledger/rust-rocksdb?rev=d2c579660e6c72ec1f14f0f2781cef5e3171d380#d2c579660e6c72ec1f14f0f2781cef5e3171d380"
 dependencies = [
  "bindgen",
  "cc",
@@ -2535,7 +2535,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.16.0"
-source = "git+https://github.com/iotaledger/rust-rocksdb?rev=e9af8f96ef66a54c67234143d93334a38032d61f#e9af8f96ef66a54c67234143d93334a38032d61f"
+source = "git+https://github.com/iotaledger/rust-rocksdb?rev=d2c579660e6c72ec1f14f0f2781cef5e3171d380#d2c579660e6c72ec1f14f0f2781cef5e3171d380"
 dependencies = [
  "libc",
  "librocksdb-sys",


### PR DESCRIPTION
# Description of change

RocksDB is currently compiled based on whether the host machine supports SSE4 and other instructions, not the target machine. This PR updates `rust-rocksdb` to include https://github.com/rust-rocksdb/rust-rocksdb/commit/81a9ede which will use the default features from `rustc`. This allows the prebuilt binaries and other consumers of `wallet.rs` to target older machines that do not support these new features. If they choose, they can opt-in to these features by changing `RUSTFLAGS` ([see more](https://rust-lang.github.io/packed_simd/perf-guide/target-feature/rustflags.html)). 

RocksDB uses SSE and AVX for [CRC32](https://github.com/facebook/rocksdb/blob/v6.17.3/util/crc32c.cc) and [xxHash](https://github.com/facebook/rocksdb/blob/v6.17.3/util/xxh3p.h) (among other things), so this change may cause a performance degradation when these are used.

Default options for major platforms (`rustc --print=cfg | grep target_feature`):
- x86_64-pc-windows-msvc:
```
target_feature="fxsr"
target_feature="sse"
target_feature="sse2"
```

- x86_64-unknown-linux-gnu:
```
target_feature="fxsr"
target_feature="sse"
target_feature="sse2"
```

- x86_64-apple-darwin:
```
target_feature="fxsr"
target_feature="sse"
target_feature="sse2"
target_feature="sse3"
target_feature="ssse3"
```


## Links to any relevant issues

https://github.com/iotaledger/firefly/issues/1205

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tests pass

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have checked that new and existing unit tests pass locally with my changes
