### PR TITLE
Add native tokens to consolidation

### DIFF
--- a/examples/output_consolidation.rs
+++ b/examples/output_consolidation.rs
@@ -1,0 +1,80 @@
+// Copyright 2021 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! cargo run --example output_consolidation --release
+// In this example we will consolidate basic outputs from an account with only an AddressUnlockCondition by sending them
+// to the same address again
+// Rename `.env.example` to `.env` first
+
+use std::env;
+
+use dotenv::dotenv;
+use iota_client::bee_block::payload::transaction::TransactionId;
+use iota_wallet::{account_manager::AccountManager, Result};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // This example uses dotenv, which is not safe for use in production
+    dotenv().ok();
+
+    // Create the account manager
+    let manager = AccountManager::builder().finish().await?;
+
+    // Get the account we generated with `01_create_wallet`
+    let account = manager.get_account("Alice").await?;
+
+    // Set the stronghold password
+    manager
+        .set_stronghold_password(&env::var("STRONGHOLD_PASSWORD").unwrap())
+        .await?;
+
+    // Sync account to make sure account is updated with outputs from previous examples
+    let _ = account.sync(None).await?;
+
+    // List unspent outputs before consolidation.
+    // The output we created with example `03_get_funds` and the basic output from `09_mint_native_tokens` have only one
+    // unlock condition and it is an `AdressUnlockCondition`, and so they are valid for consolidation. They have the
+    // same `AddressUnlockCondition`(the first address of the account), so they will be consolidated into one
+    // output.
+    let outputs = account.list_unspent_outputs().await?;
+    println!("Outputs before consolidation:");
+    outputs.iter().for_each(|output| {
+        println!(
+            "address: {:?}\n amount: {:?}\n native tokens: {:?}\n",
+            output.address.to_bech32("rms"),
+            output.amount,
+            output.output.native_tokens()
+        )
+    });
+
+    // Consolidate unspent outputs and print the consolidation transaction IDs
+    // Set `force` to true to force the consolidation even though the `output_consolidation_threshold` isn't reached
+    let consolidation = account.consolidate_outputs(true, None).await?;
+    println!(
+        "Consolidation transaction ids:\n{:?}\n",
+        consolidation
+            .iter()
+            .map(|t| t.transaction_id)
+            .collect::<Vec<TransactionId>>()
+    );
+
+    // Wait for the consolidation transactions
+    tokio::time::sleep(std::time::Duration::from_secs(15)).await;
+
+    // Sync account
+    let _ = account.sync(None).await?;
+
+    // Outputs after consolidation
+    let outputs = account.list_unspent_outputs().await?;
+    println!("Outputs after consolidation:");
+    outputs.iter().for_each(|output| {
+        println!(
+            "address: {:?}\n amount: {:?}\n native tokens: {:?}\n",
+            output.address.to_bech32("rms"),
+            output.amount,
+            output.output.native_tokens()
+        )
+    });
+
+    Ok(())
+}

