### PR TITLE
Add prepare_output

### DIFF
--- a/bindings/nodejs/examples/4b-send-transfer.js
+++ b/bindings/nodejs/examples/4b-send-transfer.js
@@ -23,7 +23,7 @@ async function run() {
 
         console.log('Output built:', output)
 
-        const response = await account.sendTransaction([output]);
+        const response = await account.sendOutputs([output]);
 
         console.log(response);
 

--- a/bindings/nodejs/lib/Account.ts
+++ b/bindings/nodejs/lib/Account.ts
@@ -320,23 +320,6 @@ export class Account {
         return JSON.parse(response).payload;
     }
 
-    async prepareMintNfts(
-        nftOptions: NftOptions[],
-        options?: TransactionOptions,
-    ): Promise<PreparedTransactionData> {
-        const response = await this.messageHandler.callAccountMethod(
-            this.meta.index,
-            {
-                name: 'PrepareMintNfts',
-                data: {
-                    nftOptions,
-                    options,
-                },
-            },
-        );
-        return JSON.parse(response).payload;
-    }
-
     async prepareSendAmount(
         addressWithAmount: AddressWithAmount[],
         options?: TransactionOptions,
@@ -353,58 +336,7 @@ export class Account {
         );
         return JSON.parse(response).payload;
     }
-
-    async prepareSendMicroTransaction(
-        addressWithMicroAmounts: AddressWithMicroAmount[],
-        options?: TransactionOptions,
-    ): Promise<PreparedTransactionData> {
-        const response = await this.messageHandler.callAccountMethod(
-            this.meta.index,
-            {
-                name: 'PrepareSendMicroTransaction',
-                data: {
-                    addressWithMicroAmounts,
-                    options,
-                },
-            },
-        );
-        return JSON.parse(response).payload;
-    }
-
-    async prepareSendNativeToken(
-        addressNativeTokens: AddressNativeTokens[],
-        options?: TransactionOptions,
-    ): Promise<PreparedTransactionData> {
-        const response = await this.messageHandler.callAccountMethod(
-            this.meta.index,
-            {
-                name: 'PrepareSendNativeToken',
-                data: {
-                    addressNativeTokens,
-                    options,
-                },
-            },
-        );
-        return JSON.parse(response).payload;
-    }
-
-    async prepareSendNft(
-        addressNftIds: AddressNftId[],
-        options?: TransactionOptions,
-    ): Promise<PreparedTransactionData> {
-        const response = await this.messageHandler.callAccountMethod(
-            this.meta.index,
-            {
-                name: 'PrepareSendNft',
-                data: {
-                    addressNftIds,
-                    options,
-                },
-            },
-        );
-        return JSON.parse(response).payload;
-    }
-
+    
     async prepareTransaction(
         outputs: OutputTypes[],
         options?: TransactionOptions,
@@ -494,14 +426,14 @@ export class Account {
         return JSON.parse(response).payload;
     }
 
-    async sendTransaction(
+    async sendOutputs(
         outputs: OutputTypes[],
         transactionOptions?: TransactionOptions,
     ): Promise<TransactionResult> {
         const response = await this.messageHandler.callAccountMethod(
             this.meta.index,
             {
-                name: 'SendTransaction',
+                name: 'SendOutputs',
                 data: {
                     outputs,
                     options: transactionOptions,

--- a/bindings/nodejs/types/bridge/account.ts
+++ b/bindings/nodejs/types/bridge/account.ts
@@ -153,30 +153,6 @@ export type __PrepareSendAmountMethod__ = {
     };
 };
 
-export type __PrepareSendMicroTransactionMethod__ = {
-    name: 'PrepareSendMicroTransaction';
-    data: {
-        addressWithMicroAmounts: AddressWithMicroAmount[];
-        options?: TransactionOptions;
-    };
-};
-
-export type __PrepareSendNativeTokenMethod__ = {
-    name: 'PrepareSendNativeToken';
-    data: {
-        addressNativeTokens: AddressNativeTokens[];
-        options?: TransactionOptions;
-    };
-};
-
-export type __PrepareSendNftMethod__ = {
-    name: 'PrepareSendNft';
-    data: {
-        addressNftIds: AddressNftId[];
-        options?: TransactionOptions;
-    };
-};
-
 export type __PrepareTransactionMethod__ = {
     name: 'PrepareTransaction';
     data: {
@@ -217,8 +193,8 @@ export type __SendNftMethod__ = {
     };
 };
 
-export type __SendTransactionMethod__ = {
-    name: 'SendTransaction';
+export type __SendOutputsMethod__ = {
+    name: 'SendOutputs';
     data: {
         outputs: OutputTypes[];
         options?: TransactionOptions;

--- a/bindings/nodejs/types/bridge/account.ts
+++ b/bindings/nodejs/types/bridge/account.ts
@@ -137,14 +137,6 @@ export type __MintNftsMethod__ = {
     };
 };
 
-export type __PrepareMintNftsMethod__ = {
-    name: 'PrepareMintNfts';
-    data: {
-        nftOptions: NftOptions[];
-        options?: TransactionOptions;
-    };
-};
-
 export type __PrepareSendAmountMethod__ = {
     name: 'PrepareSendAmount';
     data: {

--- a/bindings/nodejs/types/bridge/index.ts
+++ b/bindings/nodejs/types/bridge/index.ts
@@ -20,17 +20,13 @@ import type {
     __MinimumRequiredStorageDepositMethod__,
     __MintNativeTokenMethod__,
     __MintNftsMethod__,
-    __PrepareMintNftsMethod__,
     __PrepareSendAmountMethod__,
-    __PrepareSendMicroTransactionMethod__,
-    __PrepareSendNativeTokenMethod__,
-    __PrepareSendNftMethod__,
     __PrepareTransactionMethod__,
     __SendAmountMethod__,
     __SendMicroTransactionMethod__,
     __SendNativeTokensMethod__,
     __SendNftMethod__,
-    __SendTransactionMethod__,
+    __SendOutputsMethod__,
     __SetAliasMethod__,
     __SignTransactionEssenceMethod__,
     __SubmitAndStoreTransactionMethod__,
@@ -84,17 +80,13 @@ export type __AccountMethod__ =
     | __MinimumRequiredStorageDepositMethod__
     | __MintNativeTokenMethod__
     | __MintNftsMethod__
-    | __PrepareMintNftsMethod__
     | __PrepareSendAmountMethod__
-    | __PrepareSendMicroTransactionMethod__
-    | __PrepareSendNativeTokenMethod__
-    | __PrepareSendNftMethod__
     | __PrepareTransactionMethod__
     | __SendAmountMethod__
     | __SendMicroTransactionMethod__
     | __SendNativeTokensMethod__
     | __SendNftMethod__
-    | __SendTransactionMethod__
+    | __SendOutputsMethod__
     | __SetAliasMethod__
     | __SignTransactionEssenceMethod__
     | __SubmitAndStoreTransactionMethod__

--- a/bindings/python/native/iota_wallet/account.py
+++ b/bindings/python/native/iota_wallet/account.py
@@ -241,52 +241,12 @@ class Account:
             'GetBalance'
         )
 
-    def prepare_mint_nfts(self, nfts_options, options):
-        """Prepare mint nfts.
-        """
-        return self._call_account_method(
-            'PrepareMintNfts', {
-                'nfts_options': nfts_options,
-                'options': options
-            }
-        )
-
     def prepare_send_amount(self, addresses_with_amount, options):
         """Prepare send amount.
         """
         return self._call_account_method(
             'PrepareSendAmount', {
                 'addresses_with_amount': addresses_with_amount,
-                'options': options
-            }
-        )
-
-    def prepare_send_micro_transaction(self, addresses_with_micro_amount, options):
-        """Prepare send micro transaction.
-        """
-        return self._call_account_method(
-            'PrepareSendMicroTransaction', {
-                'addresses_with_micro_amount': addresses_with_micro_amount,
-                'options': options
-            }
-        )
-
-    def prepare_send_native_tokens(self, addresses_native_tokens, options):
-        """Prepare send native tokens.
-        """
-        return self._call_account_method(
-            'PrepareSendNativeTokens', {
-                'addresses_native_tokens': addresses_native_tokens,
-                'options': options
-            }
-        )
-
-    def prepare_send_nft(self, addresses_nft_ids, options):
-        """Prepare send nft.
-        """
-        return self._call_account_method(
-            'PrepareSendNft', {
-                'addresses_nft_ids': addresses_nft_ids,
                 'options': options
             }
         )

--- a/bindings/python/native/iota_wallet/account.py
+++ b/bindings/python/native/iota_wallet/account.py
@@ -412,12 +412,11 @@ class Account:
         )
 
     @ send_message_routine
-    def send_transaction(self, outputs, options=None):
-        """Syncs the account by fetching new information from the nodes.
-           Will also retry pending transactions and consolidate outputs if necessary.
+    def send_outputs(self, outputs, options=None):
+        """Send outputs in a transaction.
         """
         return self._call_account_method(
-            'SendTransaction', {
+            'SendOutputs', {
                 'outputs': outputs,
                 'options': options,
             }

--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -28,7 +28,7 @@ pub use self::{
         address_generation::AddressGenerationOptions,
         output_collection::OutputsToCollect,
         syncing::SyncOptions,
-        transaction::{RemainderValueStrategy, TransactionOptions},
+        transaction::{prepare_output::OutputOptions, RemainderValueStrategy, TransactionOptions},
     },
 };
 

--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -28,7 +28,10 @@ pub use self::{
         address_generation::AddressGenerationOptions,
         output_collection::OutputsToCollect,
         syncing::SyncOptions,
-        transaction::{prepare_output::OutputOptions, RemainderValueStrategy, TransactionOptions},
+        transaction::{
+            prepare_output::{Assets, Features, OutputOptions, StorageDeposit, Time, Unlocks},
+            RemainderValueStrategy, TransactionOptions,
+        },
     },
 };
 

--- a/src/account/operations/transaction/high_level/minting/mint_nfts.rs
+++ b/src/account/operations/transaction/high_level/minting/mint_nfts.rs
@@ -66,7 +66,7 @@ impl AccountHandle {
 
     /// Function to prepare the transaction for
     /// [AccountHandle.mint_nfts()](crate::account::handle::AccountHandle.mint_nfts)
-    pub async fn prepare_mint_nfts(
+    async fn prepare_mint_nfts(
         &self,
         nfts_options: Vec<NftOptions>,
         options: Option<TransactionOptions>,

--- a/src/account/operations/transaction/high_level/send_micro_transaction.rs
+++ b/src/account/operations/transaction/high_level/send_micro_transaction.rs
@@ -69,6 +69,7 @@ impl AccountHandle {
         addresses_with_micro_amount: Vec<AddressWithMicroAmount>,
         options: Option<TransactionOptions>,
     ) -> crate::Result<TransactionResult> {
+        log::debug!("[TRANSACTION] send_micro_transaction");
         let prepared_trasacton = self
             .prepare_send_micro_transaction(addresses_with_micro_amount, options)
             .await?;
@@ -77,12 +78,11 @@ impl AccountHandle {
 
     /// Function to prepare the transaction for
     /// [AccountHandle.send_micro_transaction()](crate::account::handle::AccountHandle.send_micro_transaction)
-    pub async fn prepare_send_micro_transaction(
+    async fn prepare_send_micro_transaction(
         &self,
         addresses_with_micro_amount: Vec<AddressWithMicroAmount>,
         options: Option<TransactionOptions>,
     ) -> crate::Result<PreparedTransactionData> {
-        log::debug!("[TRANSACTION] prepare_send_micro_transaction");
         let byte_cost_config = self.client.get_byte_cost_config().await?;
 
         let account_addresses = self.list_addresses().await?;

--- a/src/account/operations/transaction/high_level/send_native_tokens.rs
+++ b/src/account/operations/transaction/high_level/send_native_tokens.rs
@@ -80,7 +80,7 @@ impl AccountHandle {
 
     /// Function to prepare the transaction for
     /// [AccountHandle.send_native_tokens()](crate::account::handle::AccountHandle.send_native_tokens)
-    pub async fn prepare_send_native_tokens(
+    async fn prepare_send_native_tokens(
         &self,
         addresses_native_tokens: Vec<AddressNativeTokens>,
         options: Option<TransactionOptions>,

--- a/src/account/operations/transaction/high_level/send_nft.rs
+++ b/src/account/operations/transaction/high_level/send_nft.rs
@@ -60,7 +60,7 @@ impl AccountHandle {
 
     /// Function to prepare the transaction for
     /// [AccountHandle.send_nft()](crate::account::handle::AccountHandle.send_nft)
-    pub async fn prepare_send_nft(
+    async fn prepare_send_nft(
         &self,
         addresses_nft_ids: Vec<AddressAndNftId>,
         options: Option<TransactionOptions>,

--- a/src/account/operations/transaction/mod.rs
+++ b/src/account/operations/transaction/mod.rs
@@ -5,6 +5,7 @@ mod build_transaction;
 pub(crate) mod high_level;
 mod input_selection;
 mod options;
+pub(crate) mod prepare_output;
 mod prepare_transaction;
 mod sign_transaction;
 pub(crate) mod submit_transaction;

--- a/src/account/operations/transaction/prepare_output.rs
+++ b/src/account/operations/transaction/prepare_output.rs
@@ -21,10 +21,12 @@ use serde::{Deserialize, Serialize};
 use crate::account::{handle::AccountHandle, operations::transaction::RemainderValueStrategy, TransactionOptions};
 
 impl AccountHandle {
-    /// Prepare an output
+    /// Prepare an output for sending
     /// If the amount is below the minimum required storage deposit, by default the remaining amount will automatically
-    /// added with a StorageDepositReturn UnlockCondition
-    /// When the assets contain an nft_id, the nft output will be used, just with the address unlock conditions replaed
+    /// added with a StorageDepositReturn UnlockCondition, when setting the ReturnStrategy to `gift`, the full minimum
+    /// required storage deposit will be send to the recipient.
+    /// When the assets contain an nft_id, the data from the
+    /// exisiting nft output will be used, just with the address unlock conditions replaced
     pub async fn prepare_output(
         &self,
         options: OutputOptions,

--- a/src/account/operations/transaction/prepare_output.rs
+++ b/src/account/operations/transaction/prepare_output.rs
@@ -1,0 +1,333 @@
+// Copyright 2022 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{cmp::Ordering, str::FromStr};
+
+use iota_client::bee_block::{
+    address::Address,
+    output::{
+        dto::NativeTokenDto,
+        feature::{Feature, MetadataFeature, TagFeature},
+        unlock_condition::{
+            AddressUnlockCondition, ExpirationUnlockCondition, StorageDepositReturnUnlockCondition,
+            TimelockUnlockCondition, UnlockCondition,
+        },
+        BasicOutputBuilder, ByteCost, NativeToken, NftId, Output,
+    },
+    payload::milestone::MilestoneIndex,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::account::{handle::AccountHandle, operations::transaction::RemainderValueStrategy, TransactionOptions};
+
+impl AccountHandle {
+    /// Prepare an output
+    /// If the amount is below the minimum required storage deposit, by default the remaining amount will automatically
+    /// added with a StorageDepositReturn UnlockCondition
+    pub async fn prepare_output(
+        &self,
+        options: OutputOptions,
+        transaction_options: Option<TransactionOptions>,
+    ) -> crate::Result<Output> {
+        log::debug!("[OUTPUT] prepare_output {options:?}");
+
+        if let Some(assets) = &options.assets {
+            if let Some(nft_id) = assets.nft_id {
+                return self.prepare_nft_output(options.clone(), nft_id).await;
+            }
+        }
+        let byte_cost_config = self.client.get_byte_cost_config().await?;
+
+        // We start building with minimum storage deposit, so we know the minimum required amount and can later replace
+        // it, if needed
+        let mut basic_second_output_builder = BasicOutputBuilder::new_with_minimum_storage_deposit(
+            byte_cost_config.clone(),
+        )?
+        .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(
+            Address::try_from_bech32(options.recipient_address.clone())?.1,
+        )));
+
+        if let Some(assets) = options.assets {
+            if let Some(native_tokens) = assets.native_tokens {
+                basic_second_output_builder = basic_second_output_builder.with_native_tokens(native_tokens);
+            }
+        }
+
+        if let Some(features) = options.features {
+            if let Some(tag) = features.tag {
+                basic_second_output_builder = basic_second_output_builder
+                    .add_feature(Feature::Tag(TagFeature::new(hex::encode(tag).as_bytes().to_vec())?));
+            }
+            if let Some(metadata) = features.metadata {
+                basic_second_output_builder = basic_second_output_builder.add_feature(Feature::Metadata(
+                    MetadataFeature::new(hex::encode(metadata).as_bytes().to_vec())?,
+                ));
+            }
+        }
+
+        if let Some(unlocks) = options.unlocks {
+            if let Some(expiration) = unlocks.expiration {
+                // todo: move this in an own method
+                let remainder_address = match &transaction_options {
+                    Some(options) => {
+                        match &options.remainder_value_strategy {
+                            RemainderValueStrategy::ReuseAddress => {
+                                // select_inputs will select an address from the inputs if it's none
+                                None
+                            }
+                            RemainderValueStrategy::ChangeAddress => {
+                                let remainder_address = self.generate_remainder_address().await?;
+                                Some(remainder_address.address().inner)
+                            }
+                            RemainderValueStrategy::CustomAddress(address) => Some(address.address().inner),
+                        }
+                    }
+                    None => None,
+                };
+                let remainder_address = match remainder_address {
+                    Some(address) => address,
+                    None => self.generate_remainder_address().await?.address().inner,
+                };
+
+                basic_second_output_builder = basic_second_output_builder.add_unlock_condition(
+                    UnlockCondition::Expiration(ExpirationUnlockCondition::new(
+                        remainder_address,
+                        MilestoneIndex::new(expiration.milestone_index.unwrap_or_default()),
+                        expiration.unix_time.unwrap_or_default(),
+                    )?),
+                );
+            }
+            if let Some(timelock) = unlocks.timelock {
+                basic_second_output_builder = basic_second_output_builder.add_unlock_condition(
+                    UnlockCondition::Timelock(TimelockUnlockCondition::new(
+                        MilestoneIndex::new(timelock.milestone_index.unwrap_or_default()),
+                        timelock.unix_time.unwrap_or_default(),
+                    )?),
+                );
+            }
+        }
+
+        let first_output = basic_second_output_builder.finish()?;
+
+        let mut second_output_builder = BasicOutputBuilder::from(&first_output);
+
+        // Update the amount
+        match options.amount.cmp(&first_output.amount()) {
+            Ordering::Greater | Ordering::Equal => {
+                // if it's larger than the minimum storage deposit, just replace it
+                second_output_builder = second_output_builder.with_amount(options.amount)?;
+            }
+            Ordering::Less => {
+                let storage_deposit = options.storage_deposit.unwrap_or_default();
+                // Gift return strategy doesn't need a change, since the amount is already the minimum storage
+                // deposit
+                if let ReturnStrategy::Return = storage_deposit.return_strategy.unwrap_or_default() {
+                    // todo: move this in an own method
+                    let remainder_address = match &transaction_options {
+                        Some(options) => {
+                            match &options.remainder_value_strategy {
+                                RemainderValueStrategy::ReuseAddress => {
+                                    // select_inputs will select an address from the inputs if it's none
+                                    None
+                                }
+                                RemainderValueStrategy::ChangeAddress => {
+                                    let remainder_address = self.generate_remainder_address().await?;
+                                    Some(remainder_address.address().inner)
+                                }
+                                RemainderValueStrategy::CustomAddress(address) => Some(address.address().inner),
+                            }
+                        }
+                        None => None,
+                    };
+                    let remainder_address = match remainder_address {
+                        Some(address) => address,
+                        None => self.generate_remainder_address().await?.address().inner,
+                    };
+
+                    // Calculate the amount to be returned
+                    let minimum_storage_deposit_remainder =
+                        BasicOutputBuilder::new_with_minimum_storage_deposit(byte_cost_config.clone())?
+                            .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(
+                                Address::try_from_bech32(options.recipient_address)?.1,
+                            )))
+                            .finish_output()?
+                            .amount();
+
+                    second_output_builder = second_output_builder.add_unlock_condition(
+                        UnlockCondition::StorageDepositReturn(StorageDepositReturnUnlockCondition::new(
+                            remainder_address,
+                            minimum_storage_deposit_remainder,
+                        )?),
+                    );
+                }
+
+                if storage_deposit.use_excess_if_low.unwrap_or_default() {
+                    todo!(
+                        "Get account balance and check if the remainding balance wouldn't leave dust behind, which wouldn't allow the creation of this output"
+                    )
+                }
+            }
+        }
+
+        let second_output = second_output_builder.finish()?;
+
+        let required_storage_deposit = Output::Basic(second_output.clone()).byte_cost(&byte_cost_config);
+
+        let mut third_output_builder = BasicOutputBuilder::from(&second_output);
+
+        // We might have added more unlock conditions, so we check the minimum storage deposit again and update the
+        // amounts if needed
+        if second_output.amount() < required_storage_deposit {
+            third_output_builder = third_output_builder.with_amount(required_storage_deposit)?;
+            // add newly added amount also to the storage deposit return unlock condition, if that was added
+            let new_sdr_amount = required_storage_deposit - options.amount;
+            if let Some(UnlockCondition::StorageDepositReturn(sdr)) = second_output
+                .unlock_conditions()
+                .get(StorageDepositReturnUnlockCondition::KIND)
+            {
+                // create a new sdr unlock_condition with the updated amount and replace it
+                let new_sdr_unlock_condition = UnlockCondition::StorageDepositReturn(
+                    StorageDepositReturnUnlockCondition::new(*sdr.return_address(), new_sdr_amount)?,
+                );
+                third_output_builder = third_output_builder.replace_unlock_condition(new_sdr_unlock_condition)?;
+            }
+        }
+
+        // Build and return the final output
+        Ok(third_output_builder.finish_output()?)
+    }
+
+    /// Prepare an nft output
+    async fn prepare_nft_output(&self, options: OutputOptions, _nft_id: NftId) -> crate::Result<Output> {
+        log::debug!("[OUTPUT] prepare_nft_output {options:?}");
+
+        todo!("Implement prepare_nft_output");
+        // check if nft output is available in account
+        // add immutable fields
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct OutputOptions {
+    pub recipient_address: String,
+    pub amount: u64,
+    pub assets: Option<Assets>,
+    pub features: Option<Features>,
+    pub unlocks: Option<Unlocks>,
+    pub storage_deposit: Option<StorageDeposit>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct Assets {
+    #[serde(rename = "nativeToken")]
+    native_tokens: Option<Vec<NativeToken>>,
+    #[serde(rename = "nftId")]
+    nft_id: Option<NftId>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct Features {
+    tag: Option<String>,
+    metadata: Option<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct Unlocks {
+    expiration: Option<Time>,
+    timelock: Option<Time>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct Time {
+    #[serde(rename = "milestoneIndex")]
+    milestone_index: Option<u32>,
+    #[serde(rename = "unixTime")]
+    unix_time: Option<u32>,
+}
+
+#[derive(Debug, Default, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct StorageDeposit {
+    #[serde(rename = "returnStrategy")]
+    return_strategy: Option<ReturnStrategy>,
+    // If account has 2 Mi, min storage deposit is 1 Mi and one wants to send 1.5 Mi, it wouldn't be possible with a
+    // 0.5 Mi remainder. To still send a transaction, the 0.5 can be added to the output automatically, if set to true
+    #[serde(rename = "useExcessIfLow")]
+    use_excess_if_low: Option<bool>,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
+pub enum ReturnStrategy {
+    // A storage deposit return unlock condition will be added with the required minimum storage deposit
+    Return,
+    // The recipient address will get the additional amount to reach the minimum storage deposit gifted
+    Gift,
+}
+
+impl Default for ReturnStrategy {
+    fn default() -> Self {
+        ReturnStrategy::Return
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct OutputOptionsDto {
+    #[serde(rename = "recipientAddress")]
+    recipient_address: String,
+    amount: String,
+    #[serde(default)]
+    assets: Option<AssetsDto>,
+    #[serde(default)]
+    features: Option<Features>,
+    #[serde(default)]
+    unlocks: Option<Unlocks>,
+    #[serde(rename = "storageDeposit", default)]
+    storage_deposit: Option<StorageDeposit>,
+}
+
+impl TryFrom<&OutputOptionsDto> for OutputOptions {
+    type Error = crate::Error;
+
+    fn try_from(value: &OutputOptionsDto) -> crate::Result<Self> {
+        Ok(Self {
+            recipient_address: value.recipient_address.clone(),
+            amount: u64::from_str(&value.amount)
+                .map_err(|_| iota_client::Error::InvalidAmount(value.amount.clone()))?,
+            assets: match &value.assets {
+                Some(r) => Some(Assets::try_from(r)?),
+                None => None,
+            },
+            features: value.features.clone(),
+            unlocks: value.unlocks.clone(),
+            storage_deposit: value.storage_deposit.clone(),
+        })
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct AssetsDto {
+    #[serde(rename = "nativeTokens")]
+    native_tokens: Option<Vec<NativeTokenDto>>,
+    #[serde(rename = "nftId")]
+    nft_id: Option<String>,
+}
+
+impl TryFrom<&AssetsDto> for Assets {
+    type Error = crate::Error;
+
+    fn try_from(value: &AssetsDto) -> crate::Result<Self> {
+        Ok(Self {
+            native_tokens: match &value.native_tokens {
+                Some(r) => Some(
+                    r.iter()
+                        .map(|r| Ok(NativeToken::try_from(r)?))
+                        .collect::<crate::Result<Vec<NativeToken>>>()?,
+                ),
+                None => None,
+            },
+            nft_id: match &value.nft_id {
+                Some(r) => Some(NftId::from_str(r)?),
+                None => None,
+            },
+        })
+    }
+}

--- a/src/message_interface/account_method.rs
+++ b/src/message_interface/account_method.rs
@@ -181,39 +181,11 @@ pub enum AccountMethod {
         outputs: Vec<OutputDto>,
         options: Option<TransactionOptions>,
     },
-    /// Prepare mint nft.
-    /// Expected response: [`PreparedTransactionData`](crate::message_interface::Response::PreparedTransactionData)
-    PrepareMintNfts {
-        #[serde(rename = "nftOptions")]
-        nfts_options: Vec<NftOptions>,
-        options: Option<TransactionOptions>,
-    },
     /// Prepare send amount.
     /// Expected response: [`PreparedTransactionData`](crate::message_interface::Response::PreparedTransactionData)
     PrepareSendAmount {
         #[serde(rename = "addressWithAmount")]
         addresses_with_amount: Vec<AddressWithAmountDto>,
-        options: Option<TransactionOptions>,
-    },
-    /// Prepare send amount below minimum storage deposit.
-    /// Expected response: [`PreparedTransactionData`](crate::message_interface::Response::PreparedTransactionData)
-    PrepareSendMicroTransaction {
-        #[serde(rename = "addressWithMicroAmount")]
-        addresses_with_micro_amount: Vec<AddressWithMicroAmountDto>,
-        options: Option<TransactionOptions>,
-    },
-    /// Prepare send native tokens.
-    /// Expected response: [`PreparedTransactionData`](crate::message_interface::Response::PreparedTransactionData)
-    PrepareSendNativeTokens {
-        #[serde(rename = "addressNativeTokens")]
-        addresses_native_tokens: Vec<AddressNativeTokens>,
-        options: Option<TransactionOptions>,
-    },
-    /// Prepare send nft.
-    /// Expected response: [`PreparedTransactionData`](crate::message_interface::Response::PreparedTransactionData)
-    PrepareSendNft {
-        #[serde(rename = "addressAndNftId")]
-        addresses_nft_ids: Vec<AddressAndNftId>,
         options: Option<TransactionOptions>,
     },
     /// Syncs the account by fetching new information from the nodes. Will also retry pending transactions
@@ -254,9 +226,9 @@ pub enum AccountMethod {
     /// Set the alias of the account.
     /// Expected response: [`Ok`](crate::message_interface::Response::Ok)
     SetAlias { alias: String },
-    /// Send funds.
+    /// Send outputs in a transaction.
     /// Expected response: [`SentTransaction`](crate::message_interface::Response::SentTransaction)
-    SendTransaction {
+    SendOutputs {
         outputs: Vec<OutputDto>,
         options: Option<TransactionOptions>,
     },

--- a/src/message_interface/account_method.rs
+++ b/src/message_interface/account_method.rs
@@ -17,8 +17,10 @@ use serde::Deserialize;
 
 use crate::{
     account::operations::{
-        address_generation::AddressGenerationOptions, output_collection::OutputsToCollect, syncing::SyncOptions,
-        transaction::TransactionOptions,
+        address_generation::AddressGenerationOptions,
+        output_collection::OutputsToCollect,
+        syncing::SyncOptions,
+        transaction::{prepare_output::OutputOptionsDto, TransactionOptions},
     },
     message_interface::dtos::{AddressWithAmountDto, AddressWithMicroAmountDto},
     AddressAndNftId, AddressNativeTokens, NativeTokenOptions, NftOptions,
@@ -167,6 +169,12 @@ pub enum AccountMethod {
     /// Get account balance information.
     /// Expected response: [`Balance`](crate::message_interface::Response::Balance)
     GetBalance,
+    /// Prepare an output.
+    /// Expected response: [`Output`](crate::message_interface::Response::Output)
+    PrepareOutput {
+        options: OutputOptionsDto,
+        transaction_options: Option<TransactionOptions>,
+    },
     /// Prepare transaction.
     /// Expected response: [`PreparedTransactionData`](crate::message_interface::Response::PreparedTransactionData)
     PrepareTransaction {

--- a/src/message_interface/message_handler.rs
+++ b/src/message_interface/message_handler.rs
@@ -491,15 +491,6 @@ impl WalletMessageHandler {
             AccountMethod::GetBalance => Ok(Response::Balance(AccountBalanceDto::from(
                 &account_handle.balance().await?,
             ))),
-            AccountMethod::PrepareMintNfts { nfts_options, options } => {
-                convert_async_panics(|| async {
-                    let data = account_handle
-                        .prepare_mint_nfts(nfts_options.clone(), options.clone())
-                        .await?;
-                    Ok(Response::PreparedTransaction(PreparedTransactionDataDto::from(&data)))
-                })
-                .await
-            }
             AccountMethod::PrepareOutput {
                 options,
                 transaction_options,
@@ -525,48 +516,6 @@ impl WalletMessageHandler {
                                 .collect::<Result<Vec<AddressWithAmount>>>()?,
                             options.clone(),
                         )
-                        .await?;
-                    Ok(Response::PreparedTransaction(PreparedTransactionDataDto::from(&data)))
-                })
-                .await
-            }
-            AccountMethod::PrepareSendMicroTransaction {
-                addresses_with_micro_amount,
-                options,
-            } => {
-                convert_async_panics(|| async {
-                    let data = account_handle
-                        .prepare_send_micro_transaction(
-                            addresses_with_micro_amount
-                                .iter()
-                                .map(AddressWithMicroAmount::try_from)
-                                .collect::<Result<Vec<AddressWithMicroAmount>>>()?,
-                            options.clone(),
-                        )
-                        .await?;
-                    Ok(Response::PreparedTransaction(PreparedTransactionDataDto::from(&data)))
-                })
-                .await
-            }
-            AccountMethod::PrepareSendNativeTokens {
-                addresses_native_tokens,
-                options,
-            } => {
-                convert_async_panics(|| async {
-                    let data = account_handle
-                        .prepare_send_native_tokens(addresses_native_tokens.clone(), options.clone())
-                        .await?;
-                    Ok(Response::PreparedTransaction(PreparedTransactionDataDto::from(&data)))
-                })
-                .await
-            }
-            AccountMethod::PrepareSendNft {
-                addresses_nft_ids,
-                options,
-            } => {
-                convert_async_panics(|| async {
-                    let data = account_handle
-                        .prepare_send_nft(addresses_nft_ids.clone(), options.clone())
                         .await?;
                     Ok(Response::PreparedTransaction(PreparedTransactionDataDto::from(&data)))
                 })
@@ -657,7 +606,7 @@ impl WalletMessageHandler {
                 })
                 .await
             }
-            AccountMethod::SendTransaction { outputs, options } => {
+            AccountMethod::SendOutputs { outputs, options } => {
                 convert_async_panics(|| async {
                     let transaction = account_handle
                         .send(

--- a/src/message_interface/mod.rs
+++ b/src/message_interface/mod.rs
@@ -206,7 +206,7 @@ mod tests {
 
         let transaction = Message::CallAccountMethod {
             account_id: "alias".into(),
-            method: AccountMethod::SendTransaction { outputs, options: None },
+            method: AccountMethod::SendOutputs { outputs, options: None },
         };
 
         let _response = message_interface::send_message(&wallet_handle, transaction).await;

--- a/src/message_interface/response.rs
+++ b/src/message_interface/response.rs
@@ -59,11 +59,7 @@ pub enum Response {
     Outputs(Vec<OutputDataDto>),
     /// Response for
     /// [`PrepareSendAmount`](crate::message_interface::AccountMethod::PrepareSendAmount),
-    /// [`PrepareMintNfts`](crate::message_interface::AccountMethod::PrepareMintNfts),
-    /// [`PrepareSendMicroTransaction`](crate::message_interface::AccountMethod::PrepareSendMicroTransaction),
-    /// [`PrepareSendNativeTokens`](crate::message_interface::AccountMethod::PrepareSendNativeTokens),
-    /// [`PrepareSendNft`](crate::message_interface::AccountMethod::PrepareSendNft),
-    /// [`PrepareSendTransaction`](crate::message_interface::AccountMethod::PrepareSendTransaction)
+    /// [`PrepareTransaction`](crate::message_interface::AccountMethod::PrepareTransaction)
     PreparedTransaction(PreparedTransactionDataDto),
     /// Response for
     /// [`GetTransaction`](crate::message_interface::AccountMethod::GetTransaction),
@@ -88,7 +84,7 @@ pub enum Response {
     /// [`SendMicroTransaction`](crate::message_interface::AccountMethod::SendMicroTransaction),
     /// [`SendNativeTokens`](crate::message_interface::AccountMethod::SendNativeTokens),
     /// [`SendNft`](crate::message_interface::AccountMethod::SendNft),
-    /// [`SendTransaction`](crate::message_interface::AccountMethod::SendTransaction)
+    /// [`SendOutputs`](crate::message_interface::AccountMethod::SendOutputs)
     /// [`SubmitAndStoreTransaction`](crate::message_interface::AccountMethod::SubmitAndStoreTransaction)
     SentTransaction(TransactionResult),
     /// Response for

--- a/tests/output_preparation.rs
+++ b/tests/output_preparation.rs
@@ -1,11 +1,14 @@
 // Copyright 2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use std::str::FromStr;
+
 use iota_wallet::{
-    account::OutputOptions,
+    account::{Assets, OutputOptions},
     account_manager::AccountManager,
+    iota_client::bee_block::output::{NativeToken, NftId, TokenId},
     secret::{mnemonic::MnemonicSecretManager, SecretManager},
-    ClientOptions, Result,
+    ClientOptions, Result, U256,
 };
 
 #[ignore]
@@ -13,7 +16,7 @@ use iota_wallet::{
 async fn output_preparation() -> Result<()> {
     std::fs::remove_dir_all("test-storage/output_preparation").unwrap_or(());
     let client_options = ClientOptions::new()
-        .with_node("https://api.alphanet.iotaledger.net/")?
+        .with_node("http://localhost:14265")?
         .with_node_sync_disabled();
 
     // mnemonic without balance
@@ -46,6 +49,78 @@ async fn output_preparation() -> Result<()> {
     assert_eq!(output.amount(), 234000);
     // address and sdr unlock condition
     assert_eq!(output.unlock_conditions().unwrap().len(), 2);
+
+    let output = account
+        .prepare_output(
+            OutputOptions {
+                recipient_address: "rms1qpszqzadsym6wpppd6z037dvlejmjuke7s24hm95s9fg9vpua7vluaw60xu".to_string(),
+                amount: 500000,
+                assets: None,
+                features: None,
+                unlocks: None,
+                storage_deposit: None,
+            },
+            None,
+        )
+        .await?;
+    assert_eq!(output.amount(), 500000);
+    // only address condition
+    assert_eq!(output.unlock_conditions().unwrap().len(), 1);
+
+    let native_token = NativeToken::new(
+        TokenId::from_str("0x08847bd287c912fadedb6bf38900bda9f2d377b75b2a0bece8738699f56ebca4130100000000")?,
+        U256::from(10u32),
+    )?;
+    let output = account
+        .prepare_output(
+            OutputOptions {
+                recipient_address: "rms1qpszqzadsym6wpppd6z037dvlejmjuke7s24hm95s9fg9vpua7vluaw60xu".to_string(),
+                amount: 500000,
+                assets: Some(Assets {
+                    native_tokens: Some(vec![native_token.clone()]),
+                    nft_id: None,
+                }),
+                features: None,
+                unlocks: None,
+                storage_deposit: None,
+            },
+            None,
+        )
+        .await?;
+    assert_eq!(output.amount(), 500000);
+    // only address condition
+    assert_eq!(output.unlock_conditions().unwrap().len(), 1);
+    assert_eq!(output.native_tokens().unwrap().first(), Some(&native_token));
+
+    // only works if the nft for this NftId is available in the account
+    if let Ok(output) = account
+        .prepare_output(
+            OutputOptions {
+                recipient_address: "rms1qpszqzadsym6wpppd6z037dvlejmjuke7s24hm95s9fg9vpua7vluaw60xu".to_string(),
+                amount: 500000,
+                assets: Some(Assets {
+                    native_tokens: None,
+                    nft_id: Some(NftId::from_str(
+                        "0xa068e00a79922eaef241592a7440f131ea7f8ad9e22e580ef139415f273eff30",
+                    )?),
+                }),
+                features: None,
+                unlocks: None,
+                storage_deposit: None,
+            },
+            None,
+        )
+        .await
+    {
+        assert_eq!(
+            output.kind(),
+            iota_wallet::iota_client::bee_block::output::NftOutput::KIND
+        );
+        assert_eq!(output.amount(), 500000);
+        // only address condition
+        assert_eq!(output.unlock_conditions().unwrap().len(), 1);
+    }
+
     std::fs::remove_dir_all("test-storage/output_preparation").unwrap_or(());
     Ok(())
 }

--- a/tests/output_preparation.rs
+++ b/tests/output_preparation.rs
@@ -1,0 +1,51 @@
+// Copyright 2022 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use iota_wallet::{
+    account::OutputOptions,
+    account_manager::AccountManager,
+    secret::{mnemonic::MnemonicSecretManager, SecretManager},
+    ClientOptions, Result,
+};
+
+#[ignore]
+#[tokio::test]
+async fn output_preparation() -> Result<()> {
+    std::fs::remove_dir_all("test-storage/output_preparation").unwrap_or(());
+    let client_options = ClientOptions::new()
+        .with_node("https://api.alphanet.iotaledger.net/")?
+        .with_node_sync_disabled();
+
+    // mnemonic without balance
+    let secret_manager = MnemonicSecretManager::try_from_mnemonic(
+        "inhale gorilla deny three celery song category owner lottery rent author wealth penalty crawl hobby obtain glad warm early rain clutch slab august bleak",
+    )?;
+
+    let manager = AccountManager::builder()
+        .with_secret_manager(SecretManager::Mnemonic(secret_manager))
+        .with_client_options(client_options)
+        .with_storage_path("test-storage/output_preparation")
+        .finish()
+        .await?;
+
+    let account = manager.create_account().finish().await?;
+
+    let output = account
+        .prepare_output(
+            OutputOptions {
+                recipient_address: "rms1qpszqzadsym6wpppd6z037dvlejmjuke7s24hm95s9fg9vpua7vluaw60xu".to_string(),
+                amount: 500,
+                assets: None,
+                features: None,
+                unlocks: None,
+                storage_deposit: None,
+            },
+            None,
+        )
+        .await?;
+    assert_eq!(output.amount(), 234000);
+    // address and sdr unlock condition
+    assert_eq!(output.unlock_conditions().unwrap().len(), 2);
+    std::fs::remove_dir_all("test-storage/output_preparation").unwrap_or(());
+    Ok(())
+}


### PR DESCRIPTION
# Description of change

Add prepare_output()
Rename SendTransaction to SendOutputs
Remove most prepare methods, because they aren't really required and probably only more confusing because there are so many different options

## Links to any relevant issues

Fixes #1151 

## Type of change

- Enhancement (a breaking change which adds functionality)

## How the change has been tested

Added test

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
