### PR TITLE
Don't skip unconfirmed messages

### DIFF
--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -452,11 +452,11 @@ async fn sync_messages(
     let account = account_handle.read().await.clone();
     let client_options = account.client_options().clone();
 
-    let messages_with_known_confirmation: Vec<MessageId> = account
+    let known_confirmed_messages: Vec<MessageId> = account
         .with_messages(|messages| {
             messages
                 .iter()
-                .filter(|m| m.confirmed.is_some())
+                .filter(|m| m.confirmed.unwrap_or(false))
                 .map(|m| m.key)
                 .collect()
         })
@@ -492,7 +492,7 @@ async fn sync_messages(
                 continue;
             }
             let client = client.clone();
-            let messages_with_known_confirmation = messages_with_known_confirmation.clone();
+            let known_confirmed_messages = known_confirmed_messages.clone();
             let mut outputs = address.outputs.clone();
 
             tasks.push(async move {
@@ -575,7 +575,7 @@ async fn sync_messages(
                         // if we already have the message stored
                         // and the confirmation state is known
                         // we skip the `get_message` call
-                        if messages_with_known_confirmation.contains(&output_message_id) {
+                        if known_confirmed_messages.contains(&output_message_id) {
                             continue;
                         }
 

--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -168,11 +168,11 @@ pub(crate) async fn sync_address(
                 let message_id = *found_output.message_id();
 
                 // if we already have the message stored
-                // and the confirmation state is known
+                // and the confirmation state is confirmed
                 // we skip the `get_message` call
                 if account_messages
                     .iter()
-                    .any(|(id, confirmed)| id == &message_id && confirmed.is_some())
+                    .any(|(id, confirmed)| id == &message_id && confirmed.unwrap_or(false))
                 {
                     return crate::Result::Ok((found_output, None));
                 }
@@ -573,7 +573,7 @@ async fn sync_messages(
                         outputs.insert(output.id()?, output);
 
                         // if we already have the message stored
-                        // and the confirmation state is known
+                        // and the confirmation state is confirmed
                         // we skip the `get_message` call
                         if known_confirmed_messages.contains(&output_message_id) {
                             continue;


### PR DESCRIPTION
# Description of change

Don't skip unconfirmed messages, so we update the message state to confirmed, if that's the state then
Otherwise it could happen, that a message got set to unconfirmed and then will not be updated anymore, if it status changes to confirmed

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
