### PR TITLE
Update workflows and syncing with sync_spent_outputs enabled

### DIFF
--- a/.changes/readingMessages.md
+++ b/.changes/readingMessages.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": patch
+---
+
+Fix reading messages from db.

--- a/.changes/spentOutputs.md
+++ b/.changes/spentOutputs.md
@@ -1,0 +1,6 @@
+---
+"nodejs-binding": patch
+---
+
+Sync outputs again, when syncing spent outputs is enabled.
+Update windows workflows so binaries are built again.

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-2019]
 
     steps:
     - uses: actions/checkout@v2
@@ -31,21 +31,21 @@ jobs:
 
     - name: Install LLVM and Clang (Windows) # required for bindgen to work, see https://github.com/rust-lang/rust-bindgen/issues/1797
       uses: KyleMayes/install-llvm-action@32c4866ebb71e0949e8833eb49beeebed48532bd
-      if: matrix.os == 'windows-latest'
+      if: matrix.os == 'windows-2019'
       with:
         version: "11.0"
         directory: ${{ runner.temp }}/llvm
       
     - name: Set LIBCLANG_PATH (Windows)
       run: echo "LIBCLANG_PATH=$((gcm clang).source -replace "clang.exe")" >> $env:GITHUB_ENV
-      if: matrix.os == 'windows-latest'
+      if: matrix.os == 'windows-2019'
 
     - name: Get current date
       run: echo "CURRENT_DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
       if: matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest'
 
     - name: Get current date
-      if: matrix.os == 'windows-latest'
+      if: matrix.os == 'windows-2019'
       run: echo "CURRENT_DATE=$(Get-Date -Format "yyyy-MM-dd")" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
     - name: Install required packages (Ubuntu)
@@ -97,7 +97,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-2019]
     
     steps:
       - uses: actions/checkout@v2
@@ -110,14 +110,14 @@ jobs:
       
       - name: Install LLVM and Clang (Windows) # required for bindgen to work, see https://github.com/rust-lang/rust-bindgen/issues/1797
         uses: KyleMayes/install-llvm-action@32c4866ebb71e0949e8833eb49beeebed48532bd
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2019'
         with:
           version: "11.0"
           directory: ${{ runner.temp }}/llvm
         
       - name: Set LIBCLANG_PATH (Windows)
         run: echo "LIBCLANG_PATH=$((gcm clang).source -replace "clang.exe")" >> $env:GITHUB_ENV
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2019'
 
       - name: Set up Node.js 14.x
         uses: actions/setup-node@v2
@@ -129,7 +129,7 @@ jobs:
         if: matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest'
 
       - name: Get current date
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2019'
         run: echo "CURRENT_DATE=$(Get-Date -Format "yyyy-MM-dd")" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Install required packages (Ubuntu)
@@ -162,7 +162,7 @@ jobs:
      
       - name: Cache nodejs binding cargo target
         uses: actions/cache@v2.1.4
-        if: matrix.os != 'windows-latest'
+        if: matrix.os != 'windows-2019'
         # We get a linker error on Windows when using the cache (LNK1181: cannot open input file 'node.lib')
         # https://github.com/iotaledger/wallet.rs/pull/467/checks?check_run_id=2214108362#step:11:41
         with:
@@ -185,7 +185,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-2019]
         python-version: [3.9]
 
     steps:
@@ -199,21 +199,21 @@ jobs:
 
     - name: Install LLVM and Clang (Windows) # required for bindgen to work, see https://github.com/rust-lang/rust-bindgen/issues/1797
       uses: KyleMayes/install-llvm-action@32c4866ebb71e0949e8833eb49beeebed48532bd
-      if: matrix.os == 'windows-latest'
+      if: matrix.os == 'windows-2019'
       with:
         version: "11.0"
         directory: ${{ runner.temp }}/llvm
       
     - name: Set LIBCLANG_PATH (Windows)
       run: echo "LIBCLANG_PATH=$((gcm clang).source -replace "clang.exe")" >> $env:GITHUB_ENV
-      if: matrix.os == 'windows-latest'
+      if: matrix.os == 'windows-2019'
 
     - name: Get current date
       run: echo "CURRENT_DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
       if: matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest'
 
     - name: Get current date
