### PR TITLE
Clear storage password and verify it

### DIFF
--- a/src/actor/message.rs
+++ b/src/actor/message.rs
@@ -167,6 +167,8 @@ pub enum MessageType {
     },
     /// Sets the password used to encrypt/decrypt the storage.
     SetStoragePassword(String),
+    /// Clears the password used to encrypt/decrypt the storage.
+    ClearStoragePassword,
     /// Set stronghold snapshot password.
     #[cfg(feature = "stronghold")]
     #[cfg_attr(docsrs, doc(cfg(feature = "stronghold")))]
@@ -384,74 +386,77 @@ impl Serialize for MessageType {
             MessageType::SetStoragePassword(_) => {
                 serializer.serialize_unit_variant("MessageType", 9, "SetStoragePassword")
             }
+            MessageType::ClearStoragePassword => {
+                serializer.serialize_unit_variant("MessageType", 10, "ClearStoragePassword")
+            }
             #[cfg(feature = "stronghold")]
             MessageType::SetStrongholdPassword(_) => {
-                serializer.serialize_unit_variant("MessageType", 10, "SetStrongholdPassword")
+                serializer.serialize_unit_variant("MessageType", 11, "SetStrongholdPassword")
             }
             #[cfg(feature = "stronghold")]
             MessageType::SetStrongholdPasswordClearInterval(_) => {
-                serializer.serialize_unit_variant("MessageType", 11, "SetStrongholdPasswordClearInterval")
+                serializer.serialize_unit_variant("MessageType", 12, "SetStrongholdPasswordClearInterval")
             }
             #[cfg(feature = "stronghold")]
             MessageType::GetStrongholdStatus => {
-                serializer.serialize_unit_variant("MessageType", 12, "GetStrongholdStatus")
+                serializer.serialize_unit_variant("MessageType", 13, "GetStrongholdStatus")
             }
             #[cfg(feature = "stronghold")]
-            MessageType::LockStronghold => serializer.serialize_unit_variant("MessageType", 13, "LockStronghold"),
-            MessageType::SendTransfer { .. } => serializer.serialize_unit_variant("MessageType", 14, "SendTransfer"),
+            MessageType::LockStronghold => serializer.serialize_unit_variant("MessageType", 14, "LockStronghold"),
+            MessageType::SendTransfer { .. } => serializer.serialize_unit_variant("MessageType", 15, "SendTransfer"),
             MessageType::InternalTransfer { .. } => {
-                serializer.serialize_unit_variant("MessageType", 15, "InternalTransfer")
+                serializer.serialize_unit_variant("MessageType", 16, "InternalTransfer")
             }
-            MessageType::GenerateMnemonic => serializer.serialize_unit_variant("MessageType", 16, "GenerateMnemonic"),
-            MessageType::VerifyMnemonic(_) => serializer.serialize_unit_variant("MessageType", 17, "VerifyMnemonic"),
-            MessageType::StoreMnemonic { .. } => serializer.serialize_unit_variant("MessageType", 18, "StoreMnemonic"),
+            MessageType::GenerateMnemonic => serializer.serialize_unit_variant("MessageType", 17, "GenerateMnemonic"),
+            MessageType::VerifyMnemonic(_) => serializer.serialize_unit_variant("MessageType", 18, "VerifyMnemonic"),
+            MessageType::StoreMnemonic { .. } => serializer.serialize_unit_variant("MessageType", 19, "StoreMnemonic"),
             MessageType::IsLatestAddressUnused => {
-                serializer.serialize_unit_variant("MessageType", 19, "IsLatestAddressUnused")
+                serializer.serialize_unit_variant("MessageType", 20, "IsLatestAddressUnused")
             }
             #[cfg(any(feature = "ledger-nano", feature = "ledger-nano-simulator"))]
-            MessageType::GetLedgerStatus(_) => serializer.serialize_unit_variant("MessageType", 20, "GetLedgerStatus"),
-            MessageType::DeleteStorage => serializer.serialize_unit_variant("MessageType", 21, "DeleteStorage"),
+            MessageType::GetLedgerStatus(_) => serializer.serialize_unit_variant("MessageType", 21, "GetLedgerStatus"),
+            MessageType::DeleteStorage => serializer.serialize_unit_variant("MessageType", 22, "DeleteStorage"),
             #[cfg(feature = "stronghold")]
             MessageType::ChangeStrongholdPassword { .. } => {
-                serializer.serialize_unit_variant("MessageType", 22, "ChangeStrongholdPassword")
+                serializer.serialize_unit_variant("MessageType", 23, "ChangeStrongholdPassword")
             }
             MessageType::SetClientOptions(_) => {
-                serializer.serialize_unit_variant("MessageType", 23, "SetClientOptions")
+                serializer.serialize_unit_variant("MessageType", 24, "SetClientOptions")
             }
             MessageType::GetMigrationData { .. } => {
-                serializer.serialize_unit_variant("MessageType", 24, "GetMigrationData")
+                serializer.serialize_unit_variant("MessageType", 25, "GetMigrationData")
             }
             MessageType::CreateMigrationBundle { .. } => {
-                serializer.serialize_unit_variant("MessageType", 25, "CreateMigrationBundle")
+                serializer.serialize_unit_variant("MessageType", 26, "CreateMigrationBundle")
             }
             MessageType::SendMigrationBundle { .. } => {
-                serializer.serialize_unit_variant("MessageType", 26, "SendMigrationBundle")
+                serializer.serialize_unit_variant("MessageType", 27, "SendMigrationBundle")
             }
-            MessageType::GetSeedChecksum(_) => serializer.serialize_unit_variant("MessageType", 27, "GetSeedChecksum"),
+            MessageType::GetSeedChecksum(_) => serializer.serialize_unit_variant("MessageType", 28, "GetSeedChecksum"),
             MessageType::GetMigrationAddress { .. } => {
-                serializer.serialize_unit_variant("MessageType", 28, "GetMigrationAddress")
+                serializer.serialize_unit_variant("MessageType", 29, "GetMigrationAddress")
             }
-            MessageType::MineBundle { .. } => serializer.serialize_unit_variant("MessageType", 29, "MineBundle"),
+            MessageType::MineBundle { .. } => serializer.serialize_unit_variant("MessageType", 30, "MineBundle"),
             MessageType::GetLedgerMigrationData { .. } => {
-                serializer.serialize_unit_variant("MessageType", 30, "GetLedgerMigrationData")
+                serializer.serialize_unit_variant("MessageType", 31, "GetLedgerMigrationData")
             }
             MessageType::SendLedgerMigrationBundle { .. } => {
-                serializer.serialize_unit_variant("MessageType", 31, "SendLedgerMigrationBundle")
+                serializer.serialize_unit_variant("MessageType", 32, "SendLedgerMigrationBundle")
             }
             MessageType::GetLegacyAddressChecksum(_) => {
-                serializer.serialize_unit_variant("MessageType", 32, "GetLegacyAddressChecksum")
+                serializer.serialize_unit_variant("MessageType", 33, "GetLegacyAddressChecksum")
             }
             MessageType::StartBackgroundSync { .. } => {
-                serializer.serialize_unit_variant("MessageType", 33, "StartBackgroundSync")
+                serializer.serialize_unit_variant("MessageType", 34, "StartBackgroundSync")
             }
             MessageType::StopBackgroundSync => {
-                serializer.serialize_unit_variant("MessageType", 34, "StopBackgroundSync")
+                serializer.serialize_unit_variant("MessageType", 35, "StopBackgroundSync")
             }
             #[cfg(feature = "participation")]
-            MessageType::Participate { .. } => serializer.serialize_unit_variant("MessageType", 35, "Participate"),
+            MessageType::Participate { .. } => serializer.serialize_unit_variant("MessageType", 36, "Participate"),
             #[cfg(feature = "participation")]
             MessageType::StopParticipating { .. } => {
-                serializer.serialize_unit_variant("MessageType", 36, "StopParticipating")
+                serializer.serialize_unit_variant("MessageType", 37, "StopParticipating")
             }
             #[cfg(feature = "participation")]
             MessageType::GetParticipationOverview => {
@@ -584,6 +589,8 @@ pub enum ResponseType {
     BackupRestored,
     /// SetStoragePassword response.
     StoragePasswordSet,
+    /// ClearStoragePassword response.
+    StoragePasswordCleared,
     /// SetStrongholdPassword response.
     #[cfg(feature = "stronghold")]
     #[cfg_attr(docsrs, doc(cfg(feature = "stronghold")))]

--- a/src/actor/mod.rs
+++ b/src/actor/mod.rs
@@ -125,6 +125,9 @@ impl WalletMessageHandler {
             MessageType::SetStoragePassword(password) => {
                 convert_async_panics(|| async { self.set_storage_password(password).await }).await
             }
+            MessageType::ClearStoragePassword => {
+                convert_async_panics(|| async { self.clear_storage_password().await }).await
+            }
             #[cfg(feature = "stronghold")]
             MessageType::SetStrongholdPassword(password) => {
                 convert_async_panics(|| async { self.set_stronghold_password(password).await }).await
@@ -663,6 +666,11 @@ impl WalletMessageHandler {
     async fn set_storage_password(&self, password: &str) -> Result<ResponseType> {
         self.account_manager.set_storage_password(password).await?;
         Ok(ResponseType::StoragePasswordSet)
+    }
+
+    async fn clear_storage_password(&self) -> Result<ResponseType> {
+        self.account_manager.clear_storage_password().await?;
+        Ok(ResponseType::StoragePasswordCleared)
     }
 
     #[cfg(feature = "stronghold")]

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -30,6 +30,7 @@ use std::{
 };
 
 const ACCOUNT_INDEXATION_KEY: &str = "iota-wallet-account-indexation";
+const KCV_KEY: &str = "iota-wallet-key-checksum_value";
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 struct AccountIndexation {
@@ -83,6 +84,25 @@ struct Storage {
 }
 
 impl Storage {
+    async fn new(
+        storage_path: PathBuf,
+        storage_adapter: Box<dyn StorageAdapter + Send + Sync + 'static>,
+        encryption_key: Option<[u8; 32]>,
+    ) -> crate::Result<Self> {
+        let storage_id = storage_adapter.id();
+        let mut storage = Storage {
+            storage_path,
+            inner: storage_adapter,
+            encryption_key: None,
+        };
+
+        if storage_id != stronghold::STORAGE_ID && encryption_key.is_some() {
+            storage.set_encryption_key(encryption_key.unwrap()).await?;
+        }
+
+        Ok(storage)
+    }
+
     fn id(&self) -> &'static str {
         self.inner.id()
     }
@@ -136,6 +156,28 @@ impl Storage {
     async fn remove(&mut self, key: &str) -> crate::Result<()> {
         self.inner.remove(key).await
     }
+
+    async fn set_encryption_key(&mut self, encryption_key: [u8; 32]) -> crate::Result<()> {
+        let record = key_checksum_value(&encryption_key)?;
+        self.inner.set(KCV_KEY, serde_json::to_string(&record)?).await?;
+        self.encryption_key.replace(encryption_key);
+        Ok(())
+    }
+
+    async fn get_encryption_key_checksum(&self) -> crate::Result<Vec<u8>> {
+        let record = self.inner.get(KCV_KEY).await?;
+        Ok(serde_json::from_str(&record)?)
+    }
+
+    fn clear_encryption_key(&mut self) -> crate::Result<()> {
+        self.encryption_key.take();
+        Ok(())
+    }
+
+    #[cfg(test)]
+    async fn remove_encryption_key_checksum(&mut self) -> crate::Result<()> {
+        self.inner.remove(KCV_KEY).await
+    }
 }
 
 pub(crate) struct StorageManager {
@@ -180,8 +222,7 @@ impl StorageManager {
         self.storage.id()
     }
 
-    #[cfg(test)]
-    pub fn is_encrypted(&self) -> bool {
+    pub(crate) fn is_encrypted(&self) -> bool {
         self.storage.encryption_key.is_some()
     }
 
@@ -429,6 +470,87 @@ impl StorageManager {
     }
 }
 
+fn key_checksum_value(encryption_key: &[u8; 32]) -> crate::Result<Vec<u8>> {
+    let mut nonce = [0u8; XChaCha20Poly1305::NONCE_LENGTH];
+    crypto::utils::rand::fill(&mut nonce).map_err(|e| crate::Error::RecordEncrypt(format!("{:?}", e)))?;
+    key_checksum_value_with_nonce(encryption_key, nonce)
+}
+
+fn key_checksum_value_with_nonce(
+    encryption_key: &[u8; 32],
+    nonce: [u8; XChaCha20Poly1305::NONCE_LENGTH],
+) -> crate::Result<Vec<u8>> {
+    let mut tag = vec![0u8; XChaCha20Poly1305::TAG_LENGTH];
+    let data = [0u8; XChaCha20Poly1305::KEY_LENGTH];
+
+    let mut ciphertext = [0u8; XChaCha20Poly1305::KEY_LENGTH];
+    // we can unwrap here since we know the lengths are valid
+    XChaCha20Poly1305::encrypt(
+        encryption_key.try_into().unwrap(),
+        &nonce.try_into().unwrap(),
+        &[],
+        &data,
+        &mut ciphertext,
+        tag.as_mut_slice().try_into().unwrap(),
+    )
+    .map_err(|e| crate::Error::RecordEncrypt(format!("{:?}", e)))?;
+
+    let mut data = Vec::from(nonce);
+    data.extend_from_slice(&ciphertext[0..3]);
+
+    Ok(data)
+}
+
+fn split_key_checksum(record: &[u8]) -> crate::Result<([u8; XChaCha20Poly1305::NONCE_LENGTH], Vec<u8>)> {
+    let mut record = record;
+
+    let mut nonce = [0u8; XChaCha20Poly1305::NONCE_LENGTH];
+    let mut kcv = Vec::new();
+
+    record.read_exact(&mut nonce)?;
+    record.read_to_end(&mut kcv)?;
+
+    Ok((nonce, kcv))
+}
+
+pub(crate) async fn is_key_valid(storage_path: &Path, encryption_key: &[u8; 32]) -> crate::Result<bool> {
+    let record = crate::storage::get_encryption_key_checksum(storage_path).await;
+
+    match record {
+        Ok(record) => {
+            let (nonce, _kcv) = split_key_checksum(&record)?;
+            if record == key_checksum_value_with_nonce(encryption_key, nonce)? {
+                Ok(true)
+            } else {
+                Ok(false)
+            }
+        }
+        Err(crate::Error::RecordNotFound) => {
+            let storage_handle = crate::storage::get(storage_path).await?;
+            let is_valid = match storage_handle.lock().await.get(ACCOUNT_INDEXATION_KEY).await {
+                // Existing DB
+                Ok(indexation) => match serde_json::from_str::<Vec<AccountIndexation>>(&indexation) {
+                    Ok(_account_indexation) => {
+                        // DB is not encrypted, or is it possible that someone already set the correct password?
+                        // Maybe come back to review this decision if we ever decide to have a `change_storage_password` function
+                        Ok(true)
+                    }
+                    Err(_) => match decrypt_record(&indexation, encryption_key) {
+                        Ok(indexation) => Ok(serde_json::from_str::<Vec<AccountIndexation>>(&indexation).is_ok()),
+                        Err(_) => Ok(false),
+                    },
+                },
+                // Newly created DB
+                Err(crate::Error::RecordNotFound) => Ok(true),
+                // Some other error
+                Err(e) => Err(e),
+            };
+            is_valid
+        }
+        Err(e) => Err(e),
+    }
+}
+
 async fn load_optional_data<T: DeserializeOwned + Default>(storage: &Storage, key: &str) -> crate::Result<T> {
     let record = match storage.get(key).await {
         Ok(record) => serde_json::from_str(&record)?,
@@ -571,19 +693,12 @@ pub(crate) async fn set<P: AsRef<Path>>(
     storage_path: P,
     encryption_key: Option<[u8; 32]>,
     storage: Box<dyn StorageAdapter + Send + Sync + 'static>,
-) {
+) -> crate::Result<()> {
     let mut instances = INSTANCES.get_or_init(Default::default).write().await;
     #[allow(unused_variables)]
     let storage_id = storage.id();
-    let storage = Storage {
-        storage_path: storage_path.as_ref().to_path_buf(),
-        inner: storage,
-        encryption_key: if storage_id == stronghold::STORAGE_ID {
-            None
-        } else {
-            encryption_key
-        },
-    };
+    let storage = Storage::new(storage_path.as_ref().to_path_buf(), storage, encryption_key).await?;
+
     let storage_manager = StorageManager {
         storage,
         account_indexation: Default::default(),
@@ -598,6 +713,8 @@ pub(crate) async fn set<P: AsRef<Path>>(
         storage_path.as_ref().to_path_buf(),
         Arc::new(Mutex::new(storage_manager)),
     );
+
+    Ok(())
 }
 
 pub(crate) async fn remove(storage_path: &Path) -> Option<String> {
@@ -614,8 +731,27 @@ pub(crate) async fn set_encryption_key(storage_path: &Path, encryption_key: [u8;
     let instances = INSTANCES.get_or_init(Default::default).read().await;
     if let Some(instance) = instances.get(storage_path) {
         let mut storage_manager = instance.lock().await;
-        storage_manager.storage.encryption_key.replace(encryption_key);
-        Ok(())
+        storage_manager.storage.set_encryption_key(encryption_key).await
+    } else {
+        Err(crate::Error::StorageAdapterNotSet(storage_path.to_path_buf()))
+    }
+}
+
+pub(crate) async fn get_encryption_key_checksum(storage_path: &Path) -> crate::Result<Vec<u8>> {
+    let instances = INSTANCES.get_or_init(Default::default).read().await;
+    if let Some(instance) = instances.get(storage_path) {
+        let storage_manager = instance.lock().await;
+        storage_manager.storage.get_encryption_key_checksum().await
+    } else {
+        Err(crate::Error::StorageAdapterNotSet(storage_path.to_path_buf()))
+    }
+}
+
+pub(crate) async fn clear_encryption_key(storage_path: &Path) -> crate::Result<()> {
+    let instances = INSTANCES.get_or_init(Default::default).read().await;
+    if let Some(instance) = instances.get(storage_path) {
+        let mut storage_manager = instance.lock().await;
+        storage_manager.storage.clear_encryption_key()
     } else {
         Err(crate::Error::StorageAdapterNotSet(storage_path.to_path_buf()))
     }
@@ -745,7 +881,7 @@ mod tests {
         }
 
         let path = "./the-storage-path";
-        super::set(path, None, Box::new(MyAdapter {})).await;
+        super::set(path, None, Box::new(MyAdapter {})).await.unwrap();
         let adapter = super::get(&PathBuf::from(path)).await.unwrap();
         let adapter = adapter.lock().await;
         assert_eq!(adapter.get("").await.unwrap(), "MY_ADAPTER_GET_RESPONSE".to_string());
@@ -786,5 +922,137 @@ mod tests {
         let parsed_accounts = response.unwrap();
         let parsed_account = parsed_accounts.first().unwrap();
         assert_eq!(parsed_account, &*account_handle.read().await);
+    }
+
+    #[tokio::test]
+    async fn remove_encryption_key_checksum() {
+        let manager = crate::test_utils::get_account_manager().await;
+        manager.set_storage_password("password").await.unwrap();
+
+        let storage_handle = crate::storage::get(manager.storage_path()).await.unwrap();
+        storage_handle
+            .lock()
+            .await
+            .storage
+            .get_encryption_key_checksum()
+            .await
+            .unwrap();
+        storage_handle
+            .lock()
+            .await
+            .storage
+            .remove_encryption_key_checksum()
+            .await
+            .unwrap();
+        match storage_handle
+            .lock()
+            .await
+            .storage
+            .get_encryption_key_checksum()
+            .await
+            .err()
+            .unwrap()
+        {
+            crate::Error::RecordNotFound => {}
+            e => panic!("{:?}", e),
+        };
+    }
+
+    #[tokio::test]
+    async fn wrong_storage_password_without_kcv() {
+        let manager = crate::test_utils::get_account_manager().await;
+        manager.set_storage_password("password").await.unwrap();
+
+        let _ = crate::test_utils::AccountCreator::new(&manager).create().await;
+        assert_eq!(manager.get_accounts().await.unwrap().len(), 1);
+
+        manager.clear_storage_password().await.unwrap();
+        let storage_handle = crate::storage::get(manager.storage_path()).await.unwrap();
+        storage_handle
+            .lock()
+            .await
+            .storage
+            .remove_encryption_key_checksum()
+            .await
+            .unwrap();
+
+        match manager.set_storage_password("wrong-password").await.err().unwrap() {
+            crate::Error::RecordDecrypt(_) => {}
+            e => panic!("{:?}", e),
+        }
+    }
+
+    #[tokio::test]
+    async fn correct_storage_password_without_kcv() {
+        let manager = crate::test_utils::get_account_manager().await;
+        manager.set_storage_password("password").await.unwrap();
+
+        let _ = crate::test_utils::AccountCreator::new(&manager).create().await;
+        assert_eq!(manager.get_accounts().await.unwrap().len(), 1);
+
+        manager.clear_storage_password().await.unwrap();
+        let storage_handle = crate::storage::get(manager.storage_path()).await.unwrap();
+        storage_handle
+            .lock()
+            .await
+            .storage
+            .remove_encryption_key_checksum()
+            .await
+            .unwrap();
+
+        manager.set_storage_password("password").await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn wrong_storage_password_without_kcv_and_all_accounts_deleted() {
+        let manager = crate::test_utils::get_account_manager().await;
+        manager.set_storage_password("password").await.unwrap();
+
+        let account_handle = crate::test_utils::AccountCreator::new(&manager).create().await;
+        assert_eq!(manager.get_accounts().await.unwrap().len(), 1);
+
+        manager
+            .remove_account(account_handle.read().await.id())
+            .await
+            .expect("failed to remove account");
+        manager.clear_storage_password().await.unwrap();
+        let storage_handle = crate::storage::get(manager.storage_path()).await.unwrap();
+        storage_handle
+            .lock()
+            .await
+            .storage
+            .remove_encryption_key_checksum()
+            .await
+            .unwrap();
+
+        match manager.set_storage_password("wrong-password").await.err().unwrap() {
+            crate::Error::RecordDecrypt(_) => {}
+            e => panic!("{:?}", e),
+        }
+    }
+
+    #[tokio::test]
+    async fn correct_storage_password_without_kcv_and_all_accounts_deleted() {
+        let manager = crate::test_utils::get_account_manager().await;
+        manager.set_storage_password("password").await.unwrap();
+
+        let account_handle = crate::test_utils::AccountCreator::new(&manager).create().await;
+        assert_eq!(manager.get_accounts().await.unwrap().len(), 1);
+
+        manager
+            .remove_account(account_handle.read().await.id())
+            .await
+            .expect("failed to remove account");
+        manager.clear_storage_password().await.unwrap();
+        let storage_handle = crate::storage::get(manager.storage_path()).await.unwrap();
+        storage_handle
+            .lock()
+            .await
+            .storage
+            .remove_encryption_key_checksum()
+            .await
+            .unwrap();
+
+        manager.set_storage_password("password").await.unwrap();
     }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -532,7 +532,6 @@ pub(crate) async fn is_key_valid(storage_path: &Path, encryption_key: &[u8; 32])
                 Ok(indexation) => match serde_json::from_str::<Vec<AccountIndexation>>(&indexation) {
                     Ok(_account_indexation) => {
                         // DB is not encrypted, or is it possible that someone already set the correct password?
-                        // Maybe come back to review this decision if we ever decide to have a `change_storage_password` function
                         Ok(true)
                     }
                     Err(_) => match decrypt_record(&indexation, encryption_key) {


### PR DESCRIPTION
# Description of change

- Add a function to clear storage encryption key, this will also unload already decrypted accounts from memory.
- When there are no accounts loaded into memory, verify provided password in `set_storage_password` by comparing generated key checksum value (KCV) with persisted KCV for correct password .
- Use account indexation metadata in DB to validate password if key checksum value is not available.

 

## Links to any relevant issues

Closes #867 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)


## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
