### PR TITLE
Clean syncing

### DIFF
--- a/src/account/builder.rs
+++ b/src/account/builder.rs
@@ -15,18 +15,15 @@ use iota_client::{
 use tokio::sync::Mutex;
 use tokio::sync::RwLock;
 
-#[cfg(feature = "ledger_nano")]
-use crate::account::constants::DEFAULT_LEDGER_OUTPUT_CONSOLIDATION_THRESHOLD;
 #[cfg(feature = "events")]
 use crate::events::EventEmitter;
 #[cfg(feature = "storage")]
 use crate::storage::manager::StorageManagerHandle;
 use crate::{
     account::{
-        constants::DEFAULT_OUTPUT_CONSOLIDATION_THRESHOLD,
         handle::AccountHandle,
         types::{address::AddressWrapper, AccountAddress},
-        Account, AccountOptions,
+        Account,
     },
     ClientOptions, Error,
 };
@@ -191,13 +188,6 @@ impl AccountBuilder {
             }
         };
 
-        let consolidation_threshold = match *self.secret_manager.read().await {
-            #[cfg(feature = "ledger_nano")]
-            SecretManager::LedgerNano(_) | SecretManager::LedgerNanoSimulator(_) => {
-                DEFAULT_LEDGER_OUTPUT_CONSOLIDATION_THRESHOLD
-            }
-            _ => DEFAULT_OUTPUT_CONSOLIDATION_THRESHOLD,
-        };
         let account = Account {
             index: account_index,
             coin_type: self.coin_type.unwrap_or_default() as u32,
@@ -210,11 +200,6 @@ impl AccountBuilder {
             unspent_outputs: HashMap::new(),
             transactions: HashMap::new(),
             pending_transactions: HashSet::new(),
-            // sync interval, output consolidation
-            account_options: AccountOptions {
-                output_consolidation_threshold: consolidation_threshold,
-                automatic_output_consolidation: true,
-            },
         };
         let account_handle = AccountHandle::new(
             account,

--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -73,22 +73,4 @@ pub struct Account {
     // Maybe pending transactions even additionally separated?
     #[serde(rename = "pendingTransactions")]
     pending_transactions: HashSet<TransactionId>,
-    /// Account options
-    // sync interval, output consolidation
-    #[serde(rename = "accountOptions")]
-    #[getset(get = "pub(crate)")]
-    account_options: AccountOptions,
-}
-
-/// Account options
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
-pub struct AccountOptions {
-    /// Threshold for the amount of unspent outputs before they get consolidated (sent in a transaction to the account
-    /// itself)
-    #[serde(rename = "outputConsolidationThreshold")]
-    pub output_consolidation_threshold: usize,
-    #[serde(rename = "automaticOutputConsolidation")]
-    pub automatic_output_consolidation: bool,
-    // #[cfg(feature = "storage")]
-    // pub(crate) persist_events: bool,
 }

--- a/src/account/operations/syncing/options.rs
+++ b/src/account/operations/syncing/options.rs
@@ -3,8 +3,6 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::account::operations::output_collection::OutputsToCollect;
-
 /// The synchronization options
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SyncOptions {
@@ -16,11 +14,6 @@ pub struct SyncOptions {
     /// addresses with a lower index will be skipped, but could result in a wrong balance for that reason
     #[serde(rename = "addressStartIndex", default = "default_address_start_index")]
     pub address_start_index: u32,
-    #[serde(
-        rename = "automaticOutputConsolidation",
-        default = "default_automatic_output_consolidation"
-    )]
-    pub automatic_output_consolidation: bool,
     /// Usually we skip syncing if it's called within a few seconds, because there can only be new changes every 10
     /// seconds. But if we change the client options, we need to resync, because the new node could be from a nother
     /// network and then we need to check all addresses. This will also ignore `address_start_index` and sync all
@@ -33,26 +26,6 @@ pub struct SyncOptions {
     /// Specifies if only basic outputs should be synced or also alias and nft outputs
     #[serde(rename = "syncAliasesAndNfts", default = "default_sync_aliases_and_nfts")]
     pub sync_aliases_and_nfts: bool,
-    // Automatically try to collect basic outputs that have additional unlock conditions to their
-    // [AddressUnlockCondition](iota_client::bee_block::output::unlock_condition::AddressUnlockCondition).
-    #[serde(rename = "tryCollectOutputs", default = "default_try_collect_outputs")]
-    pub try_collect_outputs: OutputsToCollect,
-    /// Amount of unspent outputs, only with a
-    /// [`AddressUnlockCondition`](iota_client::bee_block::output::unlock_condition::AddressUnlockCondition),
-    /// before they get consolidated (merged with a transaction to a single output).
-    #[serde(
-        rename = "outputConsolidationThreshold",
-        default = "default_output_consolidation_threshold"
-    )]
-    pub output_consolidation_threshold: usize,
-}
-
-fn default_output_consolidation_threshold() -> usize {
-    100
-}
-
-fn default_automatic_output_consolidation() -> bool {
-    false
 }
 
 fn default_sync_pending_transactions() -> bool {
@@ -63,10 +36,6 @@ fn default_sync_aliases_and_nfts() -> bool {
     true
 }
 
-fn default_try_collect_outputs() -> OutputsToCollect {
-    OutputsToCollect::None
-}
-
 fn default_address_start_index() -> u32 {
     0
 }
@@ -75,12 +44,9 @@ impl Default for SyncOptions {
     fn default() -> Self {
         Self {
             addresses: Vec::new(),
-            output_consolidation_threshold: 100,
-            automatic_output_consolidation: false,
             address_start_index: 0,
             sync_pending_transactions: true,
             sync_aliases_and_nfts: true,
-            try_collect_outputs: OutputsToCollect::None,
             force_syncing: false,
         }
     }

--- a/src/account/operations/transaction/mod.rs
+++ b/src/account/operations/transaction/mod.rs
@@ -29,7 +29,6 @@ use crate::events::types::{TransactionProgressEvent, WalletEvent};
 use crate::{
     account::{
         handle::AccountHandle,
-        operations::syncing::SyncOptions,
         types::{InclusionState, Transaction},
     },
     iota_client::Error,
@@ -91,11 +90,7 @@ impl AccountHandle {
             );
         }
         if !options.clone().unwrap_or_default().skip_sync {
-            self.sync(Some(SyncOptions {
-                automatic_output_consolidation: false,
-                ..Default::default()
-            }))
-            .await?;
+            self.sync(None).await?;
         }
         self.finish_transaction(outputs, options).await
     }
@@ -149,12 +144,9 @@ impl AccountHandle {
                 WalletEvent::TransactionProgress(TransactionProgressEvent::SyncingAccount),
             );
         }