-      if: matrix.os == 'windows-latest'
+      if: matrix.os == 'windows-2019'
       run: echo "CURRENT_DATE=$(Get-Date -Format "yyyy-MM-dd")" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
     - name: Install required packages (Ubuntu)
@@ -274,19 +274,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-2019]
     steps:
       - uses: actions/checkout@v2
       - name: Install LLVM and Clang # required for bindgen to work, see https://github.com/rust-lang/rust-bindgen/issues/1797
         uses: KyleMayes/install-llvm-action@32c4866ebb71e0949e8833eb49beeebed48532bd
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2019'
         with:
           version: "11.0"
           directory: ${{ runner.temp }}/llvm
 
       - name: Set LIBCLANG_PATH
         run: echo "LIBCLANG_PATH=$((gcm clang).source -replace "clang.exe")" >> $env:GITHUB_ENV
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2019'
 
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
@@ -305,7 +305,7 @@ jobs:
         if: matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest'
 
       - name: Get current date
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2019'
         run: echo "CURRENT_DATE=$(Get-Date -Format "yyyy-MM-dd")" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Install required packages (Ubuntu)

--- a/.github/workflows/covector-version-or-publish.yml
+++ b/.github/workflows/covector-version-or-publish.yml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, macos-latest, windows-latest]
+        os: [ubuntu-18.04, macos-latest, windows-2019]
         node-version: ['10.x', '12.x', '14.x', '15.x', '16.x']
 
     steps:
@@ -75,21 +75,21 @@ jobs:
       
       - name: Install LLVM and Clang (Windows) # required for bindgen to work, see https://github.com/rust-lang/rust-bindgen/issues/1797
         uses: KyleMayes/install-llvm-action@32c4866ebb71e0949e8833eb49beeebed48532bd
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2019'
         with:
           version: "11.0"
           directory: ${{ runner.temp }}/llvm
       
       - name: Set LIBCLANG_PATH (Windows)
         run: echo "LIBCLANG_PATH=$((gcm clang).source -replace "clang.exe")" >> $env:GITHUB_ENV
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2019'
 
       - name: Get current date
         run: echo "CURRENT_DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
         if: matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest'
 
       - name: Get current date
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2019'
         run: echo "CURRENT_DATE=$(Get-Date -Format "yyyy-MM-dd")" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Install required packages (Ubuntu)
@@ -138,7 +138,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-2019]
 
     steps:
       - uses: actions/checkout@v2
@@ -156,21 +156,21 @@ jobs:
       
       - name: Install LLVM and Clang (Windows) # required for bindgen to work, see https://github.com/rust-lang/rust-bindgen/issues/1797
         uses: KyleMayes/install-llvm-action@32c4866ebb71e0949e8833eb49beeebed48532bd
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2019'
         with:
           version: "11.0"
           directory: ${{ runner.temp }}/llvm
       
       - name: Set LIBCLANG_PATH (Windows)
         run: echo "LIBCLANG_PATH=$((gcm clang).source -replace "clang.exe")" >> $env:GITHUB_ENV
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2019'
 
       - name: Get current date
         run: echo "CURRENT_DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
         if: matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest'
 
       - name: Get current date
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2019'
         run: echo "CURRENT_DATE=$(Get-Date -Format "yyyy-MM-dd")" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Install required packages (Ubuntu)

--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -546,13 +546,13 @@ async fn sync_addresses_and_messages(
                                     log::debug!("[SYNC] skip requesting spent output {}", output_id);
                                     address_output.replace(output);
                                 }
-                            } else {
+                            } else if !options.sync_spent_outputs {
                                 log::debug!(
                                     "[SYNC] skip requesting output {}, because we have it already",
                                     output_id
                                 );
-                                // If we have the output and it's still unspent, then we also don't need to request it
-                                // again, because nothing changed
+                                // If we have the output and it's still unspent, then we also don't need to request
+                                // it again, because nothing changed
                                 address_output.replace(output);
                             }
                         }


### PR DESCRIPTION
# Description of change

Update workflows and syncing with syncing spent outputs enabled, before it ignored syncing them again, but that should only happen if we don't sync spent outputs, because we then know that it's still unspent. But with syncing spent outputs we can't know it without requesting the output.
Fixes #913 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Firefly

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have checked that new and existing unit tests pass locally with my changes