--- a/src/account/operations/syncing/mod.rs
+++ b/src/account/operations/syncing/mod.rs
@@ -31,8 +31,8 @@ use crate::{
 };
 
 impl AccountHandle {
-    /// Syncs the account by fetching new information from the nodes. Will also retry pending transactions and
-    /// consolidate outputs if necessary.
+    /// Syncs the account by fetching new information from the nodes. Will also retry pending transactions
+    /// if necessary.
     pub async fn sync(&self, options: Option<SyncOptions>) -> crate::Result<AccountBalance> {
         let options = options.unwrap_or_default();
         log::debug!("[SYNC] start syncing with {:?}", options);

--- a/src/message_interface/account_method.rs
+++ b/src/message_interface/account_method.rs
@@ -96,6 +96,13 @@ pub enum AccountMethod {
         #[serde(rename = "immutableFeatures")]
         immutable_features: Option<Vec<FeatureDto>>,
     },
+    /// Consolidate outputs.
+    /// Expected response: [`SentTransactions`](crate::message_interface::Response::SentTransactions)
+    ConsolidateOutputs {
+        force: bool,
+        #[serde(rename = "outputConsolidationThreshold")]
+        output_consolidation_threshold: Option<usize>,
+    },
     /// Generate a new unused address.
     /// Expected response: [`GeneratedAddress`](crate::message_interface::Response::GeneratedAddress)
     GenerateAddresses {
@@ -201,8 +208,8 @@ pub enum AccountMethod {
         addresses_nft_ids: Vec<AddressAndNftId>,
         options: Option<TransactionOptions>,
     },
-    /// Syncs the account by fetching new information from the nodes. Will also retry pending transactions and
-    /// consolidate outputs if necessary.
+    /// Syncs the account by fetching new information from the nodes. Will also retry pending transactions
+    /// if necessary.
     /// Expected response: [`Balance`](crate::message_interface::Response::Balance)
     SyncAccount {
         /// Sync options

--- a/src/message_interface/message_handler.rs
+++ b/src/message_interface/message_handler.rs
@@ -373,10 +373,13 @@ impl WalletMessageHandler {
                 force,
                 output_consolidation_threshold,
             } => {
-                let transaction_results = account_handle
-                    .consolidate_outputs(*force, *output_consolidation_threshold)
-                    .await?;
-                Ok(Response::SentTransactions(transaction_results))
+                convert_async_panics(|| async {
+                    let transaction_results = account_handle
+                        .consolidate_outputs(*force, *output_consolidation_threshold)
+                        .await?;
+                    Ok(Response::SentTransactions(transaction_results))
+                })
+                .await
             }
             AccountMethod::GenerateAddresses { amount, options } => {
                 let address = account_handle.generate_addresses(*amount, options.clone()).await?;

--- a/src/message_interface/message_handler.rs
+++ b/src/message_interface/message_handler.rs
@@ -369,6 +369,15 @@ impl WalletMessageHandler {
                 .await?;
                 Ok(Response::BuiltOutput(output_dto))
             }
+            AccountMethod::ConsolidateOutputs {
+                force,
+                output_consolidation_threshold,
+            } => {
+                let transaction_results = account_handle
+                    .consolidate_outputs(*force, *output_consolidation_threshold)
+                    .await?;
+                Ok(Response::SentTransactions(transaction_results))
+            }
             AccountMethod::GenerateAddresses { amount, options } => {
                 let address = account_handle.generate_addresses(*amount, options.clone()).await?;
                 Ok(Response::GeneratedAddress(address))

--- a/src/message_interface/response.rs
+++ b/src/message_interface/response.rs
@@ -87,8 +87,10 @@ pub enum Response {
     /// [`SendTransaction`](crate::message_interface::AccountMethod::SendTransaction)
     /// [`SubmitAndStoreTransaction`](crate::message_interface::AccountMethod::SubmitAndStoreTransaction)
     SentTransaction(TransactionResult),
-    /// Response for [`TryCollectOutputs`](crate::message_interface::AccountMethod::TryCollectOutputs),
+    /// Response for
+    /// [`TryCollectOutputs`](crate::message_interface::AccountMethod::TryCollectOutputs),
     /// [`CollectOutputs`](crate::message_interface::AccountMethod::CollectOutputs)
+    /// [`ConsolidateOutputs`](crate::message_interface::AccountMethod::ConsolidateOutputs)
     SentTransactions(Vec<TransactionResult>),
     /// Response for
     /// [`IsStrongholdPasswordAvailable`](crate::message_interface::Message::IsStrongholdPasswordAvailable)


### PR DESCRIPTION
# Description of change

- Use a `NativeTokensBuilder` to include native tokens when consolidating outputs on an address. 
- Add an example of how to use `consolidate_outputs()`.
- Expose `consolidate_outputs()` to bindings in the `message_interface` with a new `account_method`: `ConsolidateOutputs`.

## Links to any relevant issues

Fixes issue  #1119.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Added a new example: `output_consolidation`.
Todo: test the new `account_method`.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
