### PR TITLE
Improve syncing and fix unused internal address generation

### DIFF
--- a/.changes/syncing.md
+++ b/.changes/syncing.md
@@ -1,0 +1,6 @@
+---
+"nodejs-binding": patch
+---
+
+Reduce output requests. Skip processing unchanged addresses.
+Fix unused internal address generation.


### PR DESCRIPTION
# Description of change

Reduce output requests, by skipping outputs with known confirmation. Skip processing unchanged addresses.
Fix unused internal address generation.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Node.js script and Firefly

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have checked that new and existing unit tests pass locally with my changes
