### PR TITLE
chore: bump iota-client to latest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1338,7 +1338,7 @@ dependencies = [
 [[package]]
 name = "iota-client"
 version = "1.1.0"
-source = "git+https://github.com/iotaledger/iota.rs?rev=c7d1cc4bae4ef00f16314239463ce115f8c6b35a#c7d1cc4bae4ef00f16314239463ce115f8c6b35a"
+source = "git+https://github.com/iotaledger/iota.rs?rev=981136e9118a092cd4de6735e616858140b33019#981136e9118a092cd4de6735e616858140b33019"
 dependencies = [
  "async-trait",
  "bee-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ chrono = { version = "0.4.19", default-features = false, features = ["serde"] }
 futures = { version = "0.3.17", default-features = false }
 getset = { version = "0.1.1", default-features = false }
 hex = { version = "0.4.3", default-features = false }
-iota-client = { git = "https://github.com/iotaledger/iota.rs", rev = "c7d1cc4bae4ef00f16314239463ce115f8c6b35a", default-features = false, features = ["async", "mqtt"] }
+iota-client = { git = "https://github.com/iotaledger/iota.rs", rev = "981136e9118a092cd4de6735e616858140b33019", default-features = false, features = ["async", "mqtt"] }
 log = { version = "0.4.14", default-features = false }
 once_cell = { version = "1.8.0", default-features = false }
 rand = { version = "0.8.4", default-features = false }


### PR DESCRIPTION
# Description of change

This PR updates iota.rs dependency to latest commit (to include mqtt fix). 

See: https://github.com/iotaledger/iota.rs/pull/771

## Links to any relevant issues

N/A

## Type of change

Dependency updates

## How the change has been tested

N/A

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
