### PR TITLE
652 - DOCS - Publish rust docs on gh pages

### DIFF
--- a/.github/workflows/deploy-docs-to-gh-pages.yml
+++ b/.github/workflows/deploy-docs-to-gh-pages.yml
@@ -1,67 +1,22 @@
-name: deploy
+name: Deploy Rust Docs to GH pages
 
-on:
-  pull_request:
-    branches: [dev, main ]
-  push:
-    branches: [dev, main ]
+on: workflow_dispatch
+
 
 jobs:
-  checks:
-    if: github.event_name != 'push'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
-        with:
-          node-version: '12.x'
-      - name: Test Build
-        run: |
-          cd documentation
-          if [ -e yarn.lock ]; then
-          yarn install --frozen-lockfile
-          elif [ -e package-lock.json ]; then
-          npm ci
-          else
-          npm i
-          fi
-          npm run build
   gh-release:
-    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
-        with:
-          node-version: '12.x'
-      - name: Build
-        run: |
-          cd documentation
-          if [ -e yarn.lock ]; then
-          yarn install --frozen-lockfile
-          elif [ -e package-lock.json ]; then
-          npm ci
-          else
-          npm i
-          fi
-          npm run build
-      - name: Install rust-docs with nightly toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-            profile: minimal
-            toolchain: nightly
-            override: true
-            components: rust-docs
       - name: Deploy Rust Docs
         run: |
           sudo apt-get update
           sudo apt-get install libudev-dev libusb-1.0-0-dev
           DOCFLAGS="--cfg docsrs" cargo +stable doc --all-features --document-private-items --no-deps --release
           mkdir -p ./documentation/build/rust
-          cp -r target/doc  ./documentation/build/rust
       - name: Release to GitHub Pages
         uses: iotaledger/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./documentation/build
+          publish_dir: ./target/doc
           cname: wallet-lib.docs.iota.org

--- a/.github/workflows/deploy-docs-to-gh-pages.yml
+++ b/.github/workflows/deploy-docs-to-gh-pages.yml
@@ -13,6 +13,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install libudev-dev libusb-1.0-0-dev
           DOCFLAGS="--cfg docsrs" cargo +stable doc --all-features --document-private-items --no-deps --release
+          rm -rf ./docs
+          echo "<meta http-equiv=\"refresh\" content=\"0; url=iota_wallet\">" > target/doc/index.html
       - name: Release to GitHub Pages
         uses: iotaledger/actions-gh-pages@v3
         with:

--- a/.github/workflows/deploy-docs-to-gh-pages.yml
+++ b/.github/workflows/deploy-docs-to-gh-pages.yml
@@ -17,4 +17,4 @@ jobs:
         uses: iotaledger/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./target/doc/iota_wallet/
+          publish_dir: ./target/doc/

--- a/.github/workflows/deploy-docs-to-gh-pages.yml
+++ b/.github/workflows/deploy-docs-to-gh-pages.yml
@@ -13,10 +13,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install libudev-dev libusb-1.0-0-dev
           DOCFLAGS="--cfg docsrs" cargo +stable doc --all-features --document-private-items --no-deps --release
-          mkdir -p ./documentation/build/rust
       - name: Release to GitHub Pages
         uses: iotaledger/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./target/doc
-          cname: wallet-lib.docs.iota.org
+          publish_dir: ./target/doc/iota_wallet/

--- a/.github/workflows/publish-rust-docs-on-gh-pages.yml
+++ b/.github/workflows/publish-rust-docs-on-gh-pages.yml
@@ -3,7 +3,7 @@ name:  Publish Rust Docs On GitHub Pages
 on:
   push:
     branches:
-      - mainnet
+      - production
 
 jobs:
   gh-release:

--- a/.github/workflows/publish-rust-docs-on-gh-pages.yml
+++ b/.github/workflows/publish-rust-docs-on-gh-pages.yml
@@ -1,21 +1,22 @@
-name: Deploy Rust Docs to GH pages
+name:  Publish Rust Docs On GitHub Pages
 
-on: workflow_dispatch
-
+on:
+  push:
+    branches:
+      - mainnet
 
 jobs:
   gh-release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Deploy Rust Docs
+      - name: Build Rust Docs
         run: |
           sudo apt-get update
           sudo apt-get install libudev-dev libusb-1.0-0-dev
           DOCFLAGS="--cfg docsrs" cargo +stable doc --all-features --document-private-items --no-deps --release
-          rm -rf ./docs
           echo "<meta http-equiv=\"refresh\" content=\"0; url=iota_wallet\">" > target/doc/index.html
-      - name: Release to GitHub Pages
+      - name: Publish Rust Docs On GitHub Pages
         uses: iotaledger/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-rust-docs-on-gh-pages.yml
+++ b/.github/workflows/publish-rust-docs-on-gh-pages.yml
@@ -14,10 +14,14 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install libudev-dev libusb-1.0-0-dev
+          # Build Docs
           DOCFLAGS="--cfg docsrs" cargo +stable doc --all-features --document-private-items --no-deps --release
+          # The doc root folder doesn't contain an index file.  This line creates one that redirects to the iota_wallet folder
           echo "<meta http-equiv=\"refresh\" content=\"0; url=iota_wallet\">" > target/doc/index.html
       - name: Publish Rust Docs On GitHub Pages
         uses: iotaledger/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./target/doc/
+          # Once devops has set up the publishing URL, please uncomment and update the next line
+          # cname: wallet-lib.docs.iota.org


### PR DESCRIPTION
# Description of change

Modified deploy to gh pages action to deploy the Rust docs instead of a wiki build. 

## Links to any relevant issues

https://github.com/iotaledger/wallet.rs/issues/652

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)
- Documentation Fix

## How the change has been tested

The action was tested in my fork.   [DEMO](https://lucas-tortora.github.io/wallet.rs/)

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

## Pending actions

- [ ] Verify URL and CNAME with dev ops
- [ ] Verify the action uses the correct trigger and branch
- [ ] It'd be great if we can remove the redirect from the generated index file on line 20 