### PR TITLE
Add first public address during account discovery if needed

### DIFF
--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -911,6 +911,7 @@ async fn perform_sync(
 
     let is_latest_public_address_empty = if latest_public_address_index > max_new_public_index {
         public_addresses
+            .clone()
             .max_by_key(|a| a.key_index())
             .map(|a| a.outputs().is_empty())
             .unwrap_or(false)
@@ -996,6 +997,19 @@ async fn perform_sync(
             };
             addresses_to_save.push(address);
         };
+    }
+
+    // If we discover the account and the first public address isn't added, we will do it here
+    if return_all_addresses && !addresses_to_save.iter().any(|a| *a.key_index() == 0 && !a.internal()) {
+        log::debug!("[SYNC] adding first public address because we're discovering this account");
+        addresses_to_save.push(
+            (*public_addresses
+                .collect::<Vec<&Address>>()
+                .first()
+                // Save to unwrap because we generate the first address during account creation
+                .expect("No first address"))
+            .clone(),
+        );
     }
 
     // First sort by internal and then by key index, otherwise dedup could fail

--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -1006,7 +1006,7 @@ async fn perform_sync(
             (*public_addresses
                 .collect::<Vec<&Address>>()
                 .first()
-                // Save to unwrap because we generate the first address during account creation
+                // Safe to unwrap because we generate the first address during account creation
                 .expect("No first address"))
             .clone(),
         );

--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -774,7 +774,7 @@ async fn perform_sync(
         .map(|a| *a.key_index())
         .unwrap_or(0);
 
-    let public_addresses = account.addresses.iter().filter(|a| !a.internal());
+    let mut public_addresses = account.addresses.iter().filter(|a| !a.internal());
     let internal_addresses = account.addresses.iter().filter(|a| *a.internal());
     let mut latest_public_address_index = public_addresses
         .clone()
@@ -1003,12 +1003,11 @@ async fn perform_sync(
     if return_all_addresses && !addresses_to_save.iter().any(|a| *a.key_index() == 0 && !a.internal()) {
         log::debug!("[SYNC] adding first public address because we're discovering this account");
         addresses_to_save.push(
-            (*public_addresses
-                .collect::<Vec<&Address>>()
-                .first()
+            public_addresses
+                .next()
                 // Safe to unwrap because we generate the first address during account creation
-                .expect("No first address"))
-            .clone(),
+                .expect("No first address")
+                .clone(),
         );
     }
 


### PR DESCRIPTION
# Description of change

Add first public address during account discovery if needed, because otherwise it can happen that we don't have any public address in the account and then it panics later at other places in the wallet

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

@nicole-obrien tested it in Firefly with a wallet that panicked without this change

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
