### PR TITLE
Start syncing from address index 0 by default

### DIFF
--- a/.changes/syncing.md
+++ b/.changes/syncing.md
@@ -1,0 +1,6 @@
+---
+"nodejs-binding": patch
+---
+
+Start syncing from address index 0 by default;
+Don't skip unconfirmed messages during syncing;

--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -1141,8 +1141,7 @@ impl AccountSynchronizer {
         };
         Self {
             account_handle,
-            // by default we synchronize from the latest address (supposedly unspent)
-            address_index: latest_address_index,
+            address_index: 0,
             gap_limit: if latest_address_index == 0 {
                 default_gap_limit
             } else {


### PR DESCRIPTION
# Description of change

Start syncing from address index 0 by default, otherwise it can easily happen that new transactions aren't detect if no custom address index is provided

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have checked that new and existing unit tests pass locally with my changes
