### PR TITLE
Add debug logs to message_interface without leaking secrets

### DIFF
--- a/bindings/nodejs/src/message_handler.rs
+++ b/bindings/nodejs/src/message_handler.rs
@@ -41,7 +41,6 @@ impl MessageHandler {
     }
 
     async fn send_message(&self, serialized_message: String) -> (String, bool) {
-        log::debug!("{}", serialized_message);
         match serde_json::from_str::<MessageType>(&serialized_message) {
             Ok(message) => {
                 let (response_tx, mut response_rx) = unbounded_channel();
@@ -107,7 +106,6 @@ pub fn send_message(mut cx: FunctionContext) -> JsResult<JsUndefined> {
 
     crate::RUNTIME.spawn(async move {
         let (response, is_error) = message_handler.send_message(message).await;
-        log::debug!("{:?}", response);
         message_handler.channel.send(move |mut cx| {
             let cb = callback.into_inner(&mut cx);
             let this = cx.undefined();

--- a/src/message_interface/message_handler.rs
+++ b/src/message_interface/message_handler.rs
@@ -84,6 +84,8 @@ impl WalletMessageHandler {
 
     /// Handles a message.
     pub async fn handle(&self, message: Message) {
+        log::debug!("Message: {:?}", message.message_type);
+
         let response: Result<Response> = match message.message_type {
             MessageType::CreateAccount(account) => {
                 convert_async_panics(|| async { self.create_account(&account).await }).await
@@ -196,6 +198,9 @@ impl WalletMessageHandler {
             Ok(r) => r,
             Err(e) => Response::Error(e),
         };
+
+        log::debug!("Response: {:?}", response);
+
         let _ = message.response_tx.send(response);
     }
 

--- a/src/message_interface/message_type.rs
+++ b/src/message_interface/message_type.rs
@@ -130,7 +130,7 @@ impl Debug for MessageType {
             MessageType::GetAccounts => write!(f, "GetAccounts"),
             MessageType::CallAccountMethod { account_id, method } => write!(
                 f,
-                "CallAccountMethod{{ account_id: {:?}, method: {:?} }})",
+                "CallAccountMethod{{ account_id: {:?}, method: {:?} }}",
                 account_id, method
             ),
             #[cfg(feature = "storage")]
@@ -151,11 +151,11 @@ impl Debug for MessageType {
             #[cfg(feature = "storage")]
             MessageType::DeleteStorage => write!(f, "DeleteStorage"),
             MessageType::GenerateMnemonic => write!(f, "GenerateMnemonic"),
-            MessageType::VerifyMnemonic(_) => write!(f, "VerifyMnemonic()"),
+            MessageType::VerifyMnemonic(_) => write!(f, "VerifyMnemonic(<omitted>)"),
             MessageType::SetClientOptions(options) => write!(f, "SetClientOptions({:?})", options),
             MessageType::GetNodeInfo => write!(f, "GetNodeInfo"),
-            MessageType::SetStrongholdPassword(_) => write!(f, "SetStrongholdPassword()"),
-            MessageType::StoreMnemonic(_) => write!(f, "StoreMnemonic()"),
+            MessageType::SetStrongholdPassword(_) => write!(f, "SetStrongholdPassword(<omitted>)"),
+            MessageType::StoreMnemonic(_) => write!(f, "StoreMnemonic(<omitted>)"),
             MessageType::StartBackgroundSync { options, interval } => write!(
                 f,
                 "StartBackgroundSync{{ options: {:?}, interval: {:?} }}",

--- a/src/message_interface/message_type.rs
+++ b/src/message_interface/message_type.rs
@@ -1,7 +1,11 @@
 // Copyright 2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{path::PathBuf, time::Duration};
+use std::{
+    fmt::{Debug, Formatter, Result},
+    path::PathBuf,
+    time::Duration,
+};
 
 use serde::{ser::Serializer, Deserialize, Serialize};
 
@@ -25,7 +29,7 @@ pub struct AccountToCreate {
 }
 
 /// The messages that can be sent to the actor.
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Deserialize)]
 #[serde(tag = "cmd", content = "payload")]
 #[allow(clippy::large_enum_variant)]
 pub enum MessageType {
@@ -115,6 +119,54 @@ pub enum MessageType {
     #[cfg(feature = "events")]
     #[cfg(debug_assertions)]
     EmitTestEvent(WalletEvent),
+}
+
+// Custom Debug implementation to not log secrets
+impl Debug for MessageType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        match self {
+            MessageType::CreateAccount(account) => write!(f, "CreateAccount({:?})", account),
+            MessageType::GetAccount(identifier) => write!(f, "GetAccount({:?})", identifier),
+            MessageType::GetAccounts => write!(f, "GetAccounts"),
+            MessageType::CallAccountMethod { account_id, method } => write!(
+                f,
+                "CallAccountMethod{{ account_id: {:?}, method: {:?} }})",
+                account_id, method
+            ),
+            #[cfg(feature = "storage")]
+            MessageType::Backup {
+                destination,
+                password: _,
+            } => write!(f, "Backup{{ destination: {:?} }}", destination),
+            MessageType::RecoverAccounts {
+                account_gap_limit,
+                address_gap_limit,
+            } => write!(
+                f,
+                "RecoverAccoounts{{ account_gap_limit: {:?}, address_gap_limit: {:?} }}",
+                account_gap_limit, address_gap_limit
+            ),
+            #[cfg(feature = "storage")]
+            MessageType::RestoreBackup { source, password: _ } => write!(f, "RestoreBackup{{ source: {:?} }}", source),
+            #[cfg(feature = "storage")]
+            MessageType::DeleteStorage => write!(f, "DeleteStorage"),
+            MessageType::GenerateMnemonic => write!(f, "GenerateMnemonic"),
+            MessageType::VerifyMnemonic(_) => write!(f, "VerifyMnemonic()"),
+            MessageType::SetClientOptions(options) => write!(f, "SetClientOptions({:?})", options),
+            MessageType::GetNodeInfo => write!(f, "GetNodeInfo"),
+            MessageType::SetStrongholdPassword(_) => write!(f, "SetStrongholdPassword()"),
+            MessageType::StoreMnemonic(_) => write!(f, "StoreMnemonic()"),
+            MessageType::StartBackgroundSync { options, interval } => write!(
+                f,
+                "StartBackgroundSync{{ options: {:?}, interval: {:?} }}",
+                options, interval
+            ),
+            MessageType::StopBackgroundSync => write!(f, "StopBackgroundSync"),
+            #[cfg(feature = "events")]
+            #[cfg(debug_assertions)]
+            MessageType::EmitTestEvent(event) => write!(f, "EmitTestEvent({:?})", event),
+        }
+    }
 }
 
 impl Serialize for MessageType {

--- a/src/message_interface/response.rs
+++ b/src/message_interface/response.rs
@@ -70,7 +70,7 @@ impl Debug for Response {
                 write!(f, "AddressesWithUnspentOutputs({:?})", addresses)
             }
             Response::OutputIds(output_ids) => write!(f, "OutputIds({:?})", output_ids),
-            Response::Output(output) => write!(f, "OutputData({:?})", output),
+            Response::Output(output) => write!(f, "Output({:?})", output),
             Response::Outputs(outputs) => write!(f, "Outputs{:?}", outputs),
             Response::Transactions(transactions) => write!(f, "Transactions({:?})", transactions),
             Response::GeneratedAddress(addresses) => write!(f, "GeneratedAddress({:?})", addresses),

--- a/src/message_interface/response.rs
+++ b/src/message_interface/response.rs
@@ -1,6 +1,8 @@
 // Copyright 2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use std::fmt::{Debug, Formatter, Result};
+
 use iota_client::{bee_message::output::OutputId, NodeInfoWrapper};
 use serde::Serialize;
 
@@ -17,7 +19,7 @@ use crate::{
 };
 
 /// The response message.
-#[derive(Serialize, Debug)]
+#[derive(Serialize)]
 #[serde(tag = "type", content = "payload")]
 pub enum Response {
     /// Account succesfully created or GetAccount response.
@@ -55,4 +57,31 @@ pub enum Response {
     NodeInfo(NodeInfoWrapper),
     /// All went fine.
     Ok(()),
+}
+
+// Custom Debug implementation to not log secrets
+impl Debug for Response {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        match self {
+            Response::Account(account) => write!(f, "Account({:?})", account),
+            Response::Accounts(accounts) => write!(f, "Accounts({:?})", accounts),
+            Response::Addresses(addresses) => write!(f, "Addresses({:?})", addresses),
+            Response::AddressesWithUnspentOutputs(addresses) => {
+                write!(f, "AddressesWithUnspentOutputs({:?})", addresses)
+            }
+            Response::OutputIds(output_ids) => write!(f, "OutputIds({:?})", output_ids),
+            Response::Output(output) => write!(f, "OutputData({:?})", output),
+            Response::Outputs(outputs) => write!(f, "Outputs{:?}", outputs),
+            Response::Transactions(transactions) => write!(f, "Transactions({:?})", transactions),
+            Response::GeneratedAddress(addresses) => write!(f, "GeneratedAddress({:?})", addresses),
+            Response::Balance(balance) => write!(f, "Balance({:?})", balance),
+            Response::SentTransfer(transfer) => write!(f, "SentTransfer({:?})", transfer),
+            Response::SentTransfers(transfers) => write!(f, "SentTransfers({:?})", transfers),
+            Response::Error(error) => write!(f, "Error({:?})", error),
+            Response::Panic(panic_msg) => write!(f, "Panic({:?})", panic_msg),
+            Response::GeneratedMnemonic(_) => write!(f, "GeneratedMnemonic()"),
+            Response::NodeInfo(info) => write!(f, "NodeInfo({:?})", info),
+            Response::Ok(()) => write!(f, "Ok(())"),
+        }
+    }
 }

--- a/src/message_interface/response.rs
+++ b/src/message_interface/response.rs
@@ -79,7 +79,7 @@ impl Debug for Response {
             Response::SentTransfers(transfers) => write!(f, "SentTransfers({:?})", transfers),
             Response::Error(error) => write!(f, "Error({:?})", error),
             Response::Panic(panic_msg) => write!(f, "Panic({:?})", panic_msg),
-            Response::GeneratedMnemonic(_) => write!(f, "GeneratedMnemonic()"),
+            Response::GeneratedMnemonic(_) => write!(f, "GeneratedMnemonic(<omitted>)"),
             Response::NodeInfo(info) => write!(f, "NodeInfo({:?})", info),
             Response::Ok(()) => write!(f, "Ok(())"),
         }


### PR DESCRIPTION
## Links to any relevant issues

Fixes #1026 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Node.js binding

```
2022-05-10 07:28:41 (UTC) iota_wallet::message_interface::message_handler [94mDEBUG[0m Message: GenerateMnemonic
2022-05-10 07:28:41 (UTC) iota_wallet::message_interface::message_handler [94mDEBUG[0m Response: GeneratedMnemonic()
2022-05-10 07:28:41 (UTC) iota_wallet::message_interface::message_handler [94mDEBUG[0m Message: VerifyMnemonic()
2022-05-10 07:28:41 (UTC) iota_wallet::message_interface::message_handler [94mDEBUG[0m Response: Ok(())
2022-05-10 07:28:41 (UTC) iota_wallet::message_interface::message_handler [94mDEBUG[0m Message: StoreMnemonic()
2022-05-10 07:28:41 (UTC) iota_wallet::message_interface::message_handler [94mDEBUG[0m Response: Ok(())

2022-05-10 07:47:26 (UTC) iota_wallet::message_interface::message_handler [94mDEBUG[0m Message: SetStrongholdPassword()

```


## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
