### PR TITLE
feat: coin type optional

### DIFF
--- a/bindings/nodejs/examples/1-create-account.js
+++ b/bindings/nodejs/examples/1-create-account.js
@@ -11,11 +11,17 @@ async function run() {
         // await manager.setStrongholdPassword(process.env.SH_PASSWORD);
         // await manager.storeMnemonic();
 
+        // The coin type only needs to be set on the first account
         const account = await manager.createAccount({
             alias: 'Alice',
-            coinType: CoinType.Shimmer,
+            coinType: CoinType.IOTA,
         });
         console.log('Account created:', account);
+
+        const secondAccount = await manager.createAccount({
+            alias: 'Bob',
+        });
+        console.log('Account created:', secondAccount);
     } catch (error) {
         console.log('Error: ' + error);
     }

--- a/bindings/nodejs/lib/AccountManager.ts
+++ b/bindings/nodejs/lib/AccountManager.ts
@@ -61,11 +61,11 @@ export class AccountManager {
     /**
      * The coin type only needs to be set on the first account
      */
-    async createAccount(account: CreateAccountPayload): Promise<Account> {
+    async createAccount(payload: CreateAccountPayload): Promise<Account> {
         const response = await this.messageHandler
             .sendMessage({
                 cmd: 'CreateAccount',
-                payload: account,
+                payload,
             });
 
         return new Account(

--- a/bindings/nodejs/lib/AccountManager.ts
+++ b/bindings/nodejs/lib/AccountManager.ts
@@ -57,7 +57,10 @@ export class AccountManager {
             )
         );
     }
-
+    
+    /**
+     * The coin type only needs to be set on the first account
+     */
     async createAccount(account: CreateAccountPayload): Promise<Account> {
         const response = await this.messageHandler
             .sendMessage({

--- a/bindings/nodejs/types/account.ts
+++ b/bindings/nodejs/types/account.ts
@@ -47,5 +47,5 @@ export enum CoinType {
 
 export interface CreateAccountPayload {
     alias: string
-    coinType: CoinType
+    coinType?: CoinType
 }


### PR DESCRIPTION
# Description of change

Upon creating a the first account. the AccountManager expects a coin type. This defines all further accounts created. Currently the interface is wrong, since coinType is an optional parameter and not a required one.

## Links to any relevant issues

closes: https://github.com/iotaledger/firefly/issues/3101

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Ran the first example

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
