### PR TITLE
Return error from setStrongholdPassword()

### DIFF
--- a/.changes/set_stronghold_password.md
+++ b/.changes/set_stronghold_password.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": patch
+---
+
+Return an error when calling `setStrongholdPassword()` with a wrong password.

--- a/bindings/nodejs/src/classes/account_manager/mod.rs
+++ b/bindings/nodejs/src/classes/account_manager/mod.rs
@@ -256,8 +256,11 @@ pub fn set_stronghold_password(mut cx: FunctionContext) -> JsResult<JsUndefined>
         let result = wrapper.account_manager.set_stronghold_password(password).await;
         let _ = sender.send(result);
     });
-    let _ = receiver.recv().unwrap();
-    Ok(cx.undefined())
+
+    match receiver.recv().unwrap() {
+        Ok(_) => Ok(cx.undefined()),
+        Err(e) => cx.throw_error(e.to_string()),
+    }
 }
 
 pub fn change_stronghold_password(mut cx: FunctionContext) -> JsResult<JsUndefined> {


### PR DESCRIPTION
# Description of change

Return an error when calling `setStrongholdPassword()` with a wrong password

## Links to any relevant issues

Fixes #1132 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Second example with a wrong password

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
