### PR TITLE
Save AccountManagerBuilder to db

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ backtrace = { version = "0.3.62", default-features = false, features = ["std"] }
 futures = { version = "0.3.17", default-features = false }
 getset = { version = "0.1.1", default-features = false }
 hex = { version = "0.4.3", default-features = false }
-iota-client = { git = "https://github.com/iotaledger/iota.rs", rev = "bb414aa95044207921ee21bac839e2221f0f071d", default-features = false, features = ["async", "tls"] }
+iota-client = { git = "https://github.com/iotaledger/iota.rs", rev = "178d937b0b4afd1d6d1d39f63f0243c1fa765286", default-features = false, features = ["async", "tls"] }
 iota-crypto = { version = "0.9.1", default-features = false, features = ["std", "random", "sha", "pbkdf", "hmac", "bip39", "bip39-en", "chacha", "blake2b", "slip10"] }
 log = { version = "0.4.14", default-features = false }
 once_cell = { version = "1.8.0", default-features = false, features = ["std"] }

--- a/src/account_manager/builder.rs
+++ b/src/account_manager/builder.rs
@@ -17,12 +17,12 @@ use tokio::sync::RwLock;
 use std::path::PathBuf;
 use std::sync::{atomic::AtomicUsize, Arc};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 /// Builder for the account manager.
 pub struct AccountManagerBuilder {
     #[cfg(feature = "storage")]
     storage_options: Option<StorageOptions>,
-    client_options: ClientOptions,
+    client_options: Option<ClientOptions>,
     #[serde(default, skip_serializing, skip_deserializing)]
     signer: Option<SignerHandle>,
 }
