### PR TITLE
Remove redundant storage encryption key argument in parse_accounts(...)

### DIFF
--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -272,11 +272,7 @@ async fn sync_address_list(
     log::debug!("[SYNC] address_list length: {}", addresses.len());
 
     // We split the addresses into chunks so we don't get timeouts if we have thousands
-    for addresses_chunk in addresses
-        .chunks(SYNC_CHUNK_SIZE)
-        .map(|x: &[Address]| x.to_vec())
-        .into_iter()
-    {
+    for addresses_chunk in addresses.chunks(SYNC_CHUNK_SIZE).map(|x: &[Address]| x.to_vec()) {
         let mut tasks = Vec::new();
         for address in addresses_chunk {
             let mut address = address.clone();
@@ -479,7 +475,6 @@ async fn sync_messages(
         .to_vec()
         .chunks(SYNC_CHUNK_SIZE)
         .map(|x: &[Address]| x.to_vec())
-        .into_iter()
     {
         let mut tasks = Vec::new();
         for address in addresses_chunk {

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -2005,7 +2005,7 @@ fn backup_filename(original: &str) -> String {
     let date = Local::now();
     format!(
         "{}-iota-wallet-backup{}",
-        date.format("%FT%H-%M-%S").to_string(),
+        date.format("%FT%H-%M-%S"),
         if original.is_empty() {
             "".to_string()
         } else {

--- a/src/account_manager/migration.rs
+++ b/src/account_manager/migration.rs
@@ -358,7 +358,7 @@ pub(crate) async fn create_bundle<P: AsRef<Path>>(
     )?;
     log.write_all(format!("receiveAddressBech32: {}\n", deposit_address_bech32).as_bytes())?;
     log.write_all(format!("balance: {}\n", address_inputs.iter().map(|a| a.balance).sum::<u64>()).as_bytes())?;
-    log.write_all(format!("timestamp: {}\n", Utc::now().to_string()).as_bytes())?;
+    log.write_all(format!("timestamp: {}\n", Utc::now()).as_bytes())?;
     log.write_all(
         format!(
             "spentAddresses: {:?}\n",

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -35,7 +35,7 @@ pub async fn unsubscribe(account_handle: AccountHandle) -> crate::Result<()> {
             let mut topics = Vec::new();
             for m in messages {
                 if m.confirmed.is_none() {
-                    topics.push(Topic::new(format!("messages/{}/metadata", m.key.to_string()))?);
+                    topics.push(Topic::new(format!("messages/{}/metadata", m.key))?);
                 }
             }
             crate::Result::Ok(topics)


### PR DESCRIPTION
# Description of change

Remove encryption key argument in parse_accounts(...) because it's redundant.

## Links to any relevant issues
Closes issue #858 

## Type of change
- Enhancement (a non-breaking refactoring change)

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have checked that new and existing unit tests pass locally with my changes
