### PR TITLE
Add method to remove handlers from the EventEmitter

### DIFF
--- a/bindings/nodejs/examples/7-events.js
+++ b/bindings/nodejs/examples/7-events.js
@@ -10,41 +10,65 @@ async function run() {
         const account = await manager.getAccount('Alice');
         console.log('Account:', account);
 
-        // You can also get the latest unused address:
-        // const addressObject = await account.latestAddress();
-        // console.log('Address:', addressObject);
-
         // Use the Chrysalis Faucet to send testnet tokens to your address:
         console.log(
             'Fill your address with the Faucet: https://faucet.chrysalis-devnet.iota.cafe/',
         );
 
         const callback = function (err, data) {
-            console.log('all event data:', JSON.parse(data));
-        };
-        // empty array listens to all event types
-        manager.listen([], callback);
-
-        const callback2 = function (err, data) {
             console.log('data:', JSON.parse(data));
         };
+
         // provide event type to filter only for events with this type
-        manager.listen(['BalanceChange'], callback2);
+        manager.listen(['TransactionProgress'], callback);
 
-        const address = await account.generateAddresses();
-        console.log('New address:', address);
+        // send transaction
+        await account.sendMicroTransaction([
+            {
+                address:
+                    'rms1qph3f6y3ps7zccucatf70y37kz7udzp94aefg6mzxdgpa5xxerg9u4s0xyz',
+                amount: '1000',
+            },
+        ]);
 
+        // provide event type to remove only event listeners of this type
+        manager.clearListeners(['TransactionProgress']);
+
+        const callback2 = function (err, data) {
+            console.log('all event data:', JSON.parse(data));
+        };
+        // provide empty array to listen to all event types
+        manager.listen([], callback2);
+
+        // build basic output
+        let output = await account.buildBasicOutput({
+            amount: '1000000',
+            unlockConditions: [
+                {
+                    type: 0,
+                    address: {
+                        type: 0,
+                        pubKeyHash: `0xc6cf27e8d7c54c420c1315f83567c6bd1b5fad7e9ffa83996680f2aedb2ed0be`,
+                    },
+                },
+            ],
+        });
+        // send transaction with the output we created
+        await account.sendTransaction([output]);
+
+        // provide empty array to clear all listeners for all event types
         setTimeout(() => {
-            manager.removeEventListeners('BalanceChange');
-            console.log('event listeners removed');
-        }, 300000);
+            manager.clearListeners([]);
+            console.log('All event listeners removed');
+        }, 20000);
     } catch (error) {
         console.log('Error: ' + error);
     }
 
     // Possible Event Types:
     //
-    // BalanceChange
+    // SpentOutput
+    // NewOutput
     // TransactionInclusion
     // TransactionProgress
     // ConsolidationRequired

