### PR TITLE
Update rust-rocksdb to fix illegal instruction on Windows

### DIFF
--- a/.changes/windows-popcnt.md
+++ b/.changes/windows-popcnt.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": patch
+---
+
+Fixed using RocksDB on Windows with processors that don't have support for `popcnt`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1711,7 +1711,7 @@ dependencies = [
 [[package]]
 name = "librocksdb-sys"
 version = "6.20.3"
-source = "git+https://github.com/iotaledger/rust-rocksdb?rev=b2661ac5cf37b173cb5c56db713c47a1650cdd29#b2661ac5cf37b173cb5c56db713c47a1650cdd29"
+source = "git+https://github.com/iotaledger/rust-rocksdb?rev=89eeb926c50288666b85e4f491df912040fcdbaf#89eeb926c50288666b85e4f491df912040fcdbaf"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -2443,7 +2443,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.17.0"
-source = "git+https://github.com/iotaledger/rust-rocksdb?rev=b2661ac5cf37b173cb5c56db713c47a1650cdd29#b2661ac5cf37b173cb5c56db713c47a1650cdd29"
+source = "git+https://github.com/iotaledger/rust-rocksdb?rev=89eeb926c50288666b85e4f491df912040fcdbaf#89eeb926c50288666b85e4f491df912040fcdbaf"
 dependencies = [
  "libc",
  "librocksdb-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ iota-client = { git = "https://github.com/iotaledger/iota.rs", rev = "47e5f6684e
 log = { version = "0.4.14", default-features = false }
 once_cell = { version = "1.8.0", default-features = false }
 rand = { version = "0.8.4", default-features = false }
-rocksdb = { git = "https://github.com/iotaledger/rust-rocksdb", rev = "b2661ac5cf37b173cb5c56db713c47a1650cdd29", default-features = false, features = ["lz4"] }
+rocksdb = { git = "https://github.com/iotaledger/rust-rocksdb", rev = "89eeb926c50288666b85e4f491df912040fcdbaf", default-features = false, features = ["lz4"] }
 serde = { version = "1.0.130", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.68", default-features = false }
 serde_repr = { version = "0.1.7", default-features = false }

--- a/bindings/java/Cargo.lock
+++ b/bindings/java/Cargo.lock
@@ -1801,7 +1801,7 @@ dependencies = [
 [[package]]
 name = "librocksdb-sys"
 version = "6.20.3"
-source = "git+https://github.com/iotaledger/rust-rocksdb?rev=b2661ac5cf37b173cb5c56db713c47a1650cdd29#b2661ac5cf37b173cb5c56db713c47a1650cdd29"
+source = "git+https://github.com/iotaledger/rust-rocksdb?rev=89eeb926c50288666b85e4f491df912040fcdbaf#89eeb926c50288666b85e4f491df912040fcdbaf"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -2475,7 +2475,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.17.0"
-source = "git+https://github.com/iotaledger/rust-rocksdb?rev=b2661ac5cf37b173cb5c56db713c47a1650cdd29#b2661ac5cf37b173cb5c56db713c47a1650cdd29"
+source = "git+https://github.com/iotaledger/rust-rocksdb?rev=89eeb926c50288666b85e4f491df912040fcdbaf#89eeb926c50288666b85e4f491df912040fcdbaf"
 dependencies = [
  "libc",
  "librocksdb-sys",

--- a/bindings/nodejs/Cargo.lock
+++ b/bindings/nodejs/Cargo.lock
@@ -1617,7 +1617,7 @@ dependencies = [
 [[package]]
 name = "librocksdb-sys"
 version = "6.20.3"
-source = "git+https://github.com/iotaledger/rust-rocksdb?rev=b2661ac5cf37b173cb5c56db713c47a1650cdd29#b2661ac5cf37b173cb5c56db713c47a1650cdd29"
+source = "git+https://github.com/iotaledger/rust-rocksdb?rev=89eeb926c50288666b85e4f491df912040fcdbaf#89eeb926c50288666b85e4f491df912040fcdbaf"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -2308,7 +2308,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.17.0"
-source = "git+https://github.com/iotaledger/rust-rocksdb?rev=b2661ac5cf37b173cb5c56db713c47a1650cdd29#b2661ac5cf37b173cb5c56db713c47a1650cdd29"
+source = "git+https://github.com/iotaledger/rust-rocksdb?rev=89eeb926c50288666b85e4f491df912040fcdbaf#89eeb926c50288666b85e4f491df912040fcdbaf"
 dependencies = [
  "libc",
  "librocksdb-sys",

--- a/bindings/python/native/Cargo.lock
+++ b/bindings/python/native/Cargo.lock
@@ -1801,7 +1801,7 @@ dependencies = [
 [[package]]
 name = "librocksdb-sys"
 version = "6.20.3"
-source = "git+https://github.com/iotaledger/rust-rocksdb?rev=b2661ac5cf37b173cb5c56db713c47a1650cdd29#b2661ac5cf37b173cb5c56db713c47a1650cdd29"
+source = "git+https://github.com/iotaledger/rust-rocksdb?rev=89eeb926c50288666b85e4f491df912040fcdbaf#89eeb926c50288666b85e4f491df912040fcdbaf"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -2556,7 +2556,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.17.0"
-source = "git+https://github.com/iotaledger/rust-rocksdb?rev=b2661ac5cf37b173cb5c56db713c47a1650cdd29#b2661ac5cf37b173cb5c56db713c47a1650cdd29"
+source = "git+https://github.com/iotaledger/rust-rocksdb?rev=89eeb926c50288666b85e4f491df912040fcdbaf#89eeb926c50288666b85e4f491df912040fcdbaf"
 dependencies = [
  "libc",
  "librocksdb-sys",


### PR DESCRIPTION
# Description of change
Updates rust-rocksdb to https://github.com/iotaledger/rust-rocksdb/commit/89eeb926c50288666b85e4f491df912040fcdbaf to avoid calling `popcnt` on Windows when the processor doesn't support it

## Links to any relevant issues
https://github.com/iotaledger/firefly/issues/2821

## Type of change
- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested
Fix is cherry-picked from https://github.com/facebook/rocksdb/commit/1a2781d48ce85455ff47d717366635301d33c7fa. We'll likely release an alpha version of Firefly and ask an affected user to verify the issue is fixed, as the issue only happens on processors released before 2008.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code