### PR TITLE
Update OutputData and PreparedTransaction types

### DIFF
--- a/bindings/nodejs/lib/Account.ts
+++ b/bindings/nodejs/lib/Account.ts
@@ -21,9 +21,9 @@ import type {
     AddressWithUnspentOutputs,
     TransactionResult,
     PreparedTransactionData,
-    Output,
 } from '../types';
 import type { SignedTransactionEssence } from '../types/signedTransactionEssence';
+import type { OutputTypes } from '@iota/types';
 
 export class Account {
     meta: AccountMeta;
@@ -55,9 +55,9 @@ export class Account {
         await this.messageHandler.callAccountMethod(this.meta.index, {
             name: 'SetAlias',
             data: {
-                alias
-            }
-        })
+                alias,
+            },
+        });
     }
 
     async getBalance(): Promise<AccountBalance> {
@@ -248,7 +248,7 @@ export class Account {
     }
 
     async prepareTransaction(
-        outputs: Output[],
+        outputs: OutputTypes[],
         options?: TransactionOptions,
     ): Promise<PreparedTransactionData> {
         const response = await this.messageHandler.callAccountMethod(
@@ -422,7 +422,7 @@ export class Account {
     }
 
     async SendTransaction(
-        outputs: Output[],
+        outputs: OutputTypes[],
         transactionOptions?: TransactionOptions,
     ): Promise<TransactionResult> {
         const response = await this.messageHandler.callAccountMethod(
@@ -455,7 +455,9 @@ export class Account {
         return JSON.parse(response).payload;
     }
 
-    async signTransactionEssence(preparedTransactionData: PreparedTransactionData): Promise<SignedTransactionEssence> {
+    async signTransactionEssence(
+        preparedTransactionData: PreparedTransactionData,
+    ): Promise<SignedTransactionEssence> {
         const response = await this.messageHandler.callAccountMethod(
             this.meta.index,
             {
@@ -468,7 +470,9 @@ export class Account {
         return JSON.parse(response).payload;
     }
 
-    async submitAndStoreTransaction(signedTransactionData: SignedTransactionEssence): Promise<TransactionResult> {
+    async submitAndStoreTransaction(
+        signedTransactionData: SignedTransactionEssence,
+    ): Promise<TransactionResult> {
         const response = await this.messageHandler.callAccountMethod(
             this.meta.index,
             {

--- a/bindings/nodejs/lib/AccountManager.ts
+++ b/bindings/nodejs/lib/AccountManager.ts
@@ -102,7 +102,7 @@ export class AccountManager {
         const response = await this.messageHandler.sendMessage({
             cmd: 'GetNodeInfo',
             payload: { url, auth },
-        })
+        });
         return JSON.parse(response).payload;
     }
 
@@ -126,7 +126,9 @@ export class AccountManager {
         });
     }
 
-    async setStrongholdPasswordClearInterval(intervalInMilliseconds?: number): Promise<void> {
+    async setStrongholdPasswordClearInterval(
+        intervalInMilliseconds?: number,
+    ): Promise<void> {
         await this.messageHandler.sendMessage({
             cmd: 'SetStrongholdPasswordClearInterval',
             payload: intervalInMilliseconds,

--- a/bindings/nodejs/types/bridge/account.ts
+++ b/bindings/nodejs/types/bridge/account.ts
@@ -1,3 +1,4 @@
+import type { OutputTypes } from '@iota/types';
 import type { AccountSyncOptions } from '../account';
 import type {
     AddressWithAmount,
@@ -6,9 +7,9 @@ import type {
     AddressNftId,
     AddressGenerationOptions,
 } from '../address';
-import type { OutputsToCollect, Output } from '../output';
+import type { OutputsToCollect } from '../output';
 import type { SignedTransactionEssence } from '../signedTransactionEssence';
-import type { PreparedTransactionData } from '../transaction';
+import type { PreparedTransactionData } from '../preparedTransactionData';
 import type {
     NativeTokenOptions,
     TransactionOptions,
@@ -97,8 +98,8 @@ export type __PrepareSendAmountMethod__ = {
     data: {
         addressWithAmount: AddressWithAmount[];
         options?: TransactionOptions;
-    }
-}
+    };
+};
 
 export type __PrepareSendMicroTransactionMethod__ = {
     name: 'PrepareSendMicroTransaction';
@@ -135,9 +136,9 @@ export type __PrepareMintNftsMethod__ = {
 export type __PrepareTransactionMethod__ = {
     name: 'PrepareTransaction';
     data: {
-        outputs: Output[];
+        outputs: OutputTypes[];
         options?: TransactionOptions;
-    }
+    };
 };
 
 export type __MintNftsMethod__ = {
@@ -183,7 +184,7 @@ export type __SendNftMethod__ = {
 export type __SendTransactionMethod__ = {
     name: 'SendTransaction';
     data: {
-        outputs: Output[];
+        outputs: OutputTypes[];
         options?: TransactionOptions;
     };
 };
@@ -192,8 +193,8 @@ export type __SetAliasMethod__ = {
     name: 'SetAlias';
     data: {
         alias: string;
-    }
-}
+    };
+};
 
 export type __SignTransactionEssenceMethod__ = {
     name: 'SignTransactionEssence';

--- a/bindings/nodejs/types/index.ts
+++ b/bindings/nodejs/types/index.ts
@@ -9,3 +9,4 @@ export * from './secretManager';
 export * from './transaction';
 export * from './transactionOptions';
 export * from './loggerConfig';
+export * from './preparedTransactionData';

--- a/bindings/nodejs/types/network.ts
+++ b/bindings/nodejs/types/network.ts
@@ -19,7 +19,7 @@ export interface NetworkInfo {
     localPow?: boolean;
     fallbackToLocalPow?: boolean;
     tipsInterval?: number;
-    rentStructure?: IRent
+    rentStructure?: IRent;
 }
 
 export type Node = {

--- a/bindings/nodejs/types/output.ts
+++ b/bindings/nodejs/types/output.ts
@@ -1,4 +1,8 @@
-import type { AddressTypes, IOutputResponse } from '@iota/types';
+import type {
+    AddressTypes,
+    OutputTypes,
+    IOutputMetadataResponse,
+} from '@iota/types';
 
 export enum OutputsToCollect {
     None = 'None',
@@ -8,34 +12,26 @@ export enum OutputsToCollect {
     All = 'All',
 }
 
-enum OutputType {
-    Treasury = 'Treasury',
-    Basic = 'Basic',
-    Alias = 'Alias',
-    Foundry = 'Foundry',
-    Nft = 'Nft',
-}
-
+/** An output with metadata */
 export interface OutputData {
+    /** The output id */
     outputId: string;
-    outputResponse: IOutputResponse;
-    output: Output;
+    /** The metadata of the output */
+    metadata: IOutputMetadataResponse;
+    /** The actual Output */
+    output: OutputTypes;
+    /** The output amount */
     amount: string;
+    /** If an output is spent */
     isSpent: boolean;
-    address: {
-        type: AddressTypes;
-        data: string;
-    };
+    /** Associated account address */
+    address: AddressTypes;
+    /** Network ID */
     networkId: string;
+    /** Remainder */
     remainder: boolean;
+    /** Bip32 path */
     chain?: Segment[];
-}
-
-// TODO: this should be the same as bee_block::output::OutputDto
-export interface Output {
-    type: OutputType;
-    // TODO: specify the return type 
-    data: any;
 }
 
 export interface Segment {

--- a/bindings/nodejs/types/preparedTransactionData.ts
+++ b/bindings/nodejs/types/preparedTransactionData.ts
@@ -1,0 +1,66 @@
+import type {
+    AddressTypes,
+    IOutputMetadataResponse,
+    ITransactionEssence,
+    OutputTypes,
+} from '@iota/types';
+import type { Segment } from './output';
+
+/**
+ * Helper struct for offline signing
+ */
+export interface PreparedTransactionData {
+    /**
+     * Transaction essence
+     */
+    essence: ITransactionEssence;
+    /**
+     * Required address information for signing
+     */
+    inputsData: InputSigningData[];
+    /**
+     * Optional remainder output information
+     */
+    remainder?: RemainderData;
+}
+
+/**
+ * Data for transaction inputs for signing and ordering of unlock blocks
+ */
+export interface InputSigningData {
+    /**
+     * The output
+     */
+    output: OutputTypes;
+    /**
+     * The output metadata
+     */
+    outputMetaData: IOutputMetadataResponse;
+    /**
+     * The chain derived from seed, only for ed25519 addresses
+     */
+    chain?: Segment[];
+    /**
+     * The bech32 encoded address, required because of alias outputs where we have multiple possible unlock
+     * conditions, because we otherwise don't know which one we need
+     */
+    bech32Address: string;
+}
+
+/**
+ * Data for a remainder output, used for ledger nano
+ */
+export interface RemainderData {
+    /**
+     * The remainder output
+     */
+    output: OutputTypes;
+    /**
+     * The chain derived from seed, for the remainder addresses
+     */
+    chain?: Segment[];
+    /**
+     * The remainder address
+     */
+    address: AddressTypes;
+}

--- a/bindings/nodejs/types/remainderData.ts
+++ b/bindings/nodejs/types/remainderData.ts
@@ -1,8 +1,0 @@
-import type { AddressTypes, OutputTypes } from '@iota/types'
-import type { Segment } from './output'
-
-export type RemainderData = {
-    output: OutputTypes,
-    chain: Segment[],
-    address: AddressTypes
-}

--- a/bindings/nodejs/types/signedTransactionEssence.ts
+++ b/bindings/nodejs/types/signedTransactionEssence.ts
@@ -1,7 +1,7 @@
-import type { ITransactionPayload } from '@iota/types'
-import type { InputsData } from './transaction'
+import type { ITransactionPayload } from '@iota/types';
+import type { InputSigningData } from './preparedTransactionData';
 
-export type SignedTransactionEssence = {
-    transactionPayload: ITransactionPayload,
-    inputsData: InputsData
+export interface SignedTransactionEssence {
+    transactionPayload: ITransactionPayload;
+    inputsData: InputSigningData;
 }

--- a/bindings/nodejs/types/transaction.ts
+++ b/bindings/nodejs/types/transaction.ts
@@ -1,6 +1,4 @@
-import type { IOutputMetadataResponse, ITransactionEssence, ITransactionPayload, OutputTypes } from '@iota/types';
-import type { Segment } from './output';
-import type { RemainderData } from './remainderData';
+import type { ITransactionPayload } from '@iota/types';
 
 enum InclusionState {
     Pending = 'Pending',
@@ -20,18 +18,4 @@ export interface Transaction {
 export interface TransactionResult {
     transactionId: string;
     blockId?: string;
-}
-
-// TODO replace with IPreparedTransactionData from iota.rs once exposed in @iota/types
-export interface PreparedTransactionData {
-    essence: ITransactionEssence;
-    inputsData: InputsData[];
-    remainder?: RemainderData 
-}
-
-export interface InputsData {
-    output: OutputTypes;
-    outputMetadata: IOutputMetadataResponse;
-    chain: Segment[];
-    bech32Address: string;
 }

--- a/bindings/nodejs/types/transactionOptions.ts
+++ b/bindings/nodejs/types/transactionOptions.ts
@@ -7,7 +7,10 @@ export interface TransactionOptions {
     customInputs?: string[];
 }
 
-export type RemainderValueStrategy = ChangeAddress | ReuseAddress | CustomAddress
+export type RemainderValueStrategy =
+    | ChangeAddress
+    | ReuseAddress
+    | CustomAddress;
 
 type ChangeAddress = {
     strategy: 'ChangeAddress';


### PR DESCRIPTION
# Description of change

- Updated `OutputData` and `PreparedTransaction` types.
- Replaced `Output` type with `OutputTypes` from `@iota/types`.
- Format and lint. 

## Links to any relevant issues

Fixes issue #1101.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Using the examples I created an account, requested funds and ran `16a-prepare-and-send-amount`. It ran successfully, and I inspected the `preparedTransaction` in logs. I also inspected the `OutputData` type in logs by running example `12a-list-outputs.js`.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
