### PR TITLE
Fix: only sync addresses >= address_start_index

### DIFF
--- a/.changes/addressIndex.md
+++ b/.changes/addressIndex.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": patch
+---
+
+Fixes the syncing so when an `addressIndex` is provided, only addresses with an index >= will be synced.

--- a/bindings/nodejs/Cargo.lock
+++ b/bindings/nodejs/Cargo.lock
@@ -1312,7 +1312,7 @@ dependencies = [
 [[package]]
 name = "iota-client"
 version = "1.1.0"
-source = "git+https://github.com/iotaledger/iota.rs?rev=c7d1cc4bae4ef00f16314239463ce115f8c6b35a#c7d1cc4bae4ef00f16314239463ce115f8c6b35a"
+source = "git+https://github.com/iotaledger/iota.rs?rev=981136e9118a092cd4de6735e616858140b33019#981136e9118a092cd4de6735e616858140b33019"
 dependencies = [
  "async-trait",
  "bee-common 0.5.0",


### PR DESCRIPTION
# Description of change

Fix: only sync addresses >= address_start_index, currently when syncing the messages we also sync all addresses which slows the syncing down


## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Synced an account with a higher addressIndex and checked the log to verify that not all addresses get synced anymore

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked that new and existing unit tests pass locally with my changes
