### PR TITLE
Fix set_storage_password

### DIFF
--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -222,10 +222,10 @@ impl StorageManager {
         if !self.account_indexation.contains(&index) {
             init_account_dependency_index!(self, key, message_indexation);
             self.account_indexation.push(index);
-            self.storage
-                .set(ACCOUNT_INDEXATION_KEY, &self.account_indexation)
-                .await?;
         }
+        self.storage
+            .set(ACCOUNT_INDEXATION_KEY, &self.account_indexation)
+            .await?;
         Ok(())
     }
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -223,6 +223,7 @@ impl StorageManager {
             init_account_dependency_index!(self, key, message_indexation);
             self.account_indexation.push(index);
         }
+        // store it every time, because the password might changed
         self.storage
             .set(ACCOUNT_INDEXATION_KEY, &self.account_indexation)
             .await?;


### PR DESCRIPTION
# Description of change

When we use set_storage_password, we store the accounts again with the new password, but the account_indexation wasn't updated with the new password, when the account wasn't new and this broke the db, because two different keys were needed to get the data then again.

## Links to any relevant issues

Be sure to reference any related issues by adding `fixes issue #`.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Used set_storage_password multiple times with different passwords and it still worked to load the accounts after a change

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
