### PR TITLE
account,storage: partially remove caching

### DIFF
--- a/.changes/list-messages.md
+++ b/.changes/list-messages.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": patch
+---
+
+Attempt to fix the wrong number of messages returned from `list_messages()`.


### PR DESCRIPTION
# Description of change

`Account::list_messages()` returns more entries than expected if
there are messages with the same `MessageType`s cached. Remove the
caching process to mitigate the problem, but
`Account::cached_messages` is kept to not break the API.

## Links to any relevant issues

(Should) Fix #769, #825.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

```
cargo build
```

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
