### PR TITLE
Reuse address by default

### DIFF
--- a/examples/events.rs
+++ b/examples/events.rs
@@ -10,12 +10,7 @@ use iota_client::bee_message::{
         BasicOutputBuilder, Output,
     },
 };
-use iota_wallet::{
-    account::{RemainderValueStrategy, TransferOptions},
-    account_manager::AccountManager,
-    signing::mnemonic::MnemonicSigner,
-    ClientOptions, Result,
-};
+use iota_wallet::{account_manager::AccountManager, signing::mnemonic::MnemonicSigner, ClientOptions, Result};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -65,15 +60,7 @@ async fn main() -> Result<()> {
             .finish()?,
     )];
     // let res = account.send(outputs, None).await?;
-    let res = account
-        .send(
-            outputs,
-            Some(TransferOptions {
-                remainder_value_strategy: RemainderValueStrategy::ReuseAddress,
-                ..Default::default()
-            }),
-        )
-        .await?;
+    let res = account.send(outputs, None).await?;
     println!(
         "Transaction: {} Message sent: http://localhost:14265/api/v2/messages/{}",
         res.transaction_id,

--- a/examples/ping.rs
+++ b/examples/ping.rs
@@ -14,7 +14,6 @@ use iota_client::{
     request_funds_from_faucet,
 };
 use iota_wallet::{
-    account::{RemainderValueStrategy, TransferOptions},
     account_manager::AccountManager,
     logger::{init_logger, LevelFilter},
     signing::mnemonic::MnemonicSigner,
@@ -112,15 +111,7 @@ async fn main() -> Result<()> {
                             )))
                             .finish()?,
                     )];
-                    let res = ping_account_
-                        .send(
-                            outputs,
-                            Some(TransferOptions {
-                                remainder_value_strategy: RemainderValueStrategy::ReuseAddress,
-                                ..Default::default()
-                            }),
-                        )
-                        .await?;
+                    let res = ping_account_.send(outputs, None).await?;
                     println!(
                         "Message from thread {} sent: http://localhost:14265/api/v2/messages/{}",
                         n,

--- a/examples/pong.rs
+++ b/examples/pong.rs
@@ -14,7 +14,6 @@ use iota_client::{
     request_funds_from_faucet,
 };
 use iota_wallet::{
-    account::{RemainderValueStrategy, TransferOptions},
     account_manager::AccountManager,
     logger::{init_logger, LevelFilter},
     signing::mnemonic::MnemonicSigner,
@@ -112,15 +111,7 @@ async fn main() -> Result<()> {
                             )))
                             .finish()?,
                     )];
-                    let res = pong_account_
-                        .send(
-                            outputs,
-                            Some(TransferOptions {
-                                remainder_value_strategy: RemainderValueStrategy::ReuseAddress,
-                                ..Default::default()
-                            }),
-                        )
-                        .await?;
+                    let res = pong_account_.send(outputs, None).await?;
                     println!(
                         "Message from thread {} sent: http://localhost:14265/api/v2/messages/{}",
                         n,

--- a/examples/split_funds.rs
+++ b/examples/split_funds.rs
@@ -8,7 +8,6 @@ use iota_client::bee_message::output::{
     BasicOutputBuilder, Output,
 };
 use iota_wallet::{
-    account::{RemainderValueStrategy, TransferOptions},
     account_manager::AccountManager,
     logger::{init_logger, LevelFilter},
     signing::mnemonic::MnemonicSigner,
@@ -81,16 +80,7 @@ async fn main() -> Result<()> {
                 )
             })
             .collect();
-        match account
-            .send(
-                outputs,
-                Some(TransferOptions {
-                    remainder_value_strategy: RemainderValueStrategy::ReuseAddress,
-                    ..Default::default()
-                }),
-            )
-            .await
-        {
+        match account.send(outputs, None).await {
             Ok(res) => println!(
                 "Message sent: http://localhost:14265/api/v2/messages/{}",
                 res.message_id.expect("No message created yet")

--- a/examples/threads.rs
+++ b/examples/threads.rs
@@ -13,7 +13,6 @@ use iota_client::bee_message::{
     },
 };
 use iota_wallet::{
-    account::{RemainderValueStrategy, TransferOptions},
     account_manager::AccountManager,
     logger::{init_logger, LevelFilter},
     signing::mnemonic::MnemonicSigner,
@@ -74,15 +73,7 @@ async fn main() -> Result<()> {
                             )))
                             .finish()?,
                     )];
-                    let res = account_
-                        .send(
-                            outputs,
-                            Some(TransferOptions {
-                                remainder_value_strategy: RemainderValueStrategy::ReuseAddress,
-                                ..Default::default()
-                            }),
-                        )
-                        .await?;
+                    let res = account_.send(outputs, None).await?;
                     println!(
                         "Message from thread {} sent: http://localhost:14265/api/v2/messages/{}",
                         n,

--- a/examples/wallet.rs
+++ b/examples/wallet.rs
@@ -11,7 +11,6 @@ use iota_client::bee_message::{
     },
 };
 use iota_wallet::{
-    account::{RemainderValueStrategy, TransferOptions},
     account_manager::AccountManager,
     logger::{init_logger, LevelFilter},
     signing::mnemonic::MnemonicSigner,
@@ -75,15 +74,7 @@ async fn main() -> Result<()> {
             .finish()?,
     )];
     // let res = account.send(outputs, None).await?;
-    let res = account
-        .send(
-            outputs,
-            Some(TransferOptions {
-                remainder_value_strategy: RemainderValueStrategy::ReuseAddress,
-                ..Default::default()
-            }),
-        )
-        .await?;
+    let res = account.send(outputs, None).await?;
     println!(
         "Transaction: {} Message sent: http://localhost:14265/api/v2/messages/{}",
         res.transaction_id,

--- a/src/account/operations/transfer/options.rs
+++ b/src/account/operations/transfer/options.rs
@@ -33,7 +33,6 @@ pub enum RemainderValueStrategy {
 
 impl Default for RemainderValueStrategy {
     fn default() -> Self {
-        // ChangeAddress is the default because it's better for privacy than reusing an address.
-        Self::ChangeAddress
+        Self::ReuseAddress
     }
 }


### PR DESCRIPTION
# Description of change

Reuse address by default, because otherwise we create unnecessary many remainder addresses, which only slows down syncing and makes it harder to detect funds on recovery.
Privacy also doesn't get improved very much with it, because one can still connect the used address. To prevent connection addresses it's recommended to use multiple accounts.

## Type of change

- Enhancement (a non-breaking change which adds functionality)


## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
