### PR TITLE
fix(bindings/python): Add lib name back to fix maturin build

### DIFF
--- a/bindings/python/native/Cargo.toml
+++ b/bindings/python/native/Cargo.toml
@@ -12,6 +12,7 @@ keywords = ["iota", "wallet", "transaction", "python"]
 categories = ["cryptography::cryptocurrencies"]
 
 [lib]
+name = "iota_wallet"
 crate-type = ["cdylib"]
 
 [dependencies]


### PR DESCRIPTION
# Description of change

Adds back the `lib.name` to the `Cargo.toml`, as the builds for the Python bindings are [failing](https://github.com/iotaledger/wallet.rs/runs/4365937285?check_suite_focus=true#step:8:16) with the following error:

```
💥 maturin failed
  Caused by: The module name must not contains a minus (Make sure you have set an appropriate [lib] name in your Cargo.toml)
```

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Ran `maturin build --release --manylinux off`

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code