+
         if !options.clone().unwrap_or_default().skip_sync {
-            self.sync(Some(SyncOptions {
-                automatic_output_consolidation: false,
-                ..Default::default()
-            }))
-            .await?;
+            self.sync(None).await?;
         }
 
         self.prepare_transaction(outputs, options).await

--- a/src/message_interface/dtos.rs
+++ b/src/message_interface/dtos.rs
@@ -27,7 +27,7 @@ use crate::{
             address::AddressWrapper, AccountAddress, AccountBalance, AddressWithUnspentOutputs, InclusionState,
             OutputData, Transaction,
         },
-        Account, AccountOptions,
+        Account,
     },
     AddressWithAmount, AddressWithMicroAmount,
 };
@@ -185,9 +185,6 @@ pub struct AccountDto {
     /// Pending transactions
     #[serde(rename = "pendingTransactions")]
     pub pending_transactions: HashSet<TransactionId>,
-    /// Account options
-    #[serde(rename = "accountOptions")]
-    pub account_options: AccountOptions,
 }
 
 impl From<&Account> for AccountDto {
@@ -223,7 +220,6 @@ impl From<&Account> for AccountDto {
                 .map(|(k, o)| (k, TransactionDto::from(&o)))
                 .collect(),
             pending_transactions: value.pending_transactions().clone(),
-            account_options: *value.account_options(),
         }
     }
 }


### PR DESCRIPTION
# Description of change

Remove output consolidation and collection from syncing, they should be called separated when needed
Also remove AccountOptions, since they were only used for the consolidation threshold and that can be provided in the consolidation method

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
