### PR TITLE
fix: retry/confirmation detection

### DIFF
--- a/.changes/confirmation.md
+++ b/.changes/confirmation.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": patch
+---
+
+Don't retry pruned messages forever, inputs are checked if they're spent so the status can be updated even if the messages got pruned already.

--- a/bindings/python/native/tests/fixtures/test_vectors.json
+++ b/bindings/python/native/tests/fixtures/test_vectors.json
@@ -36,7 +36,7 @@
             "backup_dir_path": "./backup"
         },
         "migration": {
-            "legacy_node": "https://nodes.devnet.iota.org",
+            "legacy_node": "https://nodes.iota.org",
             "test_only_seed": "TRYTESEEDTRYTESEEDTRYTESEEDTRYTESEEDTRYTESEEDTRYTESEEDTRYTESEEDTRYTESEEDTRYTESEED",
             "permanode": "https://chronicle.iota.org/api",
             "min_weight_magnitude": 9

--- a/bindings/python/native/tests/test_account_manager.py
+++ b/bindings/python/native/tests/test_account_manager.py
@@ -218,4 +218,4 @@ def test_get_migration_data():
             [legacy_node], bundle['bundle_hash'], min_weight_magnitude)
 
     except ValueError as e:
-        assert 'Input value is < dust protection value' in str(e)
+        assert 'input list is empty' in str(e)


### PR DESCRIPTION
# Description of change

Don't retry pruned messages forever, inputs are checked if they're spent so the status can be updated even if the messages got pruned already

Also fixed the python tests because the legacy devnet got shut down

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Checked with a wallet and a pruned message if it still gets retried or not anymore and it does not.

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have checked that new and existing unit tests pass locally with my changes
