### PR TITLE
Generate first account address during account creation

### DIFF
--- a/src/account/operations/address_generation.rs
+++ b/src/account/operations/address_generation.rs
@@ -8,10 +8,7 @@ use crate::account::{
 #[cfg(all(feature = "events", any(feature = "ledger-nano", feature = "ledger-nano")))]
 use crate::events::types::{AddressData, WalletEvent};
 
-use iota_client::{
-    constants::IOTA_COIN_TYPE,
-    signing::{GenerateAddressMetadata, Network},
-};
+use iota_client::signing::{GenerateAddressMetadata, Network};
 use serde::{Deserialize, Serialize};
 
 /// Options for address generation
@@ -113,7 +110,7 @@ impl AccountHandle {
 
         let addresses = signer
             .generate_addresses(
-                IOTA_COIN_TYPE,
+                account.coin_type,
                 account.index,
                 address_range,
                 options.internal,

--- a/tests/account_manager.rs
+++ b/tests/account_manager.rs
@@ -6,6 +6,7 @@ use iota_wallet::{account_manager::AccountManager, signing::mnemonic::MnemonicSi
 
 #[tokio::test]
 async fn stored_account_manager_data() -> Result<()> {
+    std::fs::remove_dir_all("test-storage/stored_account_manager_data").unwrap_or(());
     let client_options = ClientOptions::new().with_node("http://some-not-default-node:14265")?;
 
     // mnemonic without balance
@@ -30,5 +31,48 @@ async fn stored_account_manager_data() -> Result<()> {
     assert!(client_options.node_manager_builder.nodes.contains(&node_dto));
 
     std::fs::remove_dir_all("test-storage/stored_account_manager_data").unwrap_or(());
+    Ok(())
+}
+
+#[tokio::test]
+async fn different_seed() -> Result<()> {
+    std::fs::remove_dir_all("test-storage/different_seed").unwrap_or(());
+    let client_options = ClientOptions::new()
+        .with_node("http://localhost:14265")?
+        .with_node_sync_disabled();
+    // mnemonic without balance
+    let signer = MnemonicSigner::new("inhale gorilla deny three celery song category owner lottery rent author wealth penalty crawl hobby obtain glad warm early rain clutch slab august bleak")?;
+
+    let manager = AccountManager::builder(signer)
+        .with_client_options(client_options)
+        .with_storage_folder("test-storage/different_seed")
+        .finish()
+        .await?;
+
+    let _account = manager
+        .create_account()
+        .with_alias("Alice".to_string())
+        .finish()
+        .await?;
+
+    drop(_account);
+    drop(manager);
+
+    // Recreate AccountManager with a diferent mnemonic
+    let signer2 = MnemonicSigner::new("route hen wink below army inmate object crew vintage gas best space visit say fortune gown few brain emerge umbrella consider spider digital galaxy")?;
+    let manager = AccountManager::builder(signer2)
+        .with_storage_folder("test-storage/different_seed")
+        .finish()
+        .await?;
+
+    // Generating a new account needs to return an error, because the seed from the signer is different
+    assert!(manager
+        .create_account()
+        .with_alias("Bob".to_string())
+        .finish()
+        .await
+        .is_err());
+
+    std::fs::remove_dir_all("test-storage/different_seed").unwrap_or(());
     Ok(())
 }

--- a/tests/account_recovery.rs
+++ b/tests/account_recovery.rs
@@ -3,8 +3,10 @@
 
 use iota_wallet::{account_manager::AccountManager, signing::mnemonic::MnemonicSigner, ClientOptions, Result};
 
+#[ignore]
 #[tokio::test]
 async fn account_recovery_empty() -> Result<()> {
+    std::fs::remove_dir_all("test-storage/account_recovery_empty").unwrap_or(());
     let client_options = ClientOptions::new()
         .with_node("http://localhost:14265")?
         .with_node_sync_disabled();
@@ -20,9 +22,9 @@ async fn account_recovery_empty() -> Result<()> {
 
     let accounts = manager.recover_accounts(2, 2).await?;
 
-    std::fs::remove_dir_all("test-storage/account_recovery_empty").unwrap_or(());
     // accounts should be empty if no account was created before and no account was found with balance
     assert_eq!(0, accounts.len());
+    std::fs::remove_dir_all("test-storage/account_recovery_empty").unwrap_or(());
     Ok(())
 }
 

--- a/tests/accounts.rs
+++ b/tests/accounts.rs
@@ -131,7 +131,7 @@ async fn account_first_address_exists() -> Result<()> {
         .finish()
         .await?;
 
-    // When the address is generate the first public address also gets generated and added to it
+    // When the account is generated, the first public address also gets generated and added to it
     assert_eq!(account.list_addresses().await?.len(), 1);
     // First address is a public address
     assert_eq!(account.list_addresses().await?.first().unwrap().internal(), &false);

--- a/tests/accounts.rs
+++ b/tests/accounts.rs
@@ -5,6 +5,7 @@ use iota_wallet::{account_manager::AccountManager, signing::mnemonic::MnemonicSi
 
 #[tokio::test]
 async fn account_ordering() -> Result<()> {
+    std::fs::remove_dir_all("test-storage/account_ordering").unwrap_or(());
     let client_options = ClientOptions::new()
         .with_node("http://localhost:14265")?
         .with_node_sync_disabled();
@@ -28,6 +29,7 @@ async fn account_ordering() -> Result<()> {
 
 #[tokio::test]
 async fn account_alias_already_exists() -> Result<()> {
+    std::fs::remove_dir_all("test-storage/account_alias_already_exists").unwrap_or(());
     let client_options = ClientOptions::new()
         .with_node("http://localhost:14265")?
         .with_node_sync_disabled();
@@ -78,6 +80,7 @@ async fn account_alias_already_exists() -> Result<()> {
 
 #[tokio::test]
 async fn account_rename_alias() -> Result<()> {
+    std::fs::remove_dir_all("test-storage/account_rename_alias").unwrap_or(());
     let client_options = ClientOptions::new()
         .with_node("http://localhost:14265")?
         .with_node_sync_disabled();
@@ -104,5 +107,35 @@ async fn account_rename_alias() -> Result<()> {
     assert_eq!(account.alias().await, "Bob".to_string());
 
     std::fs::remove_dir_all("test-storage/account_rename_alias").unwrap_or(());
+    Ok(())
+}
+
+#[tokio::test]
+async fn account_first_address_exists() -> Result<()> {
+    std::fs::remove_dir_all("test-storage/account_first_address_exists").unwrap_or(());
+    let client_options = ClientOptions::new()
+        .with_node("http://localhost:14265")?
+        .with_node_sync_disabled();
+    // mnemonic without balance
+    let signer = MnemonicSigner::new("inhale gorilla deny three celery song category owner lottery rent author wealth penalty crawl hobby obtain glad warm early rain clutch slab august bleak")?;
+
+    let manager = AccountManager::builder(signer)
+        .with_client_options(client_options)
+        .with_storage_folder("test-storage/account_first_address_exists")
+        .finish()
+        .await?;
+
+    let account = manager
+        .create_account()
+        .with_alias("Alice".to_string())
+        .finish()
+        .await?;
+
+    // When the address is generate the first public address also gets generated and added to it
+    assert_eq!(account.list_addresses().await?.len(), 1);
+    // First address is a public address
+    assert_eq!(account.list_addresses().await?.first().unwrap().internal(), &false);
+
+    std::fs::remove_dir_all("test-storage/account_first_address_exists").unwrap_or(());
     Ok(())
 }


### PR DESCRIPTION
# Description of change

Generate first account address during account creation and compare first address from first account to check if the seed is the same

## Links to any relevant issues

Fixes #936 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Examples and added tests

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
