### PR TITLE
fix: expose network into type

### DIFF
--- a/bindings/nodejs/types/network.ts
+++ b/bindings/nodejs/types/network.ts
@@ -11,7 +11,7 @@ export type Auth = {
     password?: string;
 };
 
-interface NetworkInfo {
+export interface NetworkInfo {
     network?: string;
     networkId?: number;
     bech32HRP?: string;


### PR DESCRIPTION
# Description of change

Expose the `NetworkInfo` interface for the NodeJS bindings so it can be used to help construct types.

## Links to any relevant issues

_None_

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Used in Firefly's shared TypeScript library.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code