--- a/bindings/nodejs/lib/AccountManager.ts
+++ b/bindings/nodejs/lib/AccountManager.ts
@@ -38,9 +38,8 @@ export class AccountManager {
             cmd: 'ChangeStrongholdPassword',
             payload: {
                 password,
-
-            }
-        })
+            },
+        });
     }
 
     async clearStrongholdPassword(): Promise<void> {
@@ -134,6 +133,10 @@ export class AccountManager {
         callback: (error: Error, result: string) => void,
     ): void {
         return this.messageHandler.listen(eventTypes, callback);
+    }
+
+    clearListeners(eventTypes: EventType[]): void {
+        return this.messageHandler.clearListeners(eventTypes);
     }
 
     // TODO: test this

--- a/bindings/nodejs/lib/MessageHandler.ts
+++ b/bindings/nodejs/lib/MessageHandler.ts
@@ -5,6 +5,7 @@ import {
     sendMessageAsync,
     messageHandlerNew,
     listen,
+    clearListeners,
     destroy,
 } from './bindings';
 import type {
@@ -51,6 +52,10 @@ export class MessageHandler {
         callback: (error: Error, result: string) => void,
     ): void {
         return listen(eventTypes, callback, this.messageHandler);
+    }
+
+    clearListeners(eventTypes: EventType[]): void {
+        return clearListeners(eventTypes, this.messageHandler);
     }
 
     destroy(): void {

--- a/bindings/nodejs/lib/bindings.ts
+++ b/bindings/nodejs/lib/bindings.ts
@@ -10,8 +10,7 @@ const {
     sendMessage,
     messageHandlerNew,
     listen,
-    eventListenerNew,
-    removeEventListeners,
+    clearListeners,
     destroy,
 } = addon;
 
@@ -34,7 +33,6 @@ export {
     sendMessageAsync,
     messageHandlerNew,
     listen,
-    eventListenerNew,
-    removeEventListeners,
+    clearListeners,
     destroy,
 };

--- a/bindings/nodejs/src/lib.rs
+++ b/bindings/nodejs/src/lib.rs
@@ -27,6 +27,7 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function("destroy", message_handler::destroy)?;
 
     cx.export_function("listen", message_handler::listen)?;
+    cx.export_function("clearListeners", message_handler::clear_listeners)?;
 
     cx.export_function("initLogger", init_logger)?;
     Ok(())

--- a/bindings/nodejs/src/message_handler.rs
+++ b/bindings/nodejs/src/message_handler.rs
@@ -141,8 +141,9 @@ pub fn listen(mut cx: FunctionContext) -> JsResult<JsUndefined> {
     let vec: Vec<Handle<JsValue>> = js_arr_handle.to_vec(&mut cx)?;
     let mut event_types = vec![];
     for event_string in vec {
-        let event_type = event_string.downcast::<JsString, FunctionContext>(&mut cx).unwrap();
-        let wallet_event_type = WalletEventType::try_from(event_type.value(&mut cx).as_str()).unwrap();
+        let event_type = event_string.downcast_or_throw::<JsString, FunctionContext>(&mut cx)?;
+        let wallet_event_type =
+            WalletEventType::try_from(event_type.value(&mut cx).as_str()).or_else(|e| cx.throw_error(e))?;
         event_types.push(wallet_event_type);
     }
 
@@ -171,8 +172,9 @@ pub fn clear_listeners(mut cx: FunctionContext) -> JsResult<JsUndefined> {
     let vec: Vec<Handle<JsValue>> = js_arr_handle.to_vec(&mut cx)?;
     let mut event_types = vec![];
     for event_string in vec {
-        let event_type = event_string.downcast::<JsString, FunctionContext>(&mut cx).unwrap();
-        let wallet_event_type = WalletEventType::try_from(event_type.value(&mut cx).as_str()).unwrap();
+        let event_type = event_string.downcast_or_throw::<JsString, FunctionContext>(&mut cx)?;
+        let wallet_event_type =
+            WalletEventType::try_from(event_type.value(&mut cx).as_str()).or_else(|e| cx.throw_error(e))?;
         event_types.push(wallet_event_type);
     }
 

--- a/src/account_manager/mod.rs
+++ b/src/account_manager/mod.rs
@@ -238,6 +238,13 @@ impl AccountManager {
         emitter.on(events, handler);
     }
 
+    #[cfg(feature = "events")]
+    /// Remove wallet event listeners, empty vec will remove all listeners
+    pub async fn clear_listeners(&self, events: Vec<WalletEventType>) {
+        let mut emitter = self.event_emitter.lock().await;
+        emitter.clear(events);
+    }
+
     /// Generates a new random mnemonic.
     pub fn generate_mnemonic(&self) -> crate::Result<String> {
         Ok(Client::generate_mnemonic()?)

--- a/src/message_interface/message_handler.rs
+++ b/src/message_interface/message_handler.rs
@@ -93,6 +93,12 @@ impl WalletMessageHandler {
         self.account_manager.listen(events, handler).await;
     }
 
+    #[cfg(feature = "events")]
+    /// Remove wallet event listeners, empty vec will remove all listeners
+    pub async fn clear_listeners(&self, events: Vec<WalletEventType>) {
+        self.account_manager.clear_listeners(events).await;
+    }
+
     /// Handles a message.
     pub async fn handle(&self, message: Message, response_tx: UnboundedSender<Response>) {
         log::debug!("Message: {:?}", message);

--- a/src/message_interface/mod.rs
+++ b/src/message_interface/mod.rs
@@ -86,6 +86,12 @@ where
     handle.listen(events, handler).await;
 }
 
+#[cfg(feature = "events")]
+/// Remove wallet event listeners, empty vec will remove all listeners
+pub async fn clear_listeners(handle: &WalletMessageHandler, events: Vec<WalletEventType>) {
+    handle.clear_listeners(events).await;
+}
+
 #[cfg(test)]
 mod tests {
     use iota_client::bee_block::{

--- a/tests/accounts.rs
+++ b/tests/accounts.rs
@@ -68,7 +68,7 @@ async fn remove_latest_account() -> Result<()> {
         assert!(manager.get_accounts().await.unwrap().len() == 2);
 
         // Remove `second_account`.
-        let _ = manager
+        manager
             .remove_latest_account()
             .await
             .expect("cannot remove latest account");
@@ -82,7 +82,7 @@ async fn remove_latest_account() -> Result<()> {
         );
 
         // Remove `first_account`.
-        let _ = manager
+        manager
             .remove_latest_account()
             .await
             .expect("cannot remove latest account");
@@ -92,7 +92,7 @@ async fn remove_latest_account() -> Result<()> {
         assert!(accounts.is_empty());
 
         // Try remove another time (even if there is nothing to remove).
-        let _ = manager
+        manager
             .remove_latest_account()
             .await
             .expect("cannot remove latest account");


### PR DESCRIPTION
# Description of change

- [x] Add method to clear event handlers from `EventEmitter`.
- [x] Expose the new method in `account_manager` and `message_interface`.
- [x]  Implement it in the nodejs Neon module and add it to the nodejs `AccountManager`.

## Links to any relevant issues

Fixes issue  #1133.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Modified `events` test in `src/events`.
Modified example `7-events.js` in nodejs bindings.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
