### PR TITLE
Don't print DBG logs in examples compiled with --release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ iota-client = { git = "https://github.com/iotaledger/iota.rs", rev = "a884558653
 # Switch back when a new version got released
 # iota-crypto = { version = "0.11.0", default-features = false, features = [ "std", "chacha", "blake2b", "ed25519", "random", "slip10", "bip39", "bip39-en" ] }
 iota-crypto = { git = "https://github.com/iotaledger/crypto.rs", rev = "c61d29253930105d0d589e54829b639427061e81",  default-features = false, features = [ "std", "chacha", "blake2b", "ed25519", "random", "slip10", "bip39", "bip39-en" ] }
-log = { version = "0.4.14", default-features = false }
+log = { version = "0.4.14", default-features = false, features = ["release_max_level_off"] }
 primitive-types = { version = "0.10.1", default-features = false }
 serde = { version = "1.0.137", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.68", default-features = false }


### PR DESCRIPTION
# Description of change

Use release_max_level_off so examples in release mode don't print DBG logs (caused by Riker, dependency from Stronghold)

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

With the examples

## Change checklist
- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
