### PR TITLE
Use local transaction payload to reattach

### DIFF
--- a/.changes/reattach.md
+++ b/.changes/reattach.md
@@ -2,4 +2,4 @@
 "nodejs-binding": patch
 ---
 
-Use local data when reattaching transactions.
+Use local data when reattaching transactions and check inclusion state for reattached messages.

--- a/.changes/reattach.md
+++ b/.changes/reattach.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": patch
+---
+
+Use local data when reattaching transactions.

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -1959,6 +1959,8 @@ async fn retry_unconfirmed_transactions(synced_accounts: &[SyncedAccount]) -> cr
                     Err(crate::Error::ClientError(ref e)) => {
                         if let iota_client::Error::NoNeedPromoteOrReattach(_) = e.as_ref() {
                             no_need_promote_or_reattach.push(message_id);
+                        } else {
+                            log::debug!("[POLLING] retrying failed: {:?}", e);
                         }
                     }
                     _ => {}

--- a/src/message.rs
+++ b/src/message.rs
@@ -758,6 +758,48 @@ impl MessageTransactionPayload {
             unlock_blocks: unlock_blocks.into_boxed_slice(),
         })
     }
+
+    /// Convert to a transaction payload from bee_message
+    pub fn to_transaction_payload(&self) -> crate::Result<TransactionPayload> {
+        let mut essence = iota_client::bee_message::payload::transaction::RegularEssenceBuilder::new();
+        let TransactionEssence::Regular(message_essence) = self.essence();
+        let mut inputs = Vec::new();
+        for input in message_essence.inputs() {
+            if let TransactionInput::Utxo(input) = input {
+                inputs.push(iota_client::bee_message::input::Input::Utxo(input.input.clone()));
+            }
+        }
+        inputs.sort_unstable_by_key(|a| a.pack_new());
+        essence = essence.with_inputs(inputs);
+        let mut outputs = Vec::new();
+        for output in message_essence.outputs() {
+            match output {
+                TransactionOutput::SignatureLockedSingle(output) => {
+                    outputs.push(iota_client::bee_message::output::Output::SignatureLockedSingle(
+                        SignatureLockedSingleOutput::new(output.address.inner, output.amount)?,
+                    ))
+                }
+                TransactionOutput::SignatureLockedDustAllowance(output) => {
+                    outputs.push(iota_client::bee_message::output::Output::SignatureLockedDustAllowance(
+                        SignatureLockedDustAllowanceOutput::new(output.address.inner, output.amount)?,
+                    ))
+                }
+                _ => {}
+            }
+        }
+        outputs.sort_unstable_by_key(|a| a.pack_new());
+        essence = essence.with_outputs(outputs);
+        if let Some(indexation) = message_essence.payload() {
+            essence = essence.with_payload(indexation.clone());
+        }
+        let essence = essence.finish()?;
+        Ok(TransactionPayload::builder()
+            .with_essence(Essence::Regular(essence))
+            .with_unlock_blocks(iota_client::bee_message::unlock::UnlockBlocks::new(
+                self.unlock_blocks.to_vec(),
+            )?)
+            .finish()?)
+    }
 }
 
 /// Milestone payload essence.


### PR DESCRIPTION
# Description of change

Currently we try to reattach with the message from the node, but if the node doesn't has this message, then it fails. With this PR we will use the local stores transaction payload to reattach.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Retried a transaction and it worked

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
