### PR TITLE
Fix account ordering

### DIFF
--- a/examples/wallet.rs
+++ b/examples/wallet.rs
@@ -3,13 +3,6 @@
 
 //! cargo run --example wallet --release
 
-use iota_client::bee_message::{
-    address::Address,
-    output::{
-        unlock_condition::{AddressUnlockCondition, UnlockCondition},
-        BasicOutputBuilder, Output,
-    },
-};
 use iota_wallet::{
     account_manager::AccountManager, signing::mnemonic::MnemonicSigner, AddressAndAmount, ClientOptions, Result,
 };

--- a/tests/account_order.rs
+++ b/tests/account_order.rs
@@ -1,0 +1,27 @@
+// Copyright 2022 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use iota_wallet::{account_manager::AccountManager, signing::mnemonic::MnemonicSigner, ClientOptions, Result};
+
+#[tokio::test]
+async fn account_ordering() -> Result<()> {
+    let client_options = ClientOptions::new()
+        .with_node("http://localhost:14265")?
+        .with_node_sync_disabled();
+
+    // mnemonic without balance
+    let signer = MnemonicSigner::new("inhale gorilla deny three celery song category owner lottery rent author wealth penalty crawl hobby obtain glad warm early rain clutch slab august bleak")?;
+
+    let manager = AccountManager::builder(signer)
+        .with_client_options(client_options)
+        .with_storage_folder("test-storage/account_ordering")
+        .finish()
+        .await?;
+
+    for _ in 0..100 {
+        let _account = manager.create_account().finish().await?;
+    }
+    std::fs::remove_dir_all("test-storage/account_ordering").unwrap_or(());
+    manager.verify_integrity().await?;
+    Ok(())
+}

--- a/tests/account_recovery.rs
+++ b/tests/account_recovery.rs
@@ -3,8 +3,6 @@
 
 use iota_wallet::{account_manager::AccountManager, signing::mnemonic::MnemonicSigner, ClientOptions, Result};
 
-// can't be run together with all other tests because there can be only one mnemonic at a time
-#[ignore]
 #[tokio::test]
 async fn account_recovery_empty() -> Result<()> {
     let client_options = ClientOptions::new()
@@ -16,16 +14,18 @@ async fn account_recovery_empty() -> Result<()> {
 
     let manager = AccountManager::builder(signer)
         .with_client_options(client_options)
+        .with_storage_folder("test-storage/account_recovery_empty")
         .finish()
         .await?;
 
     let accounts = manager.recover_accounts(2, 2).await?;
+
+    std::fs::remove_dir_all("test-storage/account_recovery_empty").unwrap_or(());
     // accounts should be empty if no account was created before and no account was found with balance
     assert_eq!(0, accounts.len());
     Ok(())
 }
 
-// can't be run together with all other tests because there can be only one mnemonic at a time
 #[ignore]
 #[tokio::test]
 async fn account_recovery_existing_accounts() -> Result<()> {
@@ -56,7 +56,6 @@ async fn account_recovery_existing_accounts() -> Result<()> {
     Ok(())
 }
 
-// can't be run together with all other tests because there can be only one mnemonic at a time
 #[ignore]
 #[tokio::test]
 async fn account_recovery_with_balance() -> Result<()> {
@@ -91,7 +90,6 @@ async fn account_recovery_with_balance() -> Result<()> {
     Ok(())
 }
 
-// can't be run together with all other tests because there can be only one mnemonic at a time
 #[ignore]
 #[tokio::test]
 async fn account_recovery_with_balance_and_empty_addresses() -> Result<()> {


### PR DESCRIPTION
# Description of change

Fix account ordering, because the `HashSet` could every time return the account indexes in a different order

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

With many accounts and `verify_integrity()`

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