@@ -30,11 +30,11 @@ pub struct AccountManagerBuilder {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg(feature = "storage")]
 pub struct StorageOptions {
-    storage_folder: PathBuf,
-    storage_file_name: Option<String>,
+    pub(crate) storage_folder: PathBuf,
+    pub(crate) storage_file_name: Option<String>,
     // storage: ManagerStorage,
-    storage_encryption_key: Option<[u8; 32]>,
-    manager_store: ManagerStorage,
+    pub(crate) storage_encryption_key: Option<[u8; 32]>,
+    pub(crate) manager_store: ManagerStorage,
 }
 impl Default for StorageOptions {
     fn default() -> Self {
@@ -47,27 +47,6 @@ impl Default for StorageOptions {
     }
 }
 
-impl Default for AccountManagerBuilder {
-    fn default() -> Self {
-        Self {
-            #[cfg(feature = "storage")]
-            storage_options: None,
-            client_options: ClientOptions::new()
-                // .with_node("https://api.lb-0.h.chrysalis-devnet.iota.cafe")
-                // .unwrap()
-                // .with_node("https://api.thin-hornet-0.h.chrysalis-devnet.iota.cafe")
-                // .unwrap()
-                // .with_node("https://api.thin-hornet-1.h.chrysalis-devnet.iota.cafe")
-                // .unwrap()
-                // .with_node("https://chrysalis-nodes.iota.org/")?
-                .with_node("http://localhost:14265")
-                .unwrap()
-                .with_node_sync_disabled(),
-            signer: None,
-        }
-    }
-}
-
 impl AccountManagerBuilder {
     /// Initialises a new instance of the account manager builder with the default storage adapter.
     pub fn new(signer: SignerHandle) -> Self {
@@ -76,17 +55,21 @@ impl AccountManagerBuilder {
             ..Default::default()
         }
     }
+
     /// Set the IOTA client options.
-    pub fn with_client_options(mut self, options: ClientOptions) -> Self {
-        self.client_options = options;
+    pub fn with_client_options(mut self, client_options: ClientOptions) -> Self {
+        self.client_options.replace(client_options);
         self
     }
+
     /// Set the signer to be used.
     pub fn with_signer(mut self, signer: SignerHandle) -> Self {
         self.signer.replace(signer);
         self
     }
-    /// Set the signer type to be used.
+
+    #[cfg(feature = "storage")]
+    /// Set the storage folder to be used.
     pub fn with_storage_folder(mut self, folder: &str) -> Self {
         self.storage_options = Some(StorageOptions {
             storage_folder: folder.into(),
@@ -94,39 +77,58 @@ impl AccountManagerBuilder {
         });
         self
     }
+
     /// Builds the account manager
     #[allow(unreachable_code)]
     pub async fn finish(self) -> crate::Result<AccountManager> {
         #[cfg(feature = "storage")]
         {
-            let storage_folder = self.storage_options.unwrap_or_default().storage_folder;
-            let options = StorageOptions {
-                storage_folder: storage_folder.clone(),
-                storage_file_name: None,
-                // storage: ManagerStorage,
-                storage_encryption_key: None,
-                manager_store: ManagerStorage::Rocksdb,
-            };
-            let storage = crate::storage::adapter::rocksdb::RocksdbStorageAdapter::new(storage_folder.clone())?;
+            let storage_options = self.storage_options.clone().unwrap_or_default();
+
+            let storage =
+                crate::storage::adapter::rocksdb::RocksdbStorageAdapter::new(storage_options.storage_folder.clone())?;
             crate::storage::manager::set(
-                storage_folder.as_path(),
+                storage_options.storage_folder.as_path(),
                 None,
                 Box::new(storage) as Box<dyn crate::storage::adapter::StorageAdapter + Send + Sync>,
             )
             .await?;
+
             let data = crate::storage::manager::load_account_manager(
-                options.manager_store,
-                options.storage_folder,
-                options.storage_file_name,
+                storage_options.manager_store.clone(),
+                storage_options.storage_folder.clone(),
+                storage_options.storage_file_name.clone(),
             )
             .await?;
+
             let (client_options, signer) = match data.0 {
-                Some(data) => (data.client_options, data.signer.expect("Missing signer")),
-                None => (self.client_options, self.signer.expect("Missing signer")),
+                Some(data) => (
+                    data.client_options
+                        .ok_or(crate::Error::MissingParameter("ClientOptions"))?,
+                    // todo: can we get this from the read data? Maybe just with type and path for Stronghold?
+                    self.signer.ok_or(crate::Error::MissingParameter("Signer"))?,
+                ),
+                // If no account manager data exist, we will set it
+                None => {
+                    // Store account manager data in storage
+                    crate::storage::manager::get()
+                        .await?
+                        .lock()
+                        .await
+                        .save_account_manager_data(&self)
+                        .await?;
+                    (
+                        self.client_options
+                            .ok_or(crate::Error::MissingParameter("ClientOptions"))?,
+                        self.signer.ok_or(crate::Error::MissingParameter("Signer"))?,
+                    )
+                }
             };
             let client = client_options.clone().finish().await?;
+
             #[cfg(feature = "events")]
             let event_emitter = Arc::new(Mutex::new(EventEmitter::new()));
+
             return Ok(AccountManager {
                 #[cfg(not(feature = "events"))]
                 accounts: Arc::new(RwLock::new(data.1.into_iter().map(AccountHandle::new).collect())),
@@ -142,15 +144,21 @@ impl AccountManagerBuilder {
                 signer,
                 #[cfg(feature = "events")]
                 event_emitter,
+                storage_options,
             });
         }
         Ok(AccountManager {
             accounts: Arc::new(RwLock::new(Vec::new())),
             background_syncing_status: Arc::new(AtomicUsize::new(0)),
-            client_options: Arc::new(RwLock::new(self.client_options)),
-            signer: self.signer.expect("Missing signer"),
+            client_options: Arc::new(RwLock::new(
+                self.client_options
+                    .ok_or(crate::Error::MissingParameter("ClientOptions"))?,
+            )),
+            signer: self.signer.ok_or(crate::Error::MissingParameter("Signer"))?,
             #[cfg(feature = "events")]
             event_emitter: Arc::new(Mutex::new(EventEmitter::new())),
+            #[cfg(feature = "storage")]
+            storage_options: StorageOptions { ..Default::default() },
         })
     }
 }

--- a/src/account_manager/mod.rs
+++ b/src/account_manager/mod.rs
@@ -112,6 +112,11 @@ impl AccountManager {
         }
     }
 
+    /// Get the used client options
+    pub async fn get_client_options(&self) -> ClientOptions {
+        self.client_options.read().await.clone()
+    }
+
     /// Get the balance of all accounts added together
     pub async fn balance(&self) -> crate::Result<AccountBalance> {
         let mut balance = AccountBalance {

--- a/src/account_manager/mod.rs
+++ b/src/account_manager/mod.rs
@@ -4,6 +4,8 @@
 pub(crate) mod builder;
 pub(crate) mod operations;
 
+#[cfg(feature = "storage")]
+use crate::account_manager::builder::StorageOptions;
 #[cfg(feature = "events")]
 use crate::events::{
     types::{Event, WalletEventType},
@@ -42,6 +44,8 @@ pub struct AccountManager {
     pub(crate) signer: SignerHandle,
     #[cfg(feature = "events")]
     pub(crate) event_emitter: Arc<Mutex<EventEmitter>>,
+    #[cfg(feature = "storage")]
+    pub(crate) storage_options: StorageOptions,
 }
 
 impl AccountManager {
@@ -79,12 +83,33 @@ impl AccountManager {
         log::debug!("[set_client_options]");
         let mut client_options = self.client_options.write().await;
         *client_options = options.clone();
-        let new_client = options.finish().await?;
+        let new_client = options.clone().finish().await?;
         let mut accounts = self.accounts.write().await;
         for account in accounts.iter_mut() {
             account.update_account_with_new_client(new_client.clone()).await?;
         }
-        Ok(())
+        #[cfg(feature = "storage")]
+        {
+            // Update account manager data with new client options
+            let account_manager_builder = AccountManagerBuilder::new(self.signer.clone())
+                .with_storage_folder(
+                    &self
+                        .storage_options
+                        .storage_folder
+                        .clone()
+                        .into_os_string()
+                        .into_string()
+                        .expect("Can't convert os string"),
+                )
+                .with_client_options(options);
+
+            crate::storage::manager::get()
+                .await?
+                .lock()
+                .await
+                .save_account_manager_data(&account_manager_builder)
+                .await
+        }
     }
 
     /// Get the balance of all accounts added together

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,27 +17,15 @@ pub enum Error {
     /// iota.rs error.
     #[error("`{0}`")]
     ClientError(Box<iota_client::Error>),
-    /// Message not found.
-    #[error("message not found")]
-    MessageNotFound,
-    /// Message id length response invalid.
-    #[error("unexpected message_id length")]
-    InvalidMessageIdLength,
     /// failed to parse address.
     #[error("invalid address")]
     InvalidAddress,
-    /// Address length response invalid.
-    #[error("invalid address length")]
-    InvalidAddressLength,
     /// Tried to backup but storage file doesn't exist.
     #[error("storage file doesn't exist")]
     StorageDoesntExist,
     /// Insufficient funds to send transfer.
     #[error("insufficient funds {0}/{1} available")]
     InsufficientFunds(u64, u64),
-    /// Account isn't empty (has history or balance) - can't delete account.
-    #[error("can't delete account: account has history or balance")]
-    AccountNotEmpty,
     /// Latest account is empty (doesn't have history and balance) - can't create account.
     #[error("can't create accounts when the latest account doesn't have message history and balance")]
     LatestAccountIsEmpty,
@@ -47,10 +35,6 @@ pub enum Error {
     /// Record not found
     #[error("Record not found")]
     RecordNotFound,
-    /// invalid remainder value target address defined on `RemainderValueStrategy`.
-    /// the address must belong to the account.
-    #[error("the remainder value address doesn't belong to the account")]
-    InvalidRemainderValueAddress,
     /// Storage access error.
     #[error("error accessing storage: {0}")]
     Storage(String),
@@ -97,6 +81,9 @@ pub enum Error {
     /// Invalid output kind.
     #[error("invalid output kind: {0}")]
     InvalidOutputKind(String),
+    /// Missing parameter.
+    #[error("missing parameter: {0}")]
+    MissingParameter(&'static str),
     /// Failed to get remainder
     #[error("failed to get remainder address")]
     FailedToGetRemainder,
@@ -176,17 +163,12 @@ impl serde::Serialize for Error {
             Self::IoError(_) => serialize_variant(self, serializer, "IoError"),
             Self::JsonError(_) => serialize_variant(self, serializer, "JsonError"),
             Self::ClientError(_) => serialize_variant(self, serializer, "ClientError"),
-            Self::MessageNotFound => serialize_variant(self, serializer, "MessageNotFound"),
-            Self::InvalidMessageIdLength => serialize_variant(self, serializer, "InvalidMessageIdLength"),
             Self::InvalidAddress => serialize_variant(self, serializer, "InvalidAddress"),
-            Self::InvalidAddressLength => serialize_variant(self, serializer, "InvalidAddressLength"),
             Self::StorageDoesntExist => serialize_variant(self, serializer, "StorageDoesntExist"),
             Self::InsufficientFunds(..) => serialize_variant(self, serializer, "InsufficientFunds"),
-            Self::AccountNotEmpty => serialize_variant(self, serializer, "AccountNotEmpty"),
             Self::LatestAccountIsEmpty => serialize_variant(self, serializer, "LatestAccountIsEmpty"),
             Self::AccountNotFound => serialize_variant(self, serializer, "AccountNotFound"),
             Self::RecordNotFound => serialize_variant(self, serializer, "RecordNotFound"),
-            Self::InvalidRemainderValueAddress => serialize_variant(self, serializer, "InvalidRemainderValueAddress"),
             Self::Storage(_) => serialize_variant(self, serializer, "Storage"),
             Self::Panic(_) => serialize_variant(self, serializer, "Panic"),
             Self::BeeMessage(_) => serialize_variant(self, serializer, "BeeMessage"),
@@ -201,6 +183,7 @@ impl serde::Serialize for Error {
             Self::StorageIsEncrypted => serialize_variant(self, serializer, "StorageIsEncrypted"),
             Self::AccountAliasAlreadyExists => serialize_variant(self, serializer, "AccountAliasAlreadyExists"),
             Self::InvalidOutputKind(_) => serialize_variant(self, serializer, "InvalidOutputKind"),
+            Self::MissingParameter(_) => serialize_variant(self, serializer, "MissingParameter"),
             Self::FailedToGetRemainder => serialize_variant(self, serializer, "FailedToGetRemainder"),
             Self::TooManyOutputs(..) => serialize_variant(self, serializer, "TooManyOutputs"),
             Self::TooManyInputs(..) => serialize_variant(self, serializer, "TooManyInputs"),

--- a/src/storage/manager.rs
+++ b/src/storage/manager.rs
@@ -128,7 +128,18 @@ impl StorageManager {
         self.storage.get(key).await
     }
 
+    pub async fn save_account_manager_data(
+        &mut self,
+        account_manager_builder: &AccountManagerBuilder,
+    ) -> crate::Result<()> {
+        log::debug!("save_account_manager_data");
+        self.storage
+            .set(ACCOUNT_MANAGER_INDEXATION_KEY, account_manager_builder)
+            .await
+    }
+
     pub async fn get_account_manager_data(&mut self) -> crate::Result<AccountManagerBuilder> {
+        log::debug!("get_account_manager_data");
         let data = self.storage.get(ACCOUNT_MANAGER_INDEXATION_KEY).await?;
         let builder: AccountManagerBuilder = serde_json::from_str(&data)?;
         Ok(builder)

--- a/tests/account_manager.rs
+++ b/tests/account_manager.rs
@@ -1,0 +1,35 @@
+// Copyright 2022 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use iota_client::node_manager::node::{Node, NodeDto, Url};
+use iota_wallet::{account_manager::AccountManager, signing::mnemonic::MnemonicSigner, ClientOptions, Result};
+
+#[tokio::test]
+async fn stored_account_manager_data() -> Result<()> {
+    let client_options = ClientOptions::new().with_node("http://some-not-default-node:14265")?;
+
+    // mnemonic without balance
+    let signer = MnemonicSigner::new("inhale gorilla deny three celery song category owner lottery rent author wealth penalty crawl hobby obtain glad warm early rain clutch slab august bleak")?;
+
+    let manager = AccountManager::builder(signer.clone())
+        .with_client_options(client_options)
+        .with_storage_folder("test-storage/stored_account_manager_data")
+        .finish()
+        .await?;
+
+    // todo: enable when https://github.com/iotaledger/wallet.rs/issues/942 is done
+    // drop(manager);
+    // // Recreate AccountManager without providing client options
+    // let manager = AccountManager::builder(signer)
+    //     .with_storage_folder("test-storage/stored_account_manager_data")
+    //     .finish()
+    //     .await?;
+    let client_options = manager.get_client_options().await;
+
+    let node_dto = NodeDto::Node(Node::from(Url::parse("http://some-not-default-node:14265").unwrap()));
+
+    assert!(client_options.node_manager_builder.nodes.contains(&node_dto));
+
+    std::fs::remove_dir_all("test-storage/stored_account_manager_data").unwrap_or(());
+    Ok(())
+}


### PR DESCRIPTION
# Description of change

Save AccountManagerBuilder to db so the ClientOptions are loaded the next time the wallet is started with the same storage path

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

With the examples

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
