### PR TITLE
Make account recovery fast

### DIFF
--- a/src/account/operations/balance_finder.rs
+++ b/src/account/operations/balance_finder.rs
@@ -70,12 +70,12 @@ impl AccountHandle {
                 }))
                 .await?;
 
-            latest_balance.replace(balance.clone());
-
             // break if we didn't find more balance with the new addresses
             if balance.total <= latest_balance.as_ref().map_or(&AccountBalance::default(), |v| v).total {
+                latest_balance.replace(balance);
                 break;
             }
+            latest_balance.replace(balance);
         }
 
         self.clean_account_after_recovery(highest_public_address_index, highest_internal_address_index)

--- a/src/account/operations/balance_finder.rs
+++ b/src/account/operations/balance_finder.rs
@@ -71,7 +71,7 @@ impl AccountHandle {
                 .await?;
 
             // break if we didn't find more balance with the new addresses
-            if balance.total <= latest_balance.as_ref().map_or(&AccountBalance::default(), |v| v).total {
+            if balance.total <= latest_balance.as_ref().map_or(0, |v| v.total) {
                 latest_balance.replace(balance);
                 break;
             }

--- a/src/account/operations/balance_finder.rs
+++ b/src/account/operations/balance_finder.rs
@@ -73,7 +73,7 @@ impl AccountHandle {
             latest_balance.replace(balance.clone());
 
             // break if we didn't find more balance with the new addresses
-            if balance.total <= latest_balance.clone().unwrap_or_default().total {
+            if balance.total <= latest_balance.as_ref().map_or(&AccountBalance::default(), |v| v).total {
                 break;
             }
         }


### PR DESCRIPTION
# Description of change

Make account recovery fast by syncing the accounts in parallel

## Links to any relevant issues

Fixes #1164 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

With the recovery examples, `recover_accounts(10, 10).await?` took now ~2 seconds

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
