### PR TITLE
Rename ClientBuilder to ClientOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ In order to use the library you first need to create an `AccountManager`:
 
 ```rust
 use iota_wallet::{
-    account_manager::AccountManager, client::ClientBuilder, signing::SignerType,
+    account_manager::AccountManager, client::ClientOptions, signing::SignerType,
 };
 use std::path::PathBuf;
 
@@ -84,7 +84,7 @@ async fn main() -> iota_wallet::Result<()> {
             .with_storage(&storage_folder, None)
             .finish()
             .await?;
-    let client_options = ClientBuilder::new().with_node("https://api.lb-0.h.chrysalis-devnet.iota.cafe")?.build();
+    let client_options = ClientOptions::new().with_node("https://api.lb-0.h.chrysalis-devnet.iota.cafe")?.build();
     let account = manager
         .create_account(client_options)?
         .initialise()

--- a/bindings/java/examples/basic-app/src/main/java/org/example/ExampleApp.java
+++ b/bindings/java/examples/basic-app/src/main/java/org/example/ExampleApp.java
@@ -50,13 +50,13 @@ public class ExampleApp implements ErrorListener, StrongholdStatusListener {
 
         BrokerOptions mqtt = new BrokerOptions();
         
-        ClientBuilder ClientBuilder = new ClientBuilder()
+        ClientOptions ClientOptions = new ClientOptions()
             .withNode("https://api.lb-0.h.chrysalis-devnet.iota.cafe")
             .withMqttBrokerOptions(mqtt)
             .build();
         
         Account account = manager
-            .createAccount(ClientBuilder)
+            .createAccount(ClientOptions)
             .signerType(AccountSignerType.STRONGHOLD)
             .alias("alias1")
             .initialise();

--- a/bindings/java/examples/basic-app/src/main/java/org/example/Migration.java
+++ b/bindings/java/examples/basic-app/src/main/java/org/example/Migration.java
@@ -14,8 +14,8 @@ import org.iota.wallet.Account;
 import org.iota.wallet.AccountManager;
 import org.iota.wallet.AccountManagerBuilder;
 import org.iota.wallet.AccountSignerType;
-import org.iota.wallet.ClientBuilder;
-import org.iota.wallet.ClientBuilder;
+import org.iota.wallet.ClientOptions;
+import org.iota.wallet.ClientOptions;
 import org.iota.wallet.EventManager;
 import org.iota.wallet.InputData;
 import org.iota.wallet.MigrationBundle;
@@ -131,13 +131,13 @@ public class Migration implements MigrationProgressListener {
             manager.storeMnemonic(AccountSignerType.STRONGHOLD, mnemonic);
         
             // network migration6 for the migration testnet, otherwise leave out the network option for mainnet
-            ClientBuilder ClientBuilder = new ClientBuilder()
+            ClientOptions ClientOptions = new ClientOptions()
                 .withNode(CHRYSALIS_NODE)
                 .withNetwork("migration6")
                 .build();
         
             this.account = manager
-                .createAccount(ClientBuilder)
+                .createAccount(ClientOptions)
                 .alias("Migration")
                 .initialise();
         

--- a/bindings/java/native/src/classes/account/acc.rs
+++ b/bindings/java/native/src/classes/account/acc.rs
@@ -7,7 +7,7 @@ use crate::{
     acc_manager::AccountSignerType,
     sync::AccountSynchronizer,
     address::Address,
-    client_options::ClientBuilder,
+    client_options::ClientOptions,
     message::{Message, Transfer},
     types::NodeInfoWrapper,
     Result,
@@ -180,11 +180,11 @@ impl Account {
         }
     }
 
-    pub fn client_options(&self) -> ClientBuilder {
+    pub fn client_options(&self) -> ClientOptions {
         crate::block_on(async move { self.handle.client_options().await }).into()
     }
 
-    pub fn set_client_options(&self, options: ClientBuilder) -> Result<()> {
+    pub fn set_client_options(&self, options: ClientOptions) -> Result<()> {
         let opts = crate::block_on(async move { self.handle.set_client_options(options.to_inner()).await });
 
         match opts {

--- a/bindings/java/native/src/classes/account/client_options.rs
+++ b/bindings/java/native/src/classes/account/client_options.rs
@@ -4,8 +4,8 @@
 use std::{cell::RefCell, rc::Rc, time::Duration};
 
 use iota_wallet::client::{
-    Api, BrokerOptions as BrokerOptionsRust, ClientBuilder as ClientBuilderRust,
-    ClientBuilder as ClientBuilderRust,
+    Api, BrokerOptions as BrokerOptionsRust, ClientOptions as ClientOptionsRust,
+    ClientOptions as ClientOptionsRust,
 };
 
 use crate::Result;
@@ -61,12 +61,12 @@ impl BrokerOptions {
     }
 }
 
-pub struct ClientBuilder {
-    options: ClientBuilderRust,
+pub struct ClientOptions {
+    options: ClientOptionsRust,
 }
 
 
-impl core::fmt::Display for ClientBuilder {
+impl core::fmt::Display for ClientOptions {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> std::fmt::Result {
         write!(
             f,
@@ -76,44 +76,44 @@ impl core::fmt::Display for ClientBuilder {
     }
 }
 
-impl From<ClientBuilderRust> for ClientBuilder {
-    fn from(options: ClientBuilderRust) -> Self {
+impl From<ClientOptionsRust> for ClientOptions {
+    fn from(options: ClientOptionsRust) -> Self {
         Self {
             options
         }
     }
 }
 
-impl ClientBuilder {
-    pub fn to_inner(self) -> ClientBuilderRust {
+impl ClientOptions {
+    pub fn to_inner(self) -> ClientOptionsRust {
         self.options
     }
 }
 
-pub struct ClientBuilder {
-    builder: Rc<RefCell<Option<ClientBuilderRust>>>,
+pub struct ClientOptions {
+    builder: Rc<RefCell<Option<ClientOptionsRust>>>,
 }
 
-impl Default for ClientBuilder {
+impl Default for ClientOptions {
     fn default() -> Self {
         Self {
-            builder: Rc::new(RefCell::new(Option::from(ClientBuilderRust::default()))),
+            builder: Rc::new(RefCell::new(Option::from(ClientOptionsRust::default()))),
         }
     }
 }
 
-impl ClientBuilder {
+impl ClientOptions {
     pub fn new() -> Self {
         Self::default()
     }
 
-    fn new_with_builder(builder: ClientBuilderRust) -> Self {
+    fn new_with_builder(builder: ClientOptionsRust) -> Self {
         Self {
             builder: Rc::new(RefCell::new(Option::from(builder))),
         }
     }
 
-    pub fn with_primary_node(&mut self, node: &str) -> ClientBuilder {
+    pub fn with_primary_node(&mut self, node: &str) -> ClientOptions {
         let new_builder = self
             .builder
             .borrow_mut()
@@ -121,10 +121,10 @@ impl ClientBuilder {
             .unwrap()
             .with_primary_node(node)
             .unwrap();
-        ClientBuilder::new_with_builder(new_builder)
+        ClientOptions::new_with_builder(new_builder)
     }
 
-    pub fn with_primary_pow_node(&mut self, node: &str) -> ClientBuilder {
+    pub fn with_primary_pow_node(&mut self, node: &str) -> ClientOptions {
         let new_builder = self
             .builder
             .borrow_mut()
@@ -132,15 +132,15 @@ impl ClientBuilder {
             .unwrap()
             .with_primary_pow_node(node)
             .unwrap();
-        ClientBuilder::new_with_builder(new_builder)
+        ClientOptions::new_with_builder(new_builder)
     }
 
-    pub fn with_node(&mut self, node: &str) -> ClientBuilder {
+    pub fn with_node(&mut self, node: &str) -> ClientOptions {
         let new_builder = self.builder.borrow_mut().take().unwrap().with_node(node).unwrap();
-        ClientBuilder::new_with_builder(new_builder)
+        ClientOptions::new_with_builder(new_builder)
     }
 
-    pub fn with_node_pool_urls(&mut self, node_pool_urls: Vec<String>) -> ClientBuilder {
+    pub fn with_node_pool_urls(&mut self, node_pool_urls: Vec<String>) -> ClientOptions {
         let nodes_urls: Vec<&str> = node_pool_urls.iter().map(|x| &**x).collect();
         let new_builder = self
             .builder
@@ -149,62 +149,62 @@ impl ClientBuilder {
             .unwrap()
             .with_node_pool_urls(&nodes_urls)
             .unwrap();
-        ClientBuilder::new_with_builder(new_builder)
+        ClientOptions::new_with_builder(new_builder)
     }
 
-    pub fn with_network(&mut self, network: String) -> ClientBuilder {
+    pub fn with_network(&mut self, network: String) -> ClientOptions {
         let new_builder = self.builder.borrow_mut().take().unwrap().with_network(network);
-        ClientBuilder::new_with_builder(new_builder)
+        ClientOptions::new_with_builder(new_builder)
     }
 
-    pub fn with_node_sync_interval(&mut self, node_sync_interval: Duration) -> ClientBuilder {
+    pub fn with_node_sync_interval(&mut self, node_sync_interval: Duration) -> ClientOptions {
         let new_builder = self
             .builder
             .borrow_mut()
             .take()
             .unwrap()
             .with_node_sync_interval(node_sync_interval);
-        ClientBuilder::new_with_builder(new_builder)
+        ClientOptions::new_with_builder(new_builder)
     }
 
-    pub fn with_node_sync_disabled(&mut self) -> ClientBuilder {
+    pub fn with_node_sync_disabled(&mut self) -> ClientOptions {
         let new_builder = self.builder.borrow_mut().take().unwrap().with_node_sync_disabled();
-        ClientBuilder::new_with_builder(new_builder)
+        ClientOptions::new_with_builder(new_builder)
     }
 
-    pub fn with_mqtt_disabled(&mut self) -> ClientBuilder {
+    pub fn with_mqtt_disabled(&mut self) -> ClientOptions {
         let new_builder = self.builder.borrow_mut().take().unwrap().with_mqtt_disabled();
-        ClientBuilder::new_with_builder(new_builder)
+        ClientOptions::new_with_builder(new_builder)
     }
 
     /// Sets the MQTT broker options.
-    pub fn with_mqtt_mqtt_broker_options(&mut self, options: BrokerOptions) -> ClientBuilder {
+    pub fn with_mqtt_mqtt_broker_options(&mut self, options: BrokerOptions) -> ClientOptions {
         let new_builder = self
             .builder
             .borrow_mut()
             .take()
             .unwrap()
             .with_mqtt_mqtt_broker_options(options.builder.borrow_mut().take().unwrap());
-        ClientBuilder::new_with_builder(new_builder)
+        ClientOptions::new_with_builder(new_builder)
     }
 
-    pub fn with_local_pow(&mut self, local: bool) -> ClientBuilder {
+    pub fn with_local_pow(&mut self, local: bool) -> ClientOptions {
         let new_builder = self.builder.borrow_mut().take().unwrap().with_local_pow(local);
-        ClientBuilder::new_with_builder(new_builder)
+        ClientOptions::new_with_builder(new_builder)
     }
 
-    pub fn with_request_timeout(&mut self, timeout: Duration) -> ClientBuilder {
+    pub fn with_request_timeout(&mut self, timeout: Duration) -> ClientOptions {
         let new_builder = self.builder.borrow_mut().take().unwrap().with_request_timeout(timeout);
-        ClientBuilder::new_with_builder(new_builder)
+        ClientOptions::new_with_builder(new_builder)
     }
 
-    pub fn with_api_timeout(&mut self, api: Api, timeout: Duration) -> ClientBuilder {
+    pub fn with_api_timeout(&mut self, api: Api, timeout: Duration) -> ClientOptions {
         let new_builder = self.builder.borrow_mut().take().unwrap().with_api_timeout(api, timeout);
-        ClientBuilder::new_with_builder(new_builder)
+        ClientOptions::new_with_builder(new_builder)
     }
 
-    pub fn build(&mut self) -> Result<ClientBuilder> {
-        Ok(ClientBuilder {
+    pub fn build(&mut self) -> Result<ClientOptions> {
+        Ok(ClientOptions {
             options: self.builder.borrow_mut().take().unwrap().build().unwrap(),
         })
     }

--- a/bindings/java/native/src/classes/account_manager/acc_manager.rs
+++ b/bindings/java/native/src/classes/account_manager/acc_manager.rs
@@ -21,7 +21,7 @@ use std::{
 
 use crate::{
     acc::{Account, AccountInitialiser},
-    client_options::ClientBuilder,
+    client_options::ClientOptions,
     message::Message,
     sync::AccountsSynchronizer,
     types::{MigrationBundle, MigrationData, MigrationBundleOptions, MigrationAddress},
@@ -221,7 +221,7 @@ impl AccountManager {
         }
     }
 
-    pub fn create_account(&self, client_options: ClientBuilder) -> Result<AccountInitialiser> {
+    pub fn create_account(&self, client_options: ClientOptions) -> Result<AccountInitialiser> {
         match self.manager.create_account(client_options.to_inner()) {
             Err(e) => Err(anyhow!(e.to_string())),
             Ok(initialiser) => Ok(AccountInitialiser::new(initialiser)),

--- a/bindings/java/native/src/java_glue.rs.in
+++ b/bindings/java/native/src/java_glue.rs.in
@@ -257,7 +257,7 @@ foreign_class!(
         fn AccountManager::generate_mnemonic(&mut self) -> Result<String>; alias generateMnemonic;
         fn AccountManager::store_mnemonic(&mut self, signer_type_enum: AccountSignerType, mnemonic: String) -> Result<()>; alias storeMnemonic;
         fn AccountManager::verify_mnemonic(&mut self, mnemonic: String) -> Result<()>; alias verifyMnemonic;
-        fn AccountManager::create_account(&mut self, client_options: ClientBuilder) -> Result<AccountInitialiser>; alias createAccount;
+        fn AccountManager::create_account(&mut self, client_options: ClientOptions) -> Result<AccountInitialiser>; alias createAccount;
         fn AccountManager::remove_account(&self, account_id: String) -> Result<()>; alias removeAccount;
         fn AccountManager::get_account(&self, account_id: String) -> Result<Account>; alias getAccount;
         fn AccountManager::get_accounts(&self) -> Result<Vec<Account>>; alias getAccounts;
@@ -345,30 +345,30 @@ foreign_class!(class BrokerOptions {
     fn BrokerOptions::max_reconnection_attempts(&self, max_reconnection_attempts: usize) -> BrokerOptions; alias maxReconnectionAttempts;
 });
 
-foreign_class!(class ClientBuilder {
-    self_type ClientBuilder;
-    constructor ClientBuilder::new() -> ClientBuilder;
-    fn ClientBuilder::with_primary_node(&mut self, node: &str) -> ClientBuilder; alias withPrimaryNode;
-    fn ClientBuilder::with_primary_pow_node(&mut self, node: &str) -> ClientBuilder; alias withPrimaryPoWNode;
-    fn ClientBuilder::with_node(&mut self, node: &str) -> ClientBuilder; alias withNode;
-    fn ClientBuilder::with_node_pool_urls(&mut self, node_pool_urls: Vec<String>) -> ClientBuilder; alias withNodePoolUrls;
-    fn ClientBuilder::with_network(&mut self, network: String) -> ClientBuilder; alias withNetwork;
-    fn ClientBuilder::with_node_sync_interval(&mut self, node_sync_interval: Duration) -> ClientBuilder; alias withNodeSyncInterval;
-    fn ClientBuilder::with_node_sync_disabled(&mut self) -> ClientBuilder; alias withNodeSyncDisabled;
-    fn ClientBuilder::with_mqtt_disabled(&mut self) -> ClientBuilder; alias withMqttDisabled;
-    fn ClientBuilder::with_mqtt_mqtt_broker_options(&mut self, options: BrokerOptions) -> ClientBuilder; alias withMqttBrokerOptions;
-    fn ClientBuilder::with_local_pow(&mut self, local: bool) -> ClientBuilder; alias withLocalPow;
-    fn ClientBuilder::with_request_timeout(&mut self, timeout: Duration) -> ClientBuilder; alias withRequestTimeout;
-    fn ClientBuilder::with_api_timeout(&mut self, api: Api, timeout: Duration) -> ClientBuilder; alias withApiTimeout;
-    fn ClientBuilder::build(&mut self) -> Result<ClientBuilder>;
+foreign_class!(class ClientOptions {
+    self_type ClientOptions;
+    constructor ClientOptions::new() -> ClientOptions;
+    fn ClientOptions::with_primary_node(&mut self, node: &str) -> ClientOptions; alias withPrimaryNode;
+    fn ClientOptions::with_primary_pow_node(&mut self, node: &str) -> ClientOptions; alias withPrimaryPoWNode;
+    fn ClientOptions::with_node(&mut self, node: &str) -> ClientOptions; alias withNode;
+    fn ClientOptions::with_node_pool_urls(&mut self, node_pool_urls: Vec<String>) -> ClientOptions; alias withNodePoolUrls;
+    fn ClientOptions::with_network(&mut self, network: String) -> ClientOptions; alias withNetwork;
+    fn ClientOptions::with_node_sync_interval(&mut self, node_sync_interval: Duration) -> ClientOptions; alias withNodeSyncInterval;
+    fn ClientOptions::with_node_sync_disabled(&mut self) -> ClientOptions; alias withNodeSyncDisabled;
+    fn ClientOptions::with_mqtt_disabled(&mut self) -> ClientOptions; alias withMqttDisabled;
+    fn ClientOptions::with_mqtt_mqtt_broker_options(&mut self, options: BrokerOptions) -> ClientOptions; alias withMqttBrokerOptions;
+    fn ClientOptions::with_local_pow(&mut self, local: bool) -> ClientOptions; alias withLocalPow;
+    fn ClientOptions::with_request_timeout(&mut self, timeout: Duration) -> ClientOptions; alias withRequestTimeout;
+    fn ClientOptions::with_api_timeout(&mut self, api: Api, timeout: Duration) -> ClientOptions; alias withApiTimeout;
+    fn ClientOptions::build(&mut self) -> Result<ClientOptions>;
 });
 
 foreign_class!(
     #[derive(camelCaseAliases, Display)]
-    class ClientBuilder {
-        self_type ClientBuilder;
+    class ClientOptions {
+        self_type ClientOptions;
         private constructor = empty;
-        private fn ClientBuilder::to_string(&self) -> String; alias to_string;
+        private fn ClientOptions::to_string(&self) -> String; alias to_string;
     }
 );
 
@@ -589,8 +589,8 @@ foreign_class!(
         fn Account::is_latest_address_unused(&self) -> Result<bool>;
         fn Account::latest_address(&self) -> Address;
         fn Account::set_alias(&self, alias: String) -> Result<()>;
-        fn Account::client_options(&self) -> ClientBuilder;
-        fn Account::set_client_options(&self, options: ClientBuilder) -> Result<()>;
+        fn Account::client_options(&self) -> ClientOptions;
+        fn Account::set_client_options(&self, options: ClientOptions) -> Result<()>;
         fn Account::list_messages(&self, count: usize, from: usize, message_type: Option<MessageType>) -> Result<Vec<Message>>;
         fn Account::list_spent_addresses(&self) -> Result<Vec<Address>>;
         fn Account::list_unspent_addresses(&self) -> Result<Vec<Address>>;

--- a/bindings/nodejs/CHANGELOG.md
+++ b/bindings/nodejs/CHANGELOG.md
@@ -44,7 +44,7 @@
 
 - Added generateAddresses function.
   - [ee3c0fa0](https://github.com/iotaledger/wallet.rs/commit/ee3c0fa0ae12cf80161d351a9f0af83c7c49f4a6) Add generateAddresses change file ([#660](https://github.com/iotaledger/wallet.rs/pull/660)) on 2021-06-11
-- Added primaryNode and primaryPoWNode to the ClientBuilder.
+- Added primaryNode and primaryPoWNode to the ClientOptions.
   - [3d66485c](https://github.com/iotaledger/wallet.rs/commit/3d66485ca11d21fbd64fafec9e68b377235c8c9b) Bindings/primary node ([#629](https://github.com/iotaledger/wallet.rs/pull/629)) on 2021-06-10
 - Added startBackgroundSync.
   - [bd44d4b0](https://github.com/iotaledger/wallet.rs/commit/bd44d4b04c46f6560404761615f78ba36774d726) Expose start_background_sync ([#640](https://github.com/iotaledger/wallet.rs/pull/640)) on 2021-06-07
@@ -186,7 +186,7 @@
   - [eaf3763](https://github.com/iotaledger/wallet.rs/commit/eaf3763215c0f58513bfac0408ec8a573123e71d) feat(stronghold): check if mnemonic is already set, closes [#409](https://github.com/iotaledger/wallet.rs/pull/409) ([#486](https://github.com/iotaledger/wallet.rs/pull/486)) on 2021-03-31
 - Fixes address outputs syncing.
   - [67fd04f](https://github.com/iotaledger/wallet.rs/commit/67fd04fc7e27a9a6e33eb1851df6cbc29dd77022) fix(sync): fetch output from the node if local copy is unspent ([#454](https://github.com/iotaledger/wallet.rs/pull/454)) on 2021-03-21
-- The wallet now validates the nodes provided to the account creation and the `setClientBuilder` API.
+- The wallet now validates the nodes provided to the account creation and the `setClientOptions` API.
   - [a77fb60](https://github.com/iotaledger/wallet.rs/commit/a77fb60a26e8df5de79c5b3accc5412d93061af7) feat(account): add client options validation ([#404](https://github.com/iotaledger/wallet.rs/pull/404)) on 2021-03-09
 
 ## \[0.0.6]

--- a/bindings/nodejs/examples/1-create-account.js
+++ b/bindings/nodejs/examples/1-create-account.js
@@ -17,7 +17,7 @@ async function run() {
 
         const account = await manager.createAccount({
             // todo replace with https://api.lb-0.h.chrysalis-devnet.iota.cafe when the new faucet is working
-            ClientBuilder: {
+            ClientOptions: {
                 node: { url: 'https://api.lb-0.h.chrysalis-devnet.iota.cafe' },
                 localPow: true,
             },

--- a/bindings/nodejs/examples/binding_examples/1-create-account.js
+++ b/bindings/nodejs/examples/binding_examples/1-create-account.js
@@ -24,7 +24,7 @@ async function run() {
         if (!account) {
             manager.storeMnemonic(SignerType.Stronghold);
             account = manager.createAccount({
-                ClientBuilder: {
+                ClientOptions: {
                     node: { url: 'https://api.lb-0.h.chrysalis-devnet.iota.cafe' },
                     localPow: true,
                 },

--- a/bindings/nodejs/examples/message_examples/1-create-account.js
+++ b/bindings/nodejs/examples/message_examples/1-create-account.js
@@ -17,7 +17,7 @@ async function run() {
 
         const account = await manager.createAccount({
             // todo replace with https://api.lb-0.h.chrysalis-devnet.iota.cafe when the new faucet is working
-            ClientBuilder: {
+            ClientOptions: {
                 node: { url: 'https://api.lb-0.h.chrysalis-devnet.iota.cafe' },
                 localPow: true,
             },

--- a/bindings/nodejs/lib/binding/account.js
+++ b/bindings/nodejs/lib/binding/account.js
@@ -18,7 +18,7 @@ const {
     listMessages,
     listAddresses,
     setAlias,
-    setClientBuilder,
+    setClientOptions,
     getMessage,
     getAddress,
     getUnusedAddress,
@@ -93,8 +93,8 @@ class Account {
         return setAlias.apply(this.account, [alias]);
     }
 
-    setClientBuilder(options) {
-        return setClientBuilder.apply(this.account, [JSON.stringify(options)]);
+    setClientOptions(options) {
+        return setClientOptions.apply(this.account, [JSON.stringify(options)]);
     }
 
     getMessage(id) {

--- a/bindings/nodejs/lib/binding/accountManager.js
+++ b/bindings/nodejs/lib/binding/accountManager.js
@@ -20,7 +20,7 @@ const {
     generateMnemonic,
     removeAccount,
     syncAccounts,
-    setClientBuilderManager,
+    setClientOptionsManager,
     internalTransfer,
     isLatestAddressUnused,
     getBalanceChangeEvents,
@@ -67,8 +67,8 @@ class AccountManager {
         return removeAccount.apply(this.accountManager, [id]);
     }
 
-    setClientBuilder(options) {
-        return setClientBuilderManager.apply(this.accountManager, [
+    setClientOptions(options) {
+        return setClientOptionsManager.apply(this.accountManager, [
             JSON.stringify(options),
         ]);
     }

--- a/bindings/nodejs/lib/index.d.ts
+++ b/bindings/nodejs/lib/index.d.ts
@@ -166,7 +166,7 @@ export declare class Account {
   promote(messageId: string): Promise<Message>;
   consolidateOutputs(): Promise<Message[]>;
   setAlias(alias: string): void;
-  setClientBuilder(options: ClientBuilder): void;
+  setClientOptions(options: ClientOptions): void;
   getMessage(id: string): Message | undefined;
   getAddress(addressBech32: string): Address | undefined;
   generateAddress(): Address;
@@ -213,7 +213,7 @@ export declare interface Node {
   disabled?: boolean;
 }
 
-export declare interface ClientBuilder {
+export declare interface ClientOptions {
   primaryNode?: NodeUrl | Node;
   primaryPoWNode?: NodeUrl | Node;
   node?: NodeUrl | Node;
@@ -239,7 +239,7 @@ export declare enum SignerType {
 }
 
 export declare interface AccountToCreate {
-  ClientBuilder: ClientBuilder;
+  ClientOptions: ClientOptions;
   alias?: string;
   createdAt?: string;
   signerType?: SignerType;
@@ -309,7 +309,7 @@ export declare class AccountManager {
   backup(destination: string, password: string): string;
   importAccounts(source: string, password: string): void;
   isLatestAddressUnused(): Promise<boolean>;
-  setClientBuilder(options: ClientBuilder): void;
+  setClientOptions(options: ClientOptions): void;
   // events
   getBalanceChangeEvents(
     count?: number,

--- a/bindings/nodejs/lib/messages/account.js
+++ b/bindings/nodejs/lib/messages/account.js
@@ -95,10 +95,10 @@ class AccountForMessages {
         );
     }
 
-    async setClientBuilder(options) {
+    async setClientOptions(options) {
         return JSON.parse(
             await this.messageHandler.sendMessage({
-                cmd: 'SetClientBuilder',
+                cmd: 'SetClientOptions',
                 payload: options,
             }),
         );

--- a/bindings/nodejs/src/classes/account/mod.rs
+++ b/bindings/nodejs/src/classes/account/mod.rs
@@ -1,7 +1,7 @@
 // Copyright 2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::types::ClientBuilderDto;
+use crate::types::ClientOptionsDto;
 
 use std::{num::NonZeroU64, str::FromStr};
 
@@ -350,7 +350,7 @@ pub fn set_client_options(mut cx: FunctionContext) -> JsResult<JsUndefined> {
     );
 
     let client_options = cx.argument::<JsString>(0)?.value(&mut cx);
-    let client_options = serde_json::from_str::<ClientBuilderDto>(&client_options).unwrap();
+    let client_options = serde_json::from_str::<ClientOptionsDto>(&client_options).unwrap();
 
     let id = account_wrapper.account_id.clone();
 

--- a/bindings/nodejs/src/classes/account_manager/mod.rs
+++ b/bindings/nodejs/src/classes/account_manager/mod.rs
@@ -1,7 +1,7 @@
 // Copyright 2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::types::ClientBuilderDto;
+use crate::types::ClientOptionsDto;
 use std::{num::NonZeroU64, sync::Arc, time::Duration};
 
 use iota_wallet::{account::AccountIdentifier, account_manager::AccountManager, signing::SignerType, DateTime, Local};
@@ -26,8 +26,8 @@ impl Default for AccountSignerType {
 
 #[derive(Deserialize)]
 pub struct AccountToCreate {
-    #[serde(rename = "ClientBuilder")]
-    pub client_options: ClientBuilderDto,
+    #[serde(rename = "ClientOptions")]
+    pub client_options: ClientOptionsDto,
     pub alias: Option<String>,
     #[serde(rename = "createdAt")]
     pub created_at: Option<DateTime<Local>>,
@@ -643,7 +643,7 @@ pub fn set_client_options(mut cx: FunctionContext) -> JsResult<JsUndefined> {
             .downcast_or_throw::<JsBox<Arc<AccountManagerWrapper>>, FunctionContext>(&mut cx)?,
     );
     let client_options = cx.argument::<JsString>(0)?.value(&mut cx);
-    let client_options = serde_json::from_str::<ClientBuilderDto>(&client_options).unwrap();
+    let client_options = serde_json::from_str::<ClientOptionsDto>(&client_options).unwrap();
 
     let (sender, receiver) = channel();
     crate::RUNTIME.spawn(async move {

--- a/bindings/nodejs/src/lib.rs
+++ b/bindings/nodejs/src/lib.rs
@@ -112,7 +112,7 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function("listMessages", classes::account::list_messages)?;
     cx.export_function("listAddresses", classes::account::list_addresses)?;
     cx.export_function("setAlias", classes::account::set_alias)?;
-    cx.export_function("setClientBuilder", classes::account::set_client_options)?;
+    cx.export_function("setClientOptions", classes::account::set_client_options)?;
     cx.export_function("getMessage", classes::account::get_message)?;
     cx.export_function("getAddress", classes::account::get_address)?;
     cx.export_function("getUnusedAddress", classes::account::get_unused_address)?;
@@ -132,7 +132,7 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function("syncAccounts", classes::account_manager::sync_accounts)?;
     cx.export_function("createAccount", classes::account_manager::create_account)?;
     cx.export_function("internalTransfer", classes::account_manager::internal_transfer)?;
-    cx.export_function("setClientBuilderManager", classes::account_manager::set_client_options)?;
+    cx.export_function("setClientOptionsManager", classes::account_manager::set_client_options)?;
     cx.export_function(
         "isLatestAddressUnused",
         classes::account_manager::is_latest_address_unused,

--- a/bindings/nodejs/src/types.rs
+++ b/bindings/nodejs/src/types.rs
@@ -1,7 +1,7 @@
 // Copyright 2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_wallet::client::{Api, BrokerOptions, ClientBuilder, Node};
+use iota_wallet::client::{Api, BrokerOptions, ClientOptions, Node};
 use serde::Deserialize;
 use std::{collections::HashMap, path::PathBuf, time::Duration};
 use url::Url;
@@ -33,7 +33,7 @@ pub fn default_local_pow() -> bool {
 }
 
 #[derive(Deserialize)]
-pub struct ClientBuilderDto {
+pub struct ClientOptionsDto {
     #[serde(rename = "primaryNode")]
     pub primary_node: Option<NodeDto>,
     #[serde(rename = "primaryPoWNode")]
@@ -68,8 +68,8 @@ macro_rules! bind_client_option {
     }};
 }
 
-impl From<ClientBuilderDto> for ClientBuilder {
-    fn from(options: ClientBuilderDto) -> Self {
+impl From<ClientOptionsDto> for ClientOptions {
+    fn from(options: ClientOptionsDto) -> Self {
         let mut client_builder = Self::builder()
             .with_node_pool_urls(
                 &options

--- a/bindings/nodejs/tests/account.js
+++ b/bindings/nodejs/tests/account.js
@@ -17,7 +17,7 @@ async function run() {
   manager.storeMnemonic(SignerType.Stronghold);
 
   const account = manager.createAccount({
-    ClientBuilder: {
+    ClientOptions: {
       node: 'http://api.hornet-3.testnet.chrysalis2.com',
       requestTimeout: {
         secs: 5000,

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -103,7 +103,7 @@ Creat a new account.
 
 | Param          | Type                              | Default     | Description        |
 | -------------- | --------------------------------- | ----------- | ------------------ |
-| client_options | `[ClientBuilder](#ClientBuilder)` | `undefined` | The client options |
+| client_options | `[ClientOptions](#ClientOptions)` | `undefined` | The client options |
 
 Returns a constructed [AccountInitialiser](#accountinitialiser).
 
@@ -419,7 +419,7 @@ Returns the created UNIX timestamp.
 
 Returns the last synced UNIX timestamp.
 
-### client_options(): [ClientBuilder](#ClientBuilder)
+### client_options(): [ClientOptions](#ClientOptions)
 
 Returns the client options of this account.
 
@@ -534,7 +534,7 @@ Updates the account's client options.
 
 | Param   | Type                              | Default     | Description               |
 | ------- | --------------------------------- | ----------- | ------------------------- |
-| options | `[ClientBuilder](#ClientBuilder)` | `undefined` | The client options to set |
+| options | `[ClientOptions](#ClientOptions)` | `undefined` | The client options to set |
 
 ### message_count(message_type (optional)): int
 
@@ -871,7 +871,7 @@ account_balance = {
 }
 ```
 
-## ClientBuilder
+## ClientOptions
 
 A dict with the following key:value pairs.
 

--- a/bindings/python/native/src/classes/account.rs
+++ b/bindings/python/native/src/classes/account.rs
@@ -242,7 +242,7 @@ impl AccountHandle {
 
     /// Bridge to [Account#client_options](struct.Account.html#method.client_options).
     /// Return the client options of this account
-    fn client_options(&self) -> ClientBuilder {
+    fn client_options(&self) -> ClientOptions {
         crate::block_on(async { self.account_handle.client_options().await }).into()
     }
 
@@ -318,7 +318,7 @@ impl AccountHandle {
     }
 
     /// Bridge to [Account#set_client_options](struct.Account.html#method.set_client_options).
-    fn set_client_options(&self, options: ClientBuilder) -> Result<()> {
+    fn set_client_options(&self, options: ClientOptions) -> Result<()> {
         Ok(crate::block_on(async {
             self.account_handle.set_client_options(options.into()).await
         })?)

--- a/bindings/python/native/src/classes/account_manager.rs
+++ b/bindings/python/native/src/classes/account_manager.rs
@@ -231,7 +231,7 @@ impl AccountManager {
     }
 
     /// Adds a new account.
-    fn create_account(&self, client_options: ClientBuilder) -> Result<AccountInitialiser> {
+    fn create_account(&self, client_options: ClientOptions) -> Result<AccountInitialiser> {
         Ok(AccountInitialiser {
             account_initialiser: Some(self.account_manager.create_account(client_options.into())?),
             addresses: Default::default(),

--- a/bindings/python/native/src/types/message.rs
+++ b/bindings/python/native/src/types/message.rs
@@ -24,7 +24,7 @@ use iota_wallet::{
         Address as RustWalletAddress, AddressOutput as RustWalletAddressOutput, AddressWrapper as RustAddressWrapper,
         OutputKind as RustOutputKind,
     },
-    client::ClientBuilder as RustWalletClientBuilder,
+    client::ClientOptions as RustWalletClientOptions,
     message::{
         Message as RustWalletMessage, MessageMilestonePayloadEssence as RustWalletMilestonePayloadEssence,
         MessagePayload as RustWalletPayload, MessageTransactionPayload as RustWalletMessageTransactionPayload,
@@ -311,7 +311,7 @@ pub async fn to_rust_message(
     accounts: AccountStore,
     account_id: &str,
     account_addresses: &[RustWalletAddress],
-    client_options: &RustWalletClientBuilder,
+    client_options: &RustWalletClientOptions,
 ) -> Result<RustWalletMessage> {
     let mut parents = Vec::new();
     for parent in msg.parents {
@@ -463,7 +463,7 @@ pub async fn to_rust_payload(
     accounts: AccountStore,
     account_id: &str,
     account_addresses: &[RustWalletAddress],
-    client_options: &RustWalletClientBuilder,
+    client_options: &RustWalletClientOptions,
 ) -> Result<RustWalletPayload> {
     if let Some(transaction_payload) = &payload.transaction {
         let mut transaction = RustTransactionPayload::builder();

--- a/bindings/python/native/src/types/option.rs
+++ b/bindings/python/native/src/types/option.rs
@@ -3,7 +3,7 @@
 
 use dict_derive::{FromPyObject as DeriveFromPyObject, IntoPyObject as DeriveIntoPyObject};
 use iota_wallet::client::{
-    Api as RustApi, BrokerOptions as RustBrokerOptions, ClientBuilder as RustClientBuilder, Node as RustNode,
+    Api as RustApi, BrokerOptions as RustBrokerOptions, ClientOptions as RustClientOptions, Node as RustNode,
     NodeAuth as RustNodeAuth,
 };
 use std::{
@@ -66,7 +66,7 @@ impl From<RustNode> for Node {
 }
 
 #[derive(Debug, DeriveFromPyObject, DeriveIntoPyObject)]
-pub struct ClientBuilder {
+pub struct ClientOptions {
     pub primary_node: Option<Node>,
     pub primary_pow_node: Option<Node>,
     pub nodes: Option<Vec<Node>>,
@@ -110,9 +110,9 @@ impl From<BrokerOptions> for RustBrokerOptions {
     }
 }
 
-impl From<ClientBuilder> for RustClientBuilder {
-    fn from(client_options: ClientBuilder) -> Self {
-        let mut builder = RustClientBuilder::builder();
+impl From<ClientOptions> for RustClientOptions {
+    fn from(client_options: ClientOptions) -> Self {
+        let mut builder = RustClientOptions::builder();
         if let Some(primary_node) = client_options.primary_node {
             let primary_node: RustNode = primary_node.into();
             if let Some(auth) = primary_node.auth {
@@ -209,8 +209,8 @@ impl From<&RustBrokerOptions> for BrokerOptions {
     }
 }
 
-impl From<RustClientBuilder> for ClientBuilder {
-    fn from(client_options: RustClientBuilder) -> Self {
+impl From<RustClientOptions> for ClientOptions {
+    fn from(client_options: RustClientOptions) -> Self {
         Self {
             primary_node: client_options.primary_node().as_ref().map(|n| n.clone().into()),
             primary_pow_node: client_options.primary_pow_node().as_ref().map(|n| n.clone().into()),

--- a/documentation/docs/libraries/nodejs/api_reference.md
+++ b/documentation/docs/libraries/nodejs/api_reference.md
@@ -90,7 +90,7 @@ Creates a new account.
 | Param                 | Type                              | Default                   | Description                                              |
 | --------------------- | --------------------------------- | ------------------------- | -------------------------------------------------------- |
 | account               | `object`                          | `{}`                      | The account to be created                                |
-| account.ClientBuilder | `[ClientBuilder](#ClientBuilder)` | `undefined`               | The node configuration                                   |
+| account.ClientOptions | `[ClientOptions](#ClientOptions)` | `undefined`               | The node configuration                                   |
 | [account.mnemonic]    | `string`                          | `undefined`               | The account BIP39 mnemonic                               |
 | [account.alias]       | `string`                          | `Account ${index + 1}`    | The account alias                                        |
 | [account.createdAt]   | `string`                          | the current date and time | The ISO 8601 date string of the account creation         |
@@ -194,13 +194,13 @@ Determines whether all accounts have unused their latest address after syncing w
 
 Returns a promise resolving to the boolean value.
 
-### setClientBuilder(options)
+### setClientOptions(options)
 
 Updates the client options for all accounts.
 
 | Param   | Type                              | Default | Description                    |
 | ------- | --------------------------------- | ------- | ------------------------------ |
-| options | `[ClientBuilder](#ClientBuilder)` | `null`  | The new account client options |
+| options | `[ClientOptions](#ClientOptions)` | `null`  | The new account client options |
 
 ### generateMigrationAddress(address)
 
@@ -490,13 +490,13 @@ Updates the account alias.
 | ----- | -------- | ------- | --------------------- |
 | alias | `string` | `null`  | The new account alias |
 
-### setClientBuilder(options)
+### setClientOptions(options)
 
 Updates the account client options.
 
 | Param   | Type                              | Default | Description                    |
 | ------- | --------------------------------- | ------- | ------------------------------ |
-| options | `[ClientBuilder](#ClientBuilder)` | `null`  | The new account client options |
+| options | `[ClientOptions](#ClientOptions)` | `null`  | The new account client options |
 
 ### getMessage(messageId)
 
@@ -531,7 +531,7 @@ Returns the latest address (the one with the biggest keyIndex).
 Synchronizes the account addresses with the Tangle and returns the latest address in the account,
 which is an address without balance.
 
-## ClientBuilder
+## ClientOptions
 
 | Field               | Type                        | Default     | Description                                                                                              |
 | ------------------- | --------------------------- | ----------- | -------------------------------------------------------------------------------------------------------- |

--- a/documentation/docs/libraries/nodejs/examples.mdx
+++ b/documentation/docs/libraries/nodejs/examples.mdx
@@ -69,13 +69,13 @@ Once the backend storage has been created, individual accounts for individual us
 ```javascript
     let account = await manager.createAccount({
         alias: 'Alice',  // an unique id from your existing user
-        ClientBuilder: { node: 'https://api.lb-0.h.chrysalis-devnet.iota.cafe', localPow: false }
+        ClientOptions: { node: 'https://api.lb-0.h.chrysalis-devnet.iota.cafe', localPow: false }
     })
 ```
 
 Each account is related to a specific IOTA network (mainnet / testnet), which is referenced by a node properties such as node url.  In this example, the `Chrysalis` testnet balancer.
 
-For more information about _ClientBuilder_ , please refer to [Wallet NodeJs API Reference](api_reference.md).
+For more information about _ClientOptions_ , please refer to [Wallet NodeJs API Reference](api_reference.md).
 
  _Alias_ should be unique, and it can be any string that you see fit. The _alias_ is usually used to identify the account later on. Each account is also represented by an _index_ which is incremented by 1 every time new account is created. 
 Any account can be then referred to by its _index_ , _alias_ or one of its generated _addresses_ .

--- a/documentation/docs/libraries/python/api_reference.md
+++ b/documentation/docs/libraries/python/api_reference.md
@@ -112,7 +112,7 @@ Creat a new account.
 
 | Param          | Type                              | Default     | Description        |
 | -------------- | --------------------------------- | ----------- | ------------------ |
-| client_options | `[ClientBuilder](#ClientBuilder)` | `undefined` | The client options |
+| client_options | `[ClientOptions](#ClientOptions)` | `undefined` | The client options |
 
 Returns a constructed [AccountInitialiser](#accountinitialiser).
 
@@ -428,7 +428,7 @@ Returns the created UNIX timestamp.
 
 Returns the last synced UNIX timestamp.
 
-### client_options(): [ClientBuilder](#ClientBuilder)
+### client_options(): [ClientOptions](#ClientOptions)
 
 Returns the client options of this account.
 
@@ -543,7 +543,7 @@ Updates the account's client options.
 
 | Param   | Type                              | Default     | Description               |
 | ------- | --------------------------------- | ----------- | ------------------------- |
-| options | `[ClientBuilder](#ClientBuilder)` | `undefined` | The client options to set |
+| options | `[ClientOptions](#ClientOptions)` | `undefined` | The client options to set |
 
 ### message_count(message_type (optional)): int
 
@@ -880,7 +880,7 @@ account_balance = {
 }
 ```
 
-## ClientBuilder
+## ClientOptions
 
 A dict with the following key:value pairs.
 

--- a/documentation/docs/libraries/python/examples.mdx
+++ b/documentation/docs/libraries/python/examples.mdx
@@ -68,7 +68,7 @@ The `wallet.rs` library uses a model of individual accounts to separate individu
 
 Each account is related to a specific IOTA network (mainnet or testnet), which is referenced by node properties such as node url.  In this example, the `Chrysalis` testnet balancer.
 
-For more information about _client_options_ , please refer to [Wallet Python API Reference](api_reference.md#ClientBuilder).
+For more information about _client_options_ , please refer to [Wallet Python API Reference](api_reference.md#ClientOptions).
 
 <CodeBlock className="language-python">
   {b_create_account}

--- a/documentation/docs/libraries/rust/examples.mdx
+++ b/documentation/docs/libraries/rust/examples.mdx
@@ -42,7 +42,7 @@ manager.store_mnemonic(SignerType::Stronghold, None).await.unwrap();
 2. Create your account:
 
 ```rust
-let client_options = ClientBuilder::new()
+let client_options = ClientOptions::new()
     .with_node("https://api.lb-0.h.chrysalis-devnet.iota.cafe")?
     .build()
     .unwrap();

--- a/documentation/docs/libraries/rust/getting_started.md
+++ b/documentation/docs/libraries/rust/getting_started.md
@@ -72,7 +72,7 @@ iota-wallet = { git = "https://github.com/iotaledger/wallet.rs", branch = "dev" 
 In order to use the library, you first need to create an _AccountManager_ :
 
 ```rust
-use iota_wallet::{account_manager::AccountManager, client::ClientBuilder, signing::SignerType};
+use iota_wallet::{account_manager::AccountManager, client::ClientOptions, signing::SignerType};
 use std::path::PathBuf;
 
 #[tokio::main]
@@ -85,7 +85,7 @@ async fn main() -> iota_wallet::Result<()> {
     manager.set_stronghold_password("password").await?;
     // If no mnemonic is provided, then the Stronghold file is the only way for a backup
     manager.store_mnemonic(SignerType::Stronghold, None).await?;
-    let client_options = ClientBuilder::new()
+    let client_options = ClientOptions::new()
         .with_node("https://api.lb-0.h.chrysalis-devnet.iota.cafe")?
         .build()?;
     let account = manager

--- a/examples/accounts.rs
+++ b/examples/accounts.rs
@@ -6,7 +6,7 @@
 use iota_client::utils::request_funds_from_faucet;
 use iota_wallet::{
     account_manager::AccountManager,
-    client::ClientBuilder,
+    client::ClientOptions,
     logger::{init_logger, LevelFilter},
     signing::mnemonic::MnemonicSigner,
     Result,
@@ -18,7 +18,7 @@ async fn main() -> Result<()> {
     // Generates a wallet.log file with logs for debugging
     // init_logger("wallet.log", LevelFilter::Debug)?;
 
-    let client_options = ClientBuilder::new()
+    let client_options = ClientOptions::new()
         .with_node("http://localhost:14265")?
         .with_node_sync_disabled();
 

--- a/examples/address_generation.rs
+++ b/examples/address_generation.rs
@@ -6,7 +6,7 @@
 
 use iota_wallet::{
     account_manager::AccountManager,
-    client::ClientBuilder,
+    client::ClientOptions,
     logger::{init_logger, LevelFilter},
     signing::mnemonic::MnemonicSigner,
     Result,
@@ -18,7 +18,7 @@ async fn main() -> Result<()> {
     // Generates a wallet.log file with logs for debugging
     // init_logger("wallet.log", LevelFilter::Debug)?;
 
-    let client_options = ClientBuilder::new()
+    let client_options = ClientOptions::new()
         .with_node("http://localhost:14265")?
         .with_node_sync_disabled();
 

--- a/examples/background_syncing.rs
+++ b/examples/background_syncing.rs
@@ -5,7 +5,7 @@
 
 use iota_wallet::{
     account_manager::AccountManager,
-    client::ClientBuilder,
+    client::ClientOptions,
     logger::{init_logger, LevelFilter},
     signing::mnemonic::MnemonicSigner,
     Result,
@@ -17,7 +17,7 @@ async fn main() -> Result<()> {
     // Generates a wallet.log file with logs for debugging
     // init_logger("wallet.log", LevelFilter::Debug)?;
 
-    let client_options = ClientBuilder::new()
+    let client_options = ClientOptions::new()
         .with_node("http://localhost:14265")?
         .with_node_sync_disabled();
 

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -13,14 +13,14 @@ use iota_client::bee_message::{
 use iota_wallet::{
     account::{RemainderValueStrategy, TransferOptions},
     account_manager::AccountManager,
-    client::ClientBuilder,
+    client::ClientOptions,
     signing::mnemonic::MnemonicSigner,
     Result,
 };
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let client_options = ClientBuilder::new()
+    let client_options = ClientOptions::new()
         .with_node("http://localhost:14265")?
         .with_node_sync_disabled();
 

--- a/examples/ping.rs
+++ b/examples/ping.rs
@@ -13,7 +13,7 @@ use iota_client::bee_message::output::{
 use iota_wallet::{
     account::{RemainderValueStrategy, TransferOptions},
     account_manager::AccountManager,
-    client::ClientBuilder,
+    client::ClientOptions,
     logger::{init_logger, LevelFilter},
     signing::mnemonic::MnemonicSigner,
     Result,
@@ -24,7 +24,7 @@ async fn main() -> Result<()> {
     // Generates a wallet.log file with logs for debugging
     // init_logger("ping-wallet.log", LevelFilter::Debug)?;
 
-    let client_options = ClientBuilder::new()
+    let client_options = ClientOptions::new()
         .with_node("http://localhost:14265")?
         .with_node_sync_disabled();
 

--- a/examples/pong.rs
+++ b/examples/pong.rs
@@ -13,7 +13,7 @@ use iota_client::bee_message::output::{
 use iota_wallet::{
     account::{RemainderValueStrategy, TransferOptions},
     account_manager::AccountManager,
-    client::ClientBuilder,
+    client::ClientOptions,
     logger::{init_logger, LevelFilter},
     signing::mnemonic::MnemonicSigner,
     Result,
@@ -24,7 +24,7 @@ async fn main() -> Result<()> {
     // Generates a wallet.log file with logs for debugging
     // init_logger("pong-wallet.log", LevelFilter::Debug)?;
 
-    let client_options = ClientBuilder::new()
+    let client_options = ClientOptions::new()
         .with_node("http://localhost:14265")?
         .with_node_sync_disabled();
 

--- a/examples/recover_accounts.rs
+++ b/examples/recover_accounts.rs
@@ -5,7 +5,7 @@
 
 use iota_wallet::{
     account_manager::AccountManager,
-    client::ClientBuilder,
+    client::ClientOptions,
     logger::{init_logger, LevelFilter},
     signing::mnemonic::MnemonicSigner,
     Result,
@@ -17,7 +17,7 @@ async fn main() -> Result<()> {
     // Generates a wallet.log file with logs for debugging
     // init_logger("wallet.log", LevelFilter::Debug)?;
 
-    let client_options = ClientBuilder::new()
+    let client_options = ClientOptions::new()
         .with_node("http://localhost:14265")?
         .with_node_sync_disabled();
 

--- a/examples/split_funds.rs
+++ b/examples/split_funds.rs
@@ -10,7 +10,7 @@ use iota_client::bee_message::output::{
 use iota_wallet::{
     account::{RemainderValueStrategy, TransferOptions},
     account_manager::AccountManager,
-    client::ClientBuilder,
+    client::ClientOptions,
     logger::{init_logger, LevelFilter},
     signing::mnemonic::MnemonicSigner,
     Result,
@@ -22,7 +22,7 @@ async fn main() -> Result<()> {
     // Generates a wallet.log file with logs for debugging
     // init_logger("wallet.log", LevelFilter::Debug)?;
 
-    let client_options = ClientBuilder::new()
+    let client_options = ClientOptions::new()
         .with_node("http://localhost:14265")?
         .with_node_sync_disabled();
 

--- a/examples/threads.rs
+++ b/examples/threads.rs
@@ -15,7 +15,7 @@ use iota_client::bee_message::{
 use iota_wallet::{
     account::{RemainderValueStrategy, TransferOptions},
     account_manager::AccountManager,
-    client::ClientBuilder,
+    client::ClientOptions,
     logger::{init_logger, LevelFilter},
     signing::mnemonic::MnemonicSigner,
     Result,
@@ -26,7 +26,7 @@ async fn main() -> Result<()> {
     // Generates a wallet.log file with logs for debugging
     // init_logger("wallet.log", LevelFilter::Debug)?;
 
-    let client_options = ClientBuilder::new()
+    let client_options = ClientOptions::new()
         .with_node("http://localhost:14265")?
         .with_node_sync_disabled();
 

--- a/examples/wallet.rs
+++ b/examples/wallet.rs
@@ -13,7 +13,7 @@ use iota_client::bee_message::{
 use iota_wallet::{
     account::{RemainderValueStrategy, TransferOptions},
     account_manager::AccountManager,
-    client::ClientBuilder,
+    client::ClientOptions,
     logger::{init_logger, LevelFilter},
     signing::mnemonic::MnemonicSigner,
     Result,
@@ -25,7 +25,7 @@ async fn main() -> Result<()> {
     // Generates a wallet.log file with logs for debugging
     // init_logger("wallet.log", LevelFilter::Debug)?;
 
-    let client_options = ClientBuilder::new()
+    let client_options = ClientOptions::new()
         .with_node("http://localhost:14265")?
         .with_node_sync_disabled();
 
@@ -96,7 +96,7 @@ async fn main() -> Result<()> {
     println!("Balance: {:?}", balance);
 
     // // switch to mainnet
-    // let client_options = ClientBuilder::new()
+    // let client_options = ClientOptions::new()
     //     .with_node("https://chrysalis-nodes.iota.org/")?
     //     .with_node("https://chrysalis-nodes.iota.cafe/")?
     //     .with_node_sync_disabled()
@@ -108,7 +108,7 @@ async fn main() -> Result<()> {
     // println!("Balance: {:?}", account.balance().await?);
 
     // // switch back to testnet
-    // let client_options = ClientBuilder::new()
+    // let client_options = ClientOptions::new()
     //     .with_node("https://api.lb-0.h.chrysalis-devnet.iota.cafe")?
     //     .with_node("https://api.thin-hornet-0.h.chrysalis-devnet.iota.cafe")?
     //     .with_node("https://api.thin-hornet-1.h.chrysalis-devnet.iota.cafe")?

--- a/src/account_manager/builder.rs
+++ b/src/account_manager/builder.rs
@@ -5,7 +5,7 @@
 use crate::events::EventEmitter;
 #[cfg(feature = "storage")]
 use crate::storage::manager::ManagerStorage;
-use crate::{account::handle::AccountHandle, account_manager::AccountManager, client::ClientBuilder};
+use crate::{account::handle::AccountHandle, account_manager::AccountManager, client::ClientOptions};
 
 use iota_client::signing::{mnemonic::MnemonicSigner, SignerHandle};
 use serde::{Deserialize, Serialize};
@@ -22,7 +22,7 @@ use std::sync::{atomic::AtomicUsize, Arc};
 pub struct AccountManagerBuilder {
     #[cfg(feature = "storage")]
     storage_options: Option<StorageOptions>,
-    client_options: ClientBuilder,
+    client_options: ClientOptions,
     #[serde(default = "default_signer", skip_serializing, skip_deserializing)]
     signer: SignerHandle,
 }
@@ -56,7 +56,7 @@ impl Default for AccountManagerBuilder {
         Self {
             #[cfg(feature = "storage")]
             storage_options: None,
-            client_options: ClientBuilder::new()
+            client_options: ClientOptions::new()
                 // .with_node("https://api.lb-0.h.chrysalis-devnet.iota.cafe")
                 // .unwrap()
                 // .with_node("https://api.thin-hornet-0.h.chrysalis-devnet.iota.cafe")
@@ -77,7 +77,7 @@ impl AccountManagerBuilder {
         Default::default()
     }
     /// Set the IOTA client options.
-    pub fn with_client_options(mut self, options: ClientBuilder) -> Self {
+    pub fn with_client_options(mut self, options: ClientOptions) -> Self {
         self.client_options = options;
         self
     }

--- a/src/account_manager/mod.rs
+++ b/src/account_manager/mod.rs
@@ -16,7 +16,7 @@ use crate::{
         operations::syncing::SyncOptions,
         types::{AccountBalance, AccountIdentifier},
     },
-    client::ClientBuilder,
+    client::ClientOptions,
 };
 use builder::AccountManagerBuilder;
 use operations::{get_account, recover_accounts, start_background_syncing, verify_integrity};
@@ -42,7 +42,7 @@ pub struct AccountManager {
     pub(crate) accounts: Arc<RwLock<Vec<AccountHandle>>>,
     // 0 = not running, 1 = running, 2 = stopping
     pub(crate) background_syncing_status: Arc<AtomicUsize>,
-    pub(crate) client_options: Arc<RwLock<ClientBuilder>>,
+    pub(crate) client_options: Arc<RwLock<ClientOptions>>,
     pub(crate) signer: SignerHandle,
     #[cfg(feature = "events")]
     pub(crate) event_emitter: Arc<Mutex<EventEmitter>>,
@@ -91,7 +91,7 @@ impl AccountManager {
     }
 
     /// Sets the client options for all accounts, syncs them and sets the new bech32_hrp
-    pub async fn set_client_options(&self, options: ClientBuilder) -> crate::Result<()> {
+    pub async fn set_client_options(&self, options: ClientOptions) -> crate::Result<()> {
         log::debug!("[set_client_options]");
         let mut client_options = self.client_options.write().await;
         *client_options = options.clone();

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,7 +1,7 @@
 // Copyright 2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-pub use iota_client::{Client, ClientBuilder};
+pub use iota_client::{Client, ClientBuilder as ClientOptions};
 use once_cell::sync::Lazy;
 use tokio::sync::RwLock;
 
@@ -24,8 +24,8 @@ pub(crate) async fn get_client() -> crate::Result<Arc<Client>> {
     }
 }
 
-pub(crate) async fn set_client(client_builder: ClientBuilder) -> crate::Result<()> {
-    let client = client_builder.finish().await?;
+pub(crate) async fn set_client(client_options: ClientOptions) -> crate::Result<()> {
+    let client = client_options.finish().await?;
 
     let mut client_instance = client_instance().write().await;
     client_instance.replace(Arc::new(client));

--- a/tests/account_recovery.rs
+++ b/tests/account_recovery.rs
@@ -1,13 +1,13 @@
 // Copyright 2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_wallet::{account_manager::AccountManager, client::ClientBuilder, signing::mnemonic::MnemonicSigner, Result};
+use iota_wallet::{account_manager::AccountManager, client::ClientOptions, signing::mnemonic::MnemonicSigner, Result};
 
 // can't be run together with all other tests because there can be only one mnemonic at a time
 #[ignore]
 #[tokio::test]
 async fn account_recovery_empty() -> Result<()> {
-    let client_options = ClientBuilder::new()
+    let client_options = ClientOptions::new()
         .with_node("http://localhost:14265")?
         .with_node_sync_disabled();
 
@@ -30,7 +30,7 @@ async fn account_recovery_empty() -> Result<()> {
 #[ignore]
 #[tokio::test]
 async fn account_recovery_existing_accounts() -> Result<()> {
-    let client_options = ClientBuilder::new()
+    let client_options = ClientOptions::new()
         .with_node("http://localhost:14265")?
         .with_node_sync_disabled();
 
@@ -62,7 +62,7 @@ async fn account_recovery_existing_accounts() -> Result<()> {
 #[ignore]
 #[tokio::test]
 async fn account_recovery_with_balance() -> Result<()> {
-    let client_options = ClientBuilder::new()
+    let client_options = ClientOptions::new()
         .with_node("http://localhost:14265")?
         .with_node_sync_disabled();
 
@@ -98,7 +98,7 @@ async fn account_recovery_with_balance() -> Result<()> {
 #[ignore]
 #[tokio::test]
 async fn account_recovery_with_balance_and_empty_addresses() -> Result<()> {
-    let client_options = ClientBuilder::new()
+    let client_options = ClientOptions::new()
         .with_node("http://localhost:14265")?
         .with_node_sync_disabled();
 


### PR DESCRIPTION
# Description of change

Rename ClientBuilder to ClientOptions, because it's easier to understand for end users