### PR TITLE
Fix generate_address

### DIFF
--- a/.changes/generateaddress.md
+++ b/.changes/generateaddress.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": patch
+---
+
+Fix generateAddress.

--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -527,7 +527,9 @@ async fn sync_addresses_and_messages(
                     }
 
                     log::debug!(
-                        "[SYNC] syncing messages and outputs for address {}, got {} outputs",
+                        "[SYNC] syncing messages and outputs for address internal: {} index:{} {}, got {} outputs",
+                        address.internal(),
+                        address.key_index(),
                         address.address().to_bech32(),
                         address_output_ids.len(),
                     );

--- a/src/address.rs
+++ b/src/address.rs
@@ -404,6 +404,11 @@ pub(crate) async fn get_new_address(account: &Account, metadata: GenerateAddress
         }
     };
     let iota_address = get_iota_address(account, new_address_key_index, false, bech32_hrp, metadata).await?;
+    log::debug!(
+        "[get_new_address]: Generated new public address {} at index {}",
+        iota_address.to_bech32(),
+        new_address_key_index
+    );
     let address = Address {
         address: iota_address,
         key_index: new_address_key_index,


### PR DESCRIPTION
# Description of change

Fix generate_address to always return an address with a new higher index than the last one

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Nodejs script

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
