### PR TITLE
Use OutputMetadataResponse instead of OutputResponse

### DIFF
--- a/src/account/operations/syncing/mod.rs
+++ b/src/account/operations/syncing/mod.rs
@@ -197,7 +197,7 @@ impl AccountHandle {
                     account.unspent_outputs.remove(&output_id);
                     // Update spent data fields
                     if let Some(output_data) = account.outputs.get_mut(&output_id) {
-                        output_data.output_response.metadata.is_spent = true;
+                        output_data.metadata.is_spent = true;
                         output_data.is_spent = true;
                         #[cfg(feature = "events")]
                         {
@@ -218,7 +218,7 @@ impl AccountHandle {
             let transaction_id = TransactionId::from_str(&output_response.metadata.transaction_id)?;
             let output_id = OutputId::new(transaction_id, output_response.metadata.output_index)?;
             if let Some(output_data) = account.outputs.get_mut(&output_id) {
-                output_data.output_response = output_response;
+                output_data.metadata = output_response.metadata;
             }
         }
 

--- a/src/account/operations/syncing/outputs.rs
+++ b/src/account/operations/syncing/outputs.rs
@@ -7,7 +7,7 @@ use crypto::keys::slip10::Chain;
 use iota_client::{
     api::ClientBlockBuilder,
     bee_block::{
-        output::{Output, OutputId},
+        output::{dto::OutputDto, Output, OutputId},
         payload::transaction::TransactionId,
     },
     bee_rest_api::types::responses::OutputResponse,
@@ -50,7 +50,7 @@ impl AccountHandle {
 
             outputs.push(OutputData {
                 output_id: OutputId::new(transaction_id, output_response.metadata.output_index)?,
-                output_response: output_response.clone(),
+                metadata: output_response.metadata.clone(),
                 output: Output::try_from(&output_response.output)?,
                 amount,
                 is_spent: output_response.metadata.is_spent,
@@ -89,7 +89,10 @@ impl AccountHandle {
                     Some(output_data) => {
                         output_data.is_spent = false;
                         unspent_outputs.push((output_id, output_data.clone()));
-                        loaded_outputs.push(output_data.output_response.clone());
+                        loaded_outputs.push(OutputResponse {
+                            metadata: output_data.metadata.clone(),
+                            output: OutputDto::from(&output_data.output),
+                        });
                         balance_from_known_outputs += output_data.amount
                     }
                     None => unknown_outputs.push(output_id),

--- a/src/account/types/mod.rs
+++ b/src/account/types/mod.rs
@@ -17,7 +17,7 @@ use iota_client::{
         payload::transaction::TransactionPayload,
         BlockId,
     },
-    bee_rest_api::types::responses::OutputResponse,
+    bee_rest_api::types::responses::OutputMetadataResponse,
     secret::types::{InputSigningData, OutputMetadata},
 };
 use primitive_types::U256;
@@ -55,10 +55,7 @@ pub struct OutputData {
     /// The output id
     #[serde(rename = "outputId")]
     pub output_id: OutputId,
-    // todo: remove OutputResponse and store metadata alone
-    /// The output response
-    #[serde(rename = "outputResponse")]
-    pub output_response: OutputResponse,
+    pub metadata: OutputMetadataResponse,
     /// The actual Output
     pub output: Output,
     // The output amount
@@ -79,8 +76,8 @@ pub struct OutputData {
 impl OutputData {
     pub fn input_signing_data(&self) -> crate::Result<InputSigningData> {
         Ok(InputSigningData {
-            output: Output::try_from(&self.output_response.output)?,
-            output_metadata: OutputMetadata::try_from(&self.output_response.metadata)?,
+            output: self.output.clone(),
+            output_metadata: OutputMetadata::try_from(&self.metadata)?,
             chain: self.chain.clone(),
             bech32_address: self.address.to_bech32("atoi"),
         })

--- a/src/message_interface/dtos.rs
+++ b/src/message_interface/dtos.rs
@@ -16,7 +16,7 @@ use iota_client::{
         payload::transaction::{dto::TransactionPayloadDto, TransactionId},
         BlockId,
     },
-    bee_rest_api::types::responses::OutputResponse,
+    bee_rest_api::types::responses::OutputMetadataResponse,
 };
 use primitive_types::U256;
 use serde::{Deserialize, Serialize};
@@ -267,9 +267,8 @@ pub struct OutputDataDto {
     /// The output id
     #[serde(rename = "outputId")]
     pub output_id: OutputId,
-    /// The output response
-    #[serde(rename = "outputResponse")]
-    pub output_response: OutputResponse,
+    /// The metadata of the output
+    pub metadata: OutputMetadataResponse,
     /// The actual Output
     pub output: OutputDto,
     /// The output amount
@@ -292,7 +291,7 @@ impl From<&OutputData> for OutputDataDto {
     fn from(value: &OutputData) -> Self {
         Self {
             output_id: value.output_id,
-            output_response: value.output_response.clone(),
+            metadata: value.metadata.clone(),
             output: OutputDto::from(&value.output),
             amount: value.amount.to_string(),
             is_spent: value.is_spent,


### PR DESCRIPTION
# Description of change

Use OutputMetadataResponse instead of OutputResponse, because we have the Output in the OutputData already

## Type of change

- Breaking change

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
