### PR TITLE
Add native tokens sending and receiving support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ backtrace = { version = "0.3.62", default-features = false, features = ["std"] }
 futures = { version = "0.3.17", default-features = false }
 getset = { version = "0.1.1", default-features = false }
 hex = { version = "0.4.3", default-features = false }
-iota-client = { git = "https://github.com/iotaledger/iota.rs", rev = "2ab6678f248c3e9e6d71aad854c1419b9d0b43e0", default-features = false, features = ["async", "tls"] }
+iota-client = { git = "https://github.com/iotaledger/iota.rs", rev = "bb414aa95044207921ee21bac839e2221f0f071d", default-features = false, features = ["async", "tls"] }
 iota-crypto = { version = "0.9.1", default-features = false, features = ["std", "random", "sha", "pbkdf", "hmac", "bip39", "bip39-en", "chacha", "blake2b", "slip10"] }
 log = { version = "0.4.14", default-features = false }
 once_cell = { version = "1.8.0", default-features = false, features = ["std"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ backtrace = { version = "0.3.62", default-features = false, features = ["std"] }
 futures = { version = "0.3.17", default-features = false }
 getset = { version = "0.1.1", default-features = false }
 hex = { version = "0.4.3", default-features = false }
-iota-client = { git = "https://github.com/iotaledger/iota.rs", rev = "725bd9fda96d7e412c8a6b27e4d2b968b38bc754", default-features = false, features = ["async", "tls"] }
+iota-client = { git = "https://github.com/iotaledger/iota.rs", rev = "a5d7b2a9c200699758aeaebf8a31fbcc4eb126a8", default-features = false, features = ["async", "tls"] }
 iota-crypto = { version = "0.9.1", default-features = false, features = ["std", "random", "sha", "pbkdf", "hmac", "bip39", "bip39-en", "chacha", "blake2b", "slip10"] }
 log = { version = "0.4.14", default-features = false }
 once_cell = { version = "1.8.0", default-features = false, features = ["std"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ backtrace = { version = "0.3.62", default-features = false, features = ["std"] }
 futures = { version = "0.3.17", default-features = false }
 getset = { version = "0.1.1", default-features = false }
 hex = { version = "0.4.3", default-features = false }
-iota-client = { git = "https://github.com/iotaledger/iota.rs", rev = "a5d7b2a9c200699758aeaebf8a31fbcc4eb126a8", default-features = false, features = ["async", "tls"] }
+iota-client = { git = "https://github.com/iotaledger/iota.rs", rev = "725bd9fda96d7e412c8a6b27e4d2b968b38bc754", default-features = false, features = ["async", "tls"] }
 iota-crypto = { version = "0.9.1", default-features = false, features = ["std", "random", "sha", "pbkdf", "hmac", "bip39", "bip39-en", "chacha", "blake2b", "slip10"] }
 log = { version = "0.4.14", default-features = false }
 once_cell = { version = "1.8.0", default-features = false, features = ["std"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ backtrace = { version = "0.3.62", default-features = false, features = ["std"] }
 futures = { version = "0.3.17", default-features = false }
 getset = { version = "0.1.1", default-features = false }
 hex = { version = "0.4.3", default-features = false }
-iota-client = { git = "https://github.com/iotaledger/iota.rs", rev = "7299157617678654dd937da5a0aad40e55f7470f", default-features = false, features = ["async", "tls"] }
+iota-client = { git = "https://github.com/iotaledger/iota.rs", rev = "2ab6678f248c3e9e6d71aad854c1419b9d0b43e0", default-features = false, features = ["async", "tls"] }
 iota-crypto = { version = "0.9.1", default-features = false, features = ["std", "random", "sha", "pbkdf", "hmac", "bip39", "bip39-en", "chacha", "blake2b", "slip10"] }
 log = { version = "0.4.14", default-features = false }
 once_cell = { version = "1.8.0", default-features = false, features = ["std"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ backtrace = { version = "0.3.62", default-features = false, features = ["std"] }
 futures = { version = "0.3.17", default-features = false }
 getset = { version = "0.1.1", default-features = false }
 hex = { version = "0.4.3", default-features = false }
-iota-client = { git = "https://github.com/iotaledger/iota.rs", rev = "725bd9fda96d7e412c8a6b27e4d2b968b38bc754", default-features = false, features = ["async", "tls"] }
+iota-client = { git = "https://github.com/iotaledger/iota.rs", rev = "7299157617678654dd937da5a0aad40e55f7470f", default-features = false, features = ["async", "tls"] }
 iota-crypto = { version = "0.9.1", default-features = false, features = ["std", "random", "sha", "pbkdf", "hmac", "bip39", "bip39-en", "chacha", "blake2b", "slip10"] }
 log = { version = "0.4.14", default-features = false }
 once_cell = { version = "1.8.0", default-features = false, features = ["std"] }

--- a/examples/06_send_native_tokens.rs
+++ b/examples/06_send_native_tokens.rs
@@ -1,0 +1,52 @@
+// Copyright 2022 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! cargo run --example 06_send_native_tokens --release
+// In this example we will send native tokens
+// Rename `.env.example` to `.env` first
+
+use dotenv::dotenv;
+use iota_wallet::{
+    account_manager::AccountManager, iota_client::bee_message::output::TokenId, signing::stronghold::StrongholdSigner,
+    AddressNativeTokens, Result,
+};
+use primitive_types::U256;
+
+use std::{env, path::Path, str::FromStr};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // This example uses dotenv, which is not safe for use in production
+    dotenv().ok();
+    // Setup Stronghold signer
+    let signer = StrongholdSigner::try_new_signer_handle(
+        &env::var("STRONGHOLD_PASSWORD").unwrap(),
+        &Path::new("wallet.stronghold"),
+    )
+    .unwrap();
+
+    // Create the account manager
+    let manager = AccountManager::builder(signer).finish().await?;
+
+    // Get the account we generated with `01_create_wallet`
+    let account = manager.get_account("Alice").await?;
+
+    let outputs = vec![AddressNativeTokens {
+        address: "atoi1qqv5avetndkxzgr3jtrswdtz5ze6mag20s0jdqvzk4fwezve8q9vk92ryhu".to_string(),
+        native_tokens: vec![(
+            TokenId::from_str("089292bbb5129efe5e9bd767aa0a789d475b37047d0100000000000000000000000000000000")?,
+            U256::from(10),
+        )],
+        ..Default::default()
+    }];
+
+    let transfer_result = account.send_native_tokens(outputs, None).await?;
+
+    println!(
+        "Transaction: {} Message sent: http://localhost:14265/api/v2/messages/{}",
+        transfer_result.transaction_id,
+        transfer_result.message_id.expect("No message created yet")
+    );
+
+    Ok(())
+}

--- a/src/account/constants.rs
+++ b/src/account/constants.rs
@@ -12,4 +12,4 @@ pub(crate) const PARALLEL_REQUESTS_AMOUNT: usize = 500;
 
 /// ms before an account actually syncs with the network, before it just returns the previous syncing result
 /// this is done to prevent unnecessary simultaneous synchronizations
-pub(crate) const MIN_SYNC_INTERVAL: u128 = 5000;
+pub(crate) const MIN_SYNC_INTERVAL: u128 = 3000;

--- a/src/account/handle.rs
+++ b/src/account/handle.rs
@@ -16,7 +16,11 @@ use iota_client::{signing::SignerHandle, Client};
 
 use tokio::sync::{Mutex, RwLock};
 
-use std::{ops::Deref, sync::Arc};
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    ops::Deref,
+    sync::Arc,
+};
 
 /// A thread guard over an account, so we can lock the account during operations.
 #[derive(Debug, Clone)]

--- a/src/account/handle.rs
+++ b/src/account/handle.rs
@@ -16,11 +16,7 @@ use iota_client::{signing::SignerHandle, Client};
 
 use tokio::sync::{Mutex, RwLock};
 
-use std::{
-    collections::{hash_map::Entry, HashMap},
-    ops::Deref,
-    sync::Arc,
-};
+use std::{ops::Deref, sync::Arc};
 
 /// A thread guard over an account, so we can lock the account during operations.
 #[derive(Debug, Clone)]

--- a/src/account/operations/address_generation.rs
+++ b/src/account/operations/address_generation.rs
@@ -73,7 +73,11 @@ impl AccountHandle {
                 // from the client Doesn't work for offline creating, should we use the network from the
                 // GenerateAddressMetadata instead to use `iota` or `atoi`?
                 None => {
-                    let bech32_hrp = self.client.get_bech32_hrp().await?;
+                    let bech32_hrp = self
+                        .client
+                        .get_bech32_hrp()
+                        .await
+                        .unwrap_or_else(|_| "iota".to_string());
                     bech32_hrp
                 }
             }

--- a/src/account/operations/mod.rs
+++ b/src/account/operations/mod.rs
@@ -7,9 +7,13 @@ pub(crate) mod address_generation;
 pub(crate) mod balance;
 /// The module to find additional addresses with balance
 pub(crate) mod balance_finder;
+/// The module for the collection of outputs with [UnlockCondition]s, that aren't only [AddressUnlockCondition]
+pub(crate) mod output_collection;
 /// The module for the output consolidation
 pub(crate) mod output_consolidation;
 /// The module for synchronization of an account
 pub(crate) mod syncing;
+/// The module to get the local time
+pub(crate) mod time;
 /// The module for value transfers
 pub(crate) mod transfer;

--- a/src/account/operations/output_collection.rs
+++ b/src/account/operations/output_collection.rs
@@ -1,0 +1,280 @@
+// Copyright 2022 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    account::{
+        handle::AccountHandle,
+        operations::transfer::TransferResult,
+        types::{address::AddressWithBalance, OutputData},
+        TransferOptions,
+    },
+    Result,
+};
+
+use iota_client::bee_message::output::{
+    unlock_condition::{
+        AddressUnlockCondition, ExpirationUnlockCondition, StorageDepositReturnUnlockCondition, UnlockCondition,
+    },
+    BasicOutputBuilder, ByteCostConfigBuilder, NativeToken, Output, OutputId,
+};
+
+use std::collections::{hash_map::Entry, HashMap};
+
+impl AccountHandle {
+    /// Try to collect basic outputs that have additional unlock conditions to their [AddressUnlockCondition].
+    pub(crate) async fn collect_outputs(self: &AccountHandle) -> crate::Result<Vec<TransferResult>> {
+        log::debug!("[OUTPUT_COLLECTION] check if outputs can be collected");
+        let account = self.read().await;
+        let first_account_address = account
+            .public_addresses
+            .first()
+            .ok_or(crate::Error::FailedToGetRemainder)?
+            .clone();
+        let bech32_hrp = self.client.get_bech32_hrp().await?;
+        let output_consolidation_threshold = account.account_options.output_consolidation_threshold;
+        let (local_time, milestone_index) = self.get_time_and_milestone_checked().await?;
+
+        // Get outputs for the collect
+        let mut outputs_to_collect: Vec<OutputData> = Vec::new();
+        for (output_id, output_data) in &account.unspent_outputs {
+            // Don't use outputs that are locked for other transactions
+            if !account.locked_outputs.contains(output_id) {
+                if let Some(output) = account.outputs.get(output_id) {
+                    // Only collect basic outputs
+                    if let Output::Basic(basic_output) = &output.output {
+                        if can_output_be_unlocked_now(
+                            &account.addresses_with_balance,
+                            &output.output,
+                            local_time as u32,
+                            milestone_index,
+                        ) {
+                            outputs_to_collect.push(output_data.clone());
+                        }
+                    }
+                }
+            }
+        }
+        drop(account);
+
+        if outputs_to_collect.is_empty() {
+            log::debug!("[OUTPUT_COLLECTION] no outputs to collect");
+            return Ok(Vec::new());
+        }
+
+        let rent_structure = self.client.get_rent_structure().await?;
+        let byte_cost_config = ByteCostConfigBuilder::new()
+            .byte_cost(rent_structure.v_byte_cost)
+            .key_factor(rent_structure.v_byte_factor_key)
+            .data_factor(rent_structure.v_byte_factor_data)
+            .finish();
+
+        let mut collection_results = Vec::new();
+        // todo: remove magic number and get a value that works for the current signer (ledger is limited) and is <= max
+        // inputs Consideration for the ledger signer: outputs with expiration and storage deposit return unlock
+        // conditions might require more outputs, that's why I set it to 5 now, because even with duplicated
+        // output amount it will be low enough then
+        for outputs in outputs_to_collect.chunks(5) {
+            let mut outputs_to_send = Vec::new();
+            // Amount we get with the storage deposit subsstracted
+            let mut new_amount = 0;
+            let mut new_native_tokens = HashMap::new();
+            // check native tokens
+            for output_data in outputs {
+                // if expired we can send everything to us
+                if is_expired(&output_data.output, local_time as u32, milestone_index) {
+                    new_amount += output_data.output.amount();
+                    if let Some(native_tokens) = output_data.output.native_tokens() {
+                        for native_token in native_tokens.iter() {
+                            match new_native_tokens.entry(*native_token.token_id()) {
+                                Entry::Vacant(e) => {
+                                    e.insert(*native_token.amount());
+                                }
+                                Entry::Occupied(mut e) => {
+                                    *e.get_mut() += *native_token.amount();
+                                }
+                            }
+                        }
+                    }
+                } else {
+                    // if storage deposit return, we have to subtract this amount and create the return output
+                    let mut storage_deposit = false;
+                    let mut retun_amount = 0;
+                    if let Some(unlock_conditions) = output_data.output.unlock_conditions() {
+                        if let Some(UnlockCondition::StorageDepositReturn(sdr)) =
+                            unlock_conditions.get(StorageDepositReturnUnlockCondition::KIND)
+                        {
+                            storage_deposit = true;
+                            retun_amount = sdr.amount();
+                            // create return output
+                            outputs_to_send.push(Output::Basic(
+                                BasicOutputBuilder::new(retun_amount)?
+                                    .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(
+                                        *sdr.return_address(),
+                                    )))
+                                    .finish()?,
+                            ));
+                        }
+                    }
+                    if storage_deposit {
+                        // for own output
+                        new_amount += output_data.output.amount() - retun_amount;
+                        if let Some(native_tokens) = output_data.output.native_tokens() {
+                            for native_token in native_tokens.iter() {
+                                match new_native_tokens.entry(*native_token.token_id()) {
+                                    Entry::Vacant(e) => {
+                                        e.insert(*native_token.amount());
+                                    }
+                                    Entry::Occupied(mut e) => {
+                                        *e.get_mut() += *native_token.amount();
+                                    }
+                                }
+                            }
+                        }
+                    } else {
+                        new_amount += output_data.output.amount();
+                        if let Some(native_tokens) = output_data.output.native_tokens() {
+                            for native_token in native_tokens.iter() {
+                                match new_native_tokens.entry(*native_token.token_id()) {
+                                    Entry::Vacant(e) => {
+                                        e.insert(*native_token.amount());
+                                    }
+                                    Entry::Occupied(mut e) => {
+                                        *e.get_mut() += *native_token.amount();
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            // Create output with collected values
+            outputs_to_send.push(Output::Basic(
+                BasicOutputBuilder::new(new_amount)?
+                    .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(
+                        first_account_address.address.inner,
+                    )))
+                    .with_native_tokens(
+                        new_native_tokens
+                            .into_iter()
+                            .map(|(id, amount)| {
+                                NativeToken::new(id, amount).map_err(|e| crate::Error::ClientError(Box::new(e.into())))
+                            })
+                            .collect::<Result<Vec<NativeToken>>>()?,
+                    )
+                    .finish()?,
+            ));
+
+            match self
+                .send_transfer(
+                    outputs_to_send,
+                    Some(TransferOptions {
+                        skip_sync: true,
+                        custom_inputs: Some(outputs.iter().map(|o| o.output_id).collect::<Vec<OutputId>>()),
+                        ..Default::default()
+                    }),
+                    &byte_cost_config,
+                )
+                .await
+            {
+                Ok(res) => {
+                    log::debug!(
+                        "[OUTPUT_COLLECTION] Collection transaction created: msg_id: {:?} tx_id: {:?}",
+                        res.message_id,
+                        res.transaction_id
+                    );
+                    collection_results.push(res);
+                }
+                Err(e) => log::debug!("Output collection error: {}", e),
+            };
+        }
+
+        Ok(collection_results)
+    }
+}
+
+// Check if an output can be unlocked by one of the account addresses at the current time/milestone index
+fn can_output_be_unlocked_now(
+    account_addresses: &[AddressWithBalance],
+    output: &Output,
+    current_time: u32,
+    current_milestone: u32,
+) -> bool {
+    let mut can_be_unlocked = Vec::new();
+    if let Some(unlock_conditions) = output.unlock_conditions() {
+        for unlock_condition in unlock_conditions.iter() {
+            match unlock_condition {
+                UnlockCondition::Expiration(expiration) => {
+                    let mut ms_expired = false;
+                    let mut time_expired = false;
+                    // 0 gets ignored
+                    if *expiration.milestone_index() == 0 || *expiration.milestone_index() > current_milestone {
+                        ms_expired = true;
+                    }
+                    if expiration.timestamp() == 0 || expiration.timestamp() > current_time {
+                        time_expired = true;
+                    }
+                    // Check if the address which can unlock the output now is in the account
+                    if ms_expired && time_expired {
+                        // check return address
+                        can_be_unlocked.push(
+                            account_addresses
+                                .iter()
+                                .any(|a| a.address.inner == *expiration.return_address()),
+                        );
+                    } else {
+                        // check address unlock condition
+                        let can_unlocked = if let Some(UnlockCondition::Address(address_unlock_condition)) =
+                            unlock_conditions.get(AddressUnlockCondition::KIND)
+                        {
+                            account_addresses
+                                .iter()
+                                .any(|a| a.address.inner == *address_unlock_condition.address())
+                        } else {
+                            false
+                        };
+                        can_be_unlocked.push(can_unlocked);
+                    }
+                }
+                UnlockCondition::Timelock(timelock) => {
+                    let mut ms_reached = false;
+                    let mut time_reached = false;
+                    // 0 gets ignored
+                    if *timelock.milestone_index() == 0 || *timelock.milestone_index() > current_milestone {
+                        ms_reached = true;
+                    }
+                    if timelock.timestamp() == 0 || timelock.timestamp() > current_time {
+                        time_reached = true;
+                    }
+                    can_be_unlocked.push(ms_reached && time_reached);
+                }
+                _ => {}
+            }
+        }
+        // If one of the unlock conditions is not met, then we can't unlock it
+        !can_be_unlocked.contains(&false)
+    } else {
+        false
+    }
+}
+
+fn is_expired(output: &Output, current_time: u32, current_milestone: u32) -> bool {
+    if let Some(unlock_conditions) = output.unlock_conditions() {
+        if let Some(UnlockCondition::Expiration(expiration)) = unlock_conditions.get(ExpirationUnlockCondition::KIND) {
+            let mut ms_expired = false;
+            let mut time_expired = false;
+            // 0 gets ignored
+            if *expiration.milestone_index() == 0 || *expiration.milestone_index() > current_milestone {
+                ms_expired = true;
+            }
+            if expiration.timestamp() == 0 || expiration.timestamp() > current_time {
+                time_expired = true;
+            }
+            // Check if the address which can unlock the output now is in the account
+            ms_expired && time_expired
+        } else {
+            false
+        }
+    } else {
+        false
+    }
+}

--- a/src/account/operations/output_collection.rs
+++ b/src/account/operations/output_collection.rs
@@ -132,7 +132,7 @@ impl AccountHandle {
                     }
                     if storage_deposit {
                         // for own output subtract the return amount
-                        new_amount += output_data.output.amount()-return_amount;
+                        new_amount += output_data.output.amount() - return_amount;
                         if let Some(native_tokens) = output_data.output.native_tokens() {
                             for native_token in native_tokens.iter() {
                                 match new_native_tokens.entry(*native_token.token_id()) {

--- a/src/account/operations/syncing/addresses.rs
+++ b/src/account/operations/syncing/addresses.rs
@@ -79,12 +79,7 @@ impl AccountHandle {
                         let client = client;
                         // Get basic outputs
                         let mut output_ids = client
-                            .output_ids(vec![
-                                QueryParameter::Address(address.address.to_bech32()),
-                                // QueryParameter::HasExpirationCondition(false),
-                                // QueryParameter::HasTimelockCondition(false),
-                                // QueryParameter::HasStorageDepositReturnCondition(false),
-                            ])
+                            .output_ids(vec![QueryParameter::Address(address.address.to_bech32())])
                             .await?;
 
                         if sync_options.sync_aliases_and_nfts {

--- a/src/account/operations/syncing/addresses.rs
+++ b/src/account/operations/syncing/addresses.rs
@@ -16,7 +16,7 @@ impl AccountHandle {
     pub(crate) async fn get_addresses_to_sync(&self, options: &SyncOptions) -> crate::Result<Vec<AddressWithBalance>> {
         log::debug!("[SYNC] get_addresses_to_sync");
         let balance_sync_start_time = Instant::now();
-        
+
         let mut addresses_before_syncing = self.list_addresses().await?;
         // Filter addresses when address_start_index is not 0 so we skip these addresses
         // If we force syncing, we want to sync all addresses
@@ -208,10 +208,6 @@ impl AccountHandle {
                 outputs_data.extend(outputs.into_iter());
             }
         }
-        log::debug!(
-            "[SYNC] spent outputs: {:?}",
-            spent_outputs
-        );
         log::debug!(
             "[SYNC] finished get_address_output_ids in {:.2?}",
             address_outputs_start_time.elapsed()

--- a/src/account/operations/syncing/addresses.rs
+++ b/src/account/operations/syncing/addresses.rs
@@ -81,10 +81,9 @@ impl AccountHandle {
                         let mut output_ids = client
                             .output_ids(vec![
                                 QueryParameter::Address(address.address.to_bech32()),
-                                // todo: handle the following unlock conditions
-                                QueryParameter::HasExpirationCondition(false),
-                                QueryParameter::HasTimelockCondition(false),
-                                QueryParameter::HasStorageDepositReturnCondition(false),
+                                // QueryParameter::HasExpirationCondition(false),
+                                // QueryParameter::HasTimelockCondition(false),
+                                // QueryParameter::HasStorageDepositReturnCondition(false),
                             ])
                             .await?;
 
@@ -94,6 +93,7 @@ impl AccountHandle {
                                 client
                                     .nfts_output_ids(vec![
                                         QueryParameter::Address(address.address.to_bech32()),
+                                        // todo: handle the following unlock conditions
                                         QueryParameter::HasExpirationCondition(false),
                                         QueryParameter::HasTimelockCondition(false),
                                         QueryParameter::HasStorageDepositReturnCondition(false),

--- a/src/account/operations/syncing/addresses.rs
+++ b/src/account/operations/syncing/addresses.rs
@@ -16,7 +16,7 @@ impl AccountHandle {
     pub(crate) async fn get_addresses_to_sync(&self, options: &SyncOptions) -> crate::Result<Vec<AddressWithBalance>> {
         log::debug!("[SYNC] get_addresses_to_sync");
         let balance_sync_start_time = Instant::now();
-
+        
         let mut addresses_before_syncing = self.list_addresses().await?;
         // Filter addresses when address_start_index is not 0 so we skip these addresses
         // If we force syncing, we want to sync all addresses
@@ -208,6 +208,10 @@ impl AccountHandle {
                 outputs_data.extend(outputs.into_iter());
             }
         }
+        log::debug!(
+            "[SYNC] spent outputs: {:?}",
+            spent_outputs
+        );
         log::debug!(
             "[SYNC] finished get_address_output_ids in {:.2?}",
             address_outputs_start_time.elapsed()

--- a/src/account/operations/syncing/mod.rs
+++ b/src/account/operations/syncing/mod.rs
@@ -88,6 +88,18 @@ impl AccountHandle {
             }
         }
 
+        if options.try_collect_outputs {
+            // Only consolidates outputs for non ledger accounts, because they require approval from the user
+            match self.signer.signer_type {
+                #[cfg(feature = "ledger-nano")]
+                // don't automatically consolidate with ledger accounts, because they require approval from the user
+                SignerType::LedgerNano | SignerType::LedgerNanoSimulator => {}
+                _ => {
+                    self.try_collect_outputs().await?;
+                }
+            }
+        }
+
         // add a field to the sync options to also sync incoming transactions?
 
         // updates account with balances, output ids, outputs

--- a/src/account/operations/syncing/options.rs
+++ b/src/account/operations/syncing/options.rs
@@ -32,6 +32,10 @@ pub struct SyncOptions {
     // updated)
     #[serde(rename = "syncAllAddresses", default)]
     pub sync_all_addresses: bool,
+    // Automatically try to collect basic outputs that have additional unlock conditions to their
+    // [AddressUnlockCondition].
+    #[serde(rename = "tryCollectOutputs", default = "default_try_collect_outputs")]
+    pub try_collect_outputs: bool,
     // usually we skip syncing if it's called within a few ms, but if we change the client options we need to resync
     // this will also ignore `address_start_index` and sync all addresses
     #[serde(rename = "forceSyncing", default)]
@@ -54,6 +58,10 @@ fn default_sync_aliases_and_nfts() -> bool {
     true
 }
 
+fn default_try_collect_outputs() -> bool {
+    true
+}
+
 fn default_address_start_index() -> u32 {
     0
 }
@@ -72,6 +80,7 @@ impl Default for SyncOptions {
             sync_pending_transactions: true,
             sync_aliases_and_nfts: true,
             sync_all_addresses: false,
+            try_collect_outputs: true,
             force_syncing: false,
         }
     }

--- a/src/account/operations/time.rs
+++ b/src/account/operations/time.rs
@@ -1,0 +1,29 @@
+// Copyright 2022 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{account::AccountHandle, Error, Result};
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Max allowed difference between the local time and latest milestone time, 5 minutes in seconds
+const FIVE_MINUTES_IN_SECONDS: u64 = 300;
+
+impl AccountHandle {
+    /// Get the local time, but compare it to the time from the nodeinfo, if it's off more than 5 minutes, an error will
+    /// be returned
+    pub(crate) async fn get_time_and_milestone_checked(&self) -> Result<(u64, u32)> {
+        let local_time = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("Time went backwards")
+            .as_secs();
+        let status_response = self.client.get_info().await?.nodeinfo.status;
+        let latest_ms_timestamp = status_response.latest_milestone_timestamp;
+        // Check the local time is in the range of +-5 minutes of the node to prevent locking funds by accident
+        if !(latest_ms_timestamp - FIVE_MINUTES_IN_SECONDS..latest_ms_timestamp + FIVE_MINUTES_IN_SECONDS)
+            .contains(&local_time)
+        {
+            return Err(Error::TimeNotSynced(local_time, latest_ms_timestamp));
+        }
+        Ok((local_time, status_response.latest_milestone_index))
+    }
+}

--- a/src/account/operations/transfer/input_selection.rs
+++ b/src/account/operations/transfer/input_selection.rs
@@ -35,6 +35,16 @@ impl AccountHandle {
         // if custom inputs are provided we should only use them (validate if we have the outputs in this account and
         // that the amount is enough)
         if let Some(custom_inputs) = custom_inputs {
+            // Check that no input got already locked
+            for input in custom_inputs.iter() {
+                if account.locked_outputs.contains(&input.output_id()?) {
+                    return Err(crate::Error::CustomInputError(format!(
+                        "Provided custom input {} is already used in another transaction",
+                        input.output_id()?
+                    )));
+                }
+            }
+
             let selected_transaction_data =
                 try_select_inputs(custom_inputs, outputs, true, remainder_address, byte_cost_config).await?;
 

--- a/src/account/operations/transfer/input_selection.rs
+++ b/src/account/operations/transfer/input_selection.rs
@@ -62,12 +62,13 @@ impl AccountHandle {
             // check if not in pending transaction (locked_outputs) and if from the correct network
             if !output.is_spent && !account.locked_outputs.contains(output_id) && output.network_id == network_id {
                 if let Output::Basic(basic_output) = &output.output {
+                    // Only use outputs with a single unlock conditions, which is the [AddressUnlockCondition]
                     if basic_output.unlock_conditions().len() == 1 {
                         available_outputs.push(output.input_signing_data()?);
                     }
                 }
                 // Todo: handle other output types in such a way, that they don't get burned by accident
-                // Maybe don't handle it here, but add another `custom_inputs` fields for the interal, use when such
+                // Maybe don't handle it here, but add another `custom_inputs` fields for the internal use when such
                 // outputs should be added to the automatic input selection
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,3 +49,4 @@ pub use error::Error;
 pub type Result<T> = std::result::Result<T, Error>;
 
 pub use iota_client::{self, signing};
+pub use primitive_types::U256;


### PR DESCRIPTION
# Description of change

It's now possible to send and receive native tokens with expiration and storage deposit return unlock conditions.
During syncing, if try_collect_outputs is set to true in the SyncOptions, the wallet will go through basic outputs with timelock, expiration and storage deposit unlock conditions and if they can be unlocked then, transactions will be created to move them to the own address.

## Links to any relevant issues

This PR handles only basic outputs for https://github.com/iotaledger/wallet.rs/issues/883, alias, foundry and nft outputs need to be done with another PR.

## Type of change

- Enhancement (a non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

Example and two wallets sending each other native tokens.

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have checked that new and existing unit tests pass locally with my changes
