### PR TITLE
Fix restore_backup

### DIFF
--- a/src/account_manager/operations/backup.rs
+++ b/src/account_manager/operations/backup.rs
@@ -68,28 +68,24 @@ impl AccountManager {
 
         let mut secret_manager = self.secret_manager.as_ref().write().await;
         let mut new_secret_manager = None;
+        // Get the current snapshot path if set
+        let mut snapshot_path = None;
         if let SecretManager::Stronghold(stronghold) = &mut *secret_manager {
-            read_data_from_stronghold_backup(
-                self,
-                stronghold,
-                &stronghold_password,
-                backup_path,
-                &mut accounts,
-                &mut new_secret_manager,
-            )
-            .await?;
-        } else {
-            read_data_from_stronghold_backup(
-                self,
-                // If the SecretManager is not Stronghold we'll create a new one to load the backup
-                &mut StrongholdSecretManager::builder().try_build()?,
-                &stronghold_password,
-                backup_path,
-                &mut accounts,
-                &mut new_secret_manager,
-            )
-            .await?;
+            snapshot_path = stronghold.snapshot_path.clone();
         }
+
+        // We'll create a new stronghold to load the backup
+        let mut new_stronghold = StrongholdSecretManager::builder().try_build()?;
+        new_stronghold.snapshot_path = snapshot_path;
+        read_data_from_stronghold_backup(
+            self,
+            &mut new_stronghold,
+            &stronghold_password,
+            backup_path,
+            &mut accounts,
+            &mut new_secret_manager,
+        )
+        .await?;
 
         // Update secret manager
         if let Some(mut new_secret_manager) = new_secret_manager {

--- a/src/account_manager/operations/backup.rs
+++ b/src/account_manager/operations/backup.rs
@@ -69,10 +69,11 @@ impl AccountManager {
         let mut secret_manager = self.secret_manager.as_ref().write().await;
         let mut new_secret_manager = None;
         // Get the current snapshot path if set
-        let mut snapshot_path = None;
-        if let SecretManager::Stronghold(stronghold) = &mut *secret_manager {
-            snapshot_path = stronghold.snapshot_path.clone();
-        }
+        let snapshot_path = if let SecretManager::Stronghold(stronghold) = &mut *secret_manager {
+            stronghold.snapshot_path.clone()
+        } else {
+            None
+        };
 
         // We'll create a new stronghold to load the backup
         let mut new_stronghold = StrongholdSecretManager::builder().try_build()?;

--- a/tests/backup_restore.rs
+++ b/tests/backup_restore.rs
@@ -60,6 +60,16 @@ async fn backup_and_restore() -> Result<()> {
         .finish()
         .await?;
 
+    // Wrong password fails
+    restore_manager
+        .restore_backup(
+            PathBuf::from("test-storage/backup_and_restore/backup.stronghold"),
+            "wrong password".to_string(),
+        )
+        .await
+        .unwrap_err();
+
+    // Correct password works, even after trying with a wrong one before
     restore_manager
         .restore_backup(
             PathBuf::from("test-storage/backup_and_restore/backup.stronghold"),


### PR DESCRIPTION
# Description of change

Always create a new Stronghold when restoring, so only the password of the snapshot is required

## Links to any relevant issues

Fixes #1170 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Updated test

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
