### PR TITLE
Update pending transaction syncing 

### DIFF
--- a/bindings/nodejs/types/transaction.ts
+++ b/bindings/nodejs/types/transaction.ts
@@ -4,7 +4,7 @@ enum InclusionState {
     Pending = 'Pending',
     Confirmed = 'Confirmed',
     Conflicting = 'Conflicting',
-    UnkownPruned = 'UnkownPruned',
+    UnknownPruned = 'UnknownPruned',
 }
 
 export interface Transaction {

--- a/bindings/nodejs/types/transaction.ts
+++ b/bindings/nodejs/types/transaction.ts
@@ -4,6 +4,7 @@ enum InclusionState {
     Pending = 'Pending',
     Confirmed = 'Confirmed',
     Conflicting = 'Conflicting',
+    UnkownPruned = 'UnkownPruned',
 }
 
 export interface Transaction {

--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -11,6 +11,8 @@ pub(crate) mod handle;
 pub(crate) mod operations;
 /// Types used in an account and returned from methods.
 pub mod types;
+/// Methods to update the account state.
+pub(crate) mod update;
 
 use std::collections::{HashMap, HashSet};
 

--- a/src/account/operations/syncing/transactions.rs
+++ b/src/account/operations/syncing/transactions.rs
@@ -15,6 +15,7 @@ use iota_client::{
 use crate::account::{
     handle::AccountHandle,
     types::{InclusionState, Transaction},
+    Account,
 };
 
 // ignore outputs and transactions from other networks
@@ -22,19 +23,10 @@ use crate::account::{
 // also revalidate that the locked outputs needs to be there, maybe there was a conflict or the transaction got
 // confirmed, then they should get removed
 
-pub(crate) struct TransactionSyncResult {
-    pub(crate) updated_transactions: Vec<Transaction>,
-    // Outputs that got spent
-    pub(crate) spent_output_ids: Vec<OutputId>,
-    // Inputs from conflicting transactions that are unspent, but should be removed from the locked outputs so they are
-    // available again
-    pub(crate) output_ids_to_unlock: Vec<OutputId>,
-}
-
 impl AccountHandle {
     /// Sync transactions and reattach them if unconfirmed. Returns the transaction with updated metadata and spent
     /// output ids that don't need to be locked anymore
-    pub(crate) async fn sync_pending_transactions(&self) -> crate::Result<TransactionSyncResult> {
+    pub(crate) async fn sync_pending_transactions(&self) -> crate::Result<()> {
         log::debug!("[SYNC] sync pending transactions");
         let account = self.read().await;
 
@@ -49,81 +41,117 @@ impl AccountHandle {
 
         for transaction_id in &account.pending_transactions {
             log::debug!("[SYNC] sync pending transaction {}", transaction_id);
-            let mut transaction = account
+            let transaction = account
                 .transactions
                 .get(transaction_id)
                 // panic during development to easier detect if something is wrong, should be handled different later
                 .expect("transaction id stored, but transaction is missing")
                 .clone();
+
             // only check transaction from the network we're connected to
-            if transaction.network_id == network_id {
-                if let Some(block_id) = transaction.block_id {
-                    match self.client.get_block_metadata(&block_id).await {
-                        Ok(metadata) => {
-                            if let Some(inclusion_state) = metadata.ledger_inclusion_state {
-                                match inclusion_state {
-                                    LedgerInclusionStateDto::Included => {
-                                        log::debug!(
-                                            "[SYNC] confirmed transaction {} in block {}",
-                                            transaction_id,
-                                            metadata.block_id
-                                        );
+            if transaction.network_id != network_id {
+                continue;
+            }
+
+            // check if we have an output (remainder, if not sending to an own address) that got created by this
+            // transaction, if that's the case, then the transaction got confirmed
+            let transaction_output = account
+                .outputs
+                .keys()
+                .into_iter()
+                .find(|o| o.transaction_id() == transaction_id);
+
+            if let Some(transaction_output) = transaction_output {
+                // Save to unwrap, we just got the output
+                let confirmed_output_data = account.outputs.get(transaction_output).expect("Output exists");
+                log::debug!(
+                    "[SYNC] confirmed transaction {} in block {}",
+                    transaction_id,
+                    confirmed_output_data.metadata.block_id
+                );
+                updated_transaction_and_outputs(
+                    transaction,
+                    Some(BlockId::from_str(&confirmed_output_data.metadata.block_id)?),
+                    InclusionState::Confirmed,
+                    &mut updated_transactions,
+                    &mut spent_output_ids,
+                );
+                continue;
+            }
+
+            // Check if the inputs of the transaction are still unspent
+            let TransactionEssence::Regular(essence) = transaction.payload.essence();
+            let mut input_got_spent = false;
+            for input in essence.inputs() {
+                if let Input::Utxo(input) = input {
+                    if let Some(input) = account.outputs.get(input.output_id()) {
+                        if input.is_spent {
+                            input_got_spent = true;
+                        }
+                    }
+                }
+            }
+
+            if let Some(block_id) = transaction.block_id {
+                match self.client.get_block_metadata(&block_id).await {
+                    Ok(metadata) => {
+                        if let Some(inclusion_state) = metadata.ledger_inclusion_state {
+                            match inclusion_state {
+                                LedgerInclusionStateDto::Included => {
+                                    log::debug!(
+                                        "[SYNC] confirmed transaction {} in block {}",
+                                        transaction_id,
+                                        metadata.block_id
+                                    );
+                                    updated_transaction_and_outputs(
+                                        transaction,
+                                        Some(BlockId::from_str(&metadata.block_id)?),
+                                        InclusionState::Confirmed,
+                                        &mut updated_transactions,
+                                        &mut spent_output_ids,
+                                    );
+                                }
+                                LedgerInclusionStateDto::Conflicting => {
+                                    log::debug!("[SYNC] conflicting transaction {}", transaction_id);
+                                    // try to get the included block, because maybe only this attachment is
+                                    // conflicting because it got confirmed in another block
+                                    if let Ok(included_block) =
+                                        self.client.get_included_block(&transaction.payload.id()).await
+                                    {
                                         updated_transaction_and_outputs(
                                             transaction,
-                                            BlockId::from_str(&metadata.block_id)?,
+                                            Some(included_block.id()),
+                                            // block metadata was Conflicting, but it's confirmed in another attachment
                                             InclusionState::Confirmed,
                                             &mut updated_transactions,
                                             &mut spent_output_ids,
                                         );
-                                    }
-                                    LedgerInclusionStateDto::Conflicting => {
-                                        log::debug!("[SYNC] conflicting transaction {}", transaction_id);
-                                        // try to get the included block, because maybe only this attachment is
-                                        // conflicting because it got confirmed in another block
-                                        if let Ok(included_block) =
-                                            self.client.get_included_block(&transaction.payload.id()).await
-                                        {
-                                            updated_transaction_and_outputs(
-                                                transaction,
-                                                included_block.id(),
-                                                InclusionState::Confirmed,
-                                                &mut updated_transactions,
-                                                &mut spent_output_ids,
-                                            );
-                                        } else {
-                                            // if we didn't get the included block it means that it got pruned, an
-                                            // input was spent in another transaction or there is another conflict
-                                            // reason, we check the inputs because some of them could still be unspent
-                                            let TransactionEssence::Regular(essence) = transaction.payload.essence();
-                                            for input in essence.inputs() {
-                                                if let Input::Utxo(input) = input {
-                                                    if let Ok(output_response) =
-                                                        self.client.get_output(input.output_id()).await
-                                                    {
-                                                        if output_response.metadata.is_spent {
-                                                            spent_output_ids.push(*input.output_id());
-                                                        } else {
-                                                            output_ids_to_unlock.push(*input.output_id());
-                                                        }
-                                                    } else {
-                                                        // if we didn't get the output it could be because it got
-                                                        // already spent and pruned, even if that's not the case we
-                                                        // well get it again during next syncing
-                                                        spent_output_ids.push(*input.output_id());
-                                                    }
-                                                }
-                                            }
-
-                                            transaction.inclusion_state = InclusionState::Conflicting;
-                                            updated_transactions.push(transaction);
-                                        }
-                                    }
-                                    LedgerInclusionStateDto::NoTransaction => {
-                                        unreachable!(
-                                            "We should only get the metadata for blocks with a transaction payload"
-                                        )
+                                    } else {
+                                        updated_transaction_and_outputs(
+                                            transaction,
+                                            None,
+                                            InclusionState::Conflicting,
+                                            &mut updated_transactions,
+                                            &mut spent_output_ids,
+                                        );
                                     }
                                 }
+                                LedgerInclusionStateDto::NoTransaction => {
+                                    unreachable!(
+                                        "We should only get the metadata for blocks with a transaction payload"
+                                    )
+                                }
+                            }
+                        } else {
+                            // no need to reattach if one input got spent
+                            if input_got_spent {
+                                process_transaction_with_unknown_state(
+                                    &account,
+                                    transaction,
+                                    &mut updated_transactions,
+                                    &mut output_ids_to_unlock,
+                                )
+                                .await?;
                             } else {
                                 let time_now = SystemTime::now()
                                     .duration_since(UNIX_EPOCH)
@@ -131,22 +159,48 @@ impl AccountHandle {
                                     .as_millis();
                                 // Reattach if older than 30 seconds
                                 if transaction.timestamp + 30000 < time_now {
+                                    // only reattach if inputs are still unspent
                                     transactions_to_reattach.push(transaction);
                                 }
                             }
                         }
-                        Err(ClientError::NotFound) => {
-                            transactions_to_reattach.push(transaction);
-                        }
-                        Err(e) => return Err(e.into()),
                     }
+                    Err(ClientError::NotFound) => {
+                        // no need to reattach if one input got spent
+                        if input_got_spent {
+                            process_transaction_with_unknown_state(
+                                &account,
+                                transaction,
+                                &mut updated_transactions,
+                                &mut output_ids_to_unlock,
+                            )
+                            .await?;
+                        } else {
+                            let time_now = SystemTime::now()
+                                .duration_since(UNIX_EPOCH)
+                                .expect("Time went backwards")
+                                .as_millis();
+                            // Reattach if older than 30 seconds
+                            if transaction.timestamp + 30000 < time_now {
+                                // only reattach if inputs are still unspent
+                                transactions_to_reattach.push(transaction);
+                            }
+                        }
+                    }
+                    Err(e) => return Err(e.into()),
+                }
+            } else {
+                // transaction wasn't submitted yet, so we have to send it again
+                // no need to reattach if one input got spent
+                if input_got_spent {
                 } else {
-                    // transaction wasn't submitted yet, so we have to send it again
+                    // only reattach if inputs are still unspent
                     transactions_to_reattach.push(transaction);
                 }
             }
         }
         drop(account);
+
         for mut transaction in transactions_to_reattach {
             log::debug!("[SYNC] reattach transaction");
             let reattached_block = self.submit_transaction_payload(transaction.payload.clone()).await?;
@@ -154,22 +208,23 @@ impl AccountHandle {
             updated_transactions.push(transaction);
         }
 
-        Ok(TransactionSyncResult {
-            updated_transactions,
-            spent_output_ids,
-            output_ids_to_unlock,
-        })
+        // updates account with balances, output ids, outputs
+        self.update_account_with_transactions(updated_transactions, spent_output_ids, output_ids_to_unlock)
+            .await?;
+
+        Ok(())
     }
 }
 
+// Set the outputs as spent so they will not be used as input again
 fn updated_transaction_and_outputs(
     mut transaction: Transaction,
-    block_id: BlockId,
+    block_id: Option<BlockId>,
     inclusion_state: InclusionState,
     updated_transactions: &mut Vec<Transaction>,
     spent_output_ids: &mut Vec<OutputId>,
 ) {
-    transaction.block_id.replace(block_id);
+    transaction.block_id = block_id;
     transaction.inclusion_state = inclusion_state;
     // get spent inputs
     let TransactionEssence::Regular(essence) = transaction.payload.essence();
@@ -179,4 +234,37 @@ fn updated_transaction_and_outputs(
         }
     }
     updated_transactions.push(transaction);
+}
+
+// When a transaction got pruned, the inputs and outputs are also not available, then this could mean that it was
+// confirmed and the created outputs got also already spent and pruned or the inputs got spent in another transaction
+async fn process_transaction_with_unknown_state(
+    account: &Account,
+    mut transaction: Transaction,
+    updated_transactions: &mut Vec<Transaction>,
+    output_ids_to_unlock: &mut Vec<OutputId>,
+) -> crate::Result<()> {
+    let mut all_inputs_spent = true;
+    let TransactionEssence::Regular(essence) = transaction.payload.essence();
+    for input in essence.inputs() {
+        if let Input::Utxo(input) = input {
+            if let Some(output_data) = account.outputs.get(input.output_id()) {
+                if !output_data.metadata.is_spent {
+                    // unspent output needs to be made available again
+                    output_ids_to_unlock.push(*input.output_id());
+                    all_inputs_spent = false;
+                }
+            } else {
+                all_inputs_spent = false;
+            }
+        }
+    }
+    // If only a part of the inputs got spent, then it couldn't happen with this transaction, so it's conflicting
+    if all_inputs_spent {
+        transaction.inclusion_state = InclusionState::UnkownPruned;
+    } else {
+        transaction.inclusion_state = InclusionState::Conflicting;
+    }
+    updated_transactions.push(transaction);
+    Ok(())
 }

--- a/src/account/operations/syncing/transactions.rs
+++ b/src/account/operations/syncing/transactions.rs
@@ -261,7 +261,7 @@ async fn process_transaction_with_unknown_state(
     }
     // If only a part of the inputs got spent, then it couldn't happen with this transaction, so it's conflicting
     if all_inputs_spent {
-        transaction.inclusion_state = InclusionState::UnkownPruned;
+        transaction.inclusion_state = InclusionState::UnknownPruned;
     } else {
         transaction.inclusion_state = InclusionState::Conflicting;
     }

--- a/src/account/types/mod.rs
+++ b/src/account/types/mod.rs
@@ -121,6 +121,7 @@ pub enum InclusionState {
     Pending,
     Confirmed,
     Conflicting,
+    UnkownPruned,
 }
 
 /// The output kind enum.

--- a/src/account/types/mod.rs
+++ b/src/account/types/mod.rs
@@ -121,7 +121,7 @@ pub enum InclusionState {
     Pending,
     Confirmed,
     Conflicting,
-    UnkownPruned,
+    UnknownPruned,
 }
 
 /// The output kind enum.

--- a/src/account/update.rs
+++ b/src/account/update.rs
@@ -178,7 +178,7 @@ impl AccountHandle {
 
         for transaction in updated_transactions {
             match transaction.inclusion_state {
-                InclusionState::Confirmed | InclusionState::Conflicting | InclusionState::UnkownPruned => {
+                InclusionState::Confirmed | InclusionState::Conflicting | InclusionState::UnknownPruned => {
                     let transaction_id = transaction.payload.id();
                     account.pending_transactions.remove(&transaction_id);
                     log::debug!(

--- a/src/account/update.rs
+++ b/src/account/update.rs
@@ -1,0 +1,322 @@
+// Copyright 2022 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::str::FromStr;
+
+use iota_client::{
+    api::ClientBlockBuilder,
+    bee_block::{
+        output::{Output, OutputId},
+        payload::transaction::TransactionId,
+    },
+    bee_rest_api::types::responses::OutputResponse,
+    Client,
+};
+
+use crate::account::{
+    handle::AccountHandle,
+    operations::syncing::options::SyncOptions,
+    types::{address::AddressWithUnspentOutputs, InclusionState, OutputData, Transaction},
+    AccountAddress,
+};
+#[cfg(feature = "events")]
+use crate::{
+    events::types::{NewOutputEvent, SpentOutputEvent, TransactionInclusionEvent, WalletEvent},
+    message_interface::dtos::OutputDataDto,
+};
+
+impl AccountHandle {
+    // Set the alias for the account
+    pub async fn set_alias(&self, alias: &str) -> crate::Result<()> {
+        let mut account = self.write().await;
+        account.alias = alias.to_string();
+        #[cfg(feature = "storage")]
+        self.save(Some(&account)).await?;
+        Ok(())
+    }
+
+    /// Update account with newly synced data and emit events for outputs
+    pub(crate) async fn update_account(
+        &self,
+        addresses_with_unspent_outputs: Vec<AddressWithUnspentOutputs>,
+        unspent_outputs: Vec<OutputData>,
+        spent_outputs: Vec<OutputId>,
+        spent_output_responses: Vec<OutputResponse>,
+        options: &SyncOptions,
+    ) -> crate::Result<()> {
+        log::debug!("[SYNC] Update account with new synced transactions");
+
+        let network_id = self.client.get_network_id().await?;
+        let mut account = self.write().await;
+        #[cfg(feature = "events")]
+        let account_index = account.index;
+
+        // update used field of the addresses
+        for address_with_unspent_outputs in addresses_with_unspent_outputs.iter() {
+            if address_with_unspent_outputs.internal {
+                let position = account
+                    .internal_addresses
+                    .binary_search_by_key(
+                        &(
+                            address_with_unspent_outputs.key_index,
+                            address_with_unspent_outputs.internal,
+                        ),
+                        |a| (a.key_index, a.internal),
+                    )
+                    .map_err(|_| {
+                        crate::Error::AddressNotFoundInAccount(address_with_unspent_outputs.address.to_bech32())
+                    })?;
+                account.internal_addresses[position].used = true;
+            } else {
+                let position = account
+                    .public_addresses
+                    .binary_search_by_key(
+                        &(
+                            address_with_unspent_outputs.key_index,
+                            address_with_unspent_outputs.internal,
+                        ),
+                        |a| (a.key_index, a.internal),
+                    )
+                    .map_err(|_| {
+                        crate::Error::AddressNotFoundInAccount(address_with_unspent_outputs.address.to_bech32())
+                    })?;
+                account.public_addresses[position].used = true;
+            }
+        }
+
+        // Update addresses_with_unspent_outputs
+        // get all addresses with balance that we didn't sync because their index is below the address_start_index of
+        // the options
+        account.addresses_with_unspent_outputs = account
+            .addresses_with_unspent_outputs
+            .iter()
+            .filter(|a| a.key_index < options.address_start_index)
+            .cloned()
+            .collect();
+        // then add all synced addresses with balance, all other addresses that had balance before will then be removed
+        // from this list
+        account
+            .addresses_with_unspent_outputs
+            .extend(addresses_with_unspent_outputs);
+
+        // Update spent outputs
+        for output_id in spent_outputs {
+            if let Some(output) = account.outputs.get(&output_id) {
+                // Could also be outputs from other networks after we switched the node, so we check that first
+                if output.network_id == network_id {
+                    log::debug!("[SYNC] Spent output {}", output_id);
+                    account.locked_outputs.remove(&output_id);
+                    account.unspent_outputs.remove(&output_id);
+                    // Update spent data fields
+                    if let Some(output_data) = account.outputs.get_mut(&output_id) {
+                        output_data.metadata.is_spent = true;
+                        output_data.is_spent = true;
+                        #[cfg(feature = "events")]
+                        {
+                            self.event_emitter.lock().await.emit(
+                                account_index,
+                                WalletEvent::SpentOutput(SpentOutputEvent {
+                                    output: OutputDataDto::from(&*output_data),
+                                }),
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
+        // Update output_response if it got spent to include the new metadata
+        for output_response in spent_output_responses {
+            let transaction_id = TransactionId::from_str(&output_response.metadata.transaction_id)?;
+            let output_id = OutputId::new(transaction_id, output_response.metadata.output_index)?;
+            if let Some(output_data) = account.outputs.get_mut(&output_id) {
+                output_data.metadata = output_response.metadata;
+            }
+        }
+
+        // Add new synced outputs
+        for output_data in unspent_outputs {
+            // Insert output, if it's unknown emit the NewOutputEvent
+            if account
+                .outputs
+                .insert(output_data.output_id, output_data.clone())
+                .is_none()
+            {
+                #[cfg(feature = "events")]
+                {
+                    self.event_emitter.lock().await.emit(
+                        account_index,
+                        WalletEvent::NewOutput(NewOutputEvent {
+                            output: OutputDataDto::from(&output_data),
+                        }),
+                    );
+                }
+            };
+            if !output_data.is_spent {
+                account.unspent_outputs.insert(output_data.output_id, output_data);
+            }
+        }
+
+        #[cfg(feature = "storage")]
+        {
+            log::debug!("[SYNC] storing account {} with new synced data", account.alias());
+            self.save(Some(&account)).await?;
+        }
+        Ok(())
+    }
+
+    /// Update account with newly synced transactions
+    pub(crate) async fn update_account_with_transactions(
+        &self,
+        updated_transactions: Vec<Transaction>,
+        spent_output_ids: Vec<OutputId>,
+        output_ids_to_unlock: Vec<OutputId>,
+    ) -> crate::Result<()> {
+        log::debug!("[SYNC] Update account with new synced transactions");
+
+        let mut account = self.write().await;
+
+        for transaction in updated_transactions {
+            match transaction.inclusion_state {
+                InclusionState::Confirmed | InclusionState::Conflicting | InclusionState::UnkownPruned => {
+                    let transaction_id = transaction.payload.id();
+                    account.pending_transactions.remove(&transaction_id);
+                    log::debug!(
+                        "[SYNC] inclusion_state of {transaction_id} changed to {:?}",
+                        transaction.inclusion_state
+                    );
+                    #[cfg(feature = "events")]
+                    {
+                        self.event_emitter.lock().await.emit(
+                            account.index,
+                            WalletEvent::TransactionInclusion(TransactionInclusionEvent {
+                                transaction_id,
+                                inclusion_state: transaction.inclusion_state,
+                            }),
+                        );
+                    }
+                }
+                _ => {}
+            }
+            account
+                .transactions
+                .insert(transaction.payload.id(), transaction.clone());
+        }
+
+        for output_to_unlock in &spent_output_ids {
+            if let Some(output) = account.outputs.get_mut(output_to_unlock) {
+                output.is_spent = true;
+            }
+            account.locked_outputs.remove(output_to_unlock);
+            account.unspent_outputs.remove(output_to_unlock);
+            log::debug!("[SYNC] Unlocked spent output {}", output_to_unlock);
+        }
+
+        for output_to_unlock in &output_ids_to_unlock {
+            account.locked_outputs.remove(output_to_unlock);
+            log::debug!(
+                "[SYNC] Unlocked unspent output {} because of a conflicting transaction",
+                output_to_unlock
+            );
+        }
+
+        #[cfg(feature = "storage")]
+        {
+            log::debug!(
+                "[SYNC] storing account {} with new synced transactions",
+                account.alias()
+            );
+            self.save(Some(&account)).await?;
+        }
+        Ok(())
+    }
+
+    /// Update account with newly generated addresses
+    pub(crate) async fn update_account_addresses(
+        &self,
+        internal: bool,
+        new_addresses: Vec<AccountAddress>,
+    ) -> crate::Result<()> {
+        log::debug!("[SYNC] Update account with new synced transactions");
+
+        let mut account = self.write().await;
+
+        // add addresses to the account
+        if internal {
+            account.internal_addresses.extend(new_addresses);
+        } else {
+            account.public_addresses.extend(new_addresses);
+        };
+
+        #[cfg(feature = "storage")]
+        {
+            log::debug!("[ADDRESS GENERATION] storing account {}", account.index());
+            self.save(Some(&account)).await?;
+        }
+        Ok(())
+    }
+
+    // Should only be called from the AccountManager so all accounts are on the same state
+    pub(crate) async fn update_account_with_new_client(&mut self, client: Client) -> crate::Result<()> {
+        self.client = client;
+        let bech32_hrp = self.client.get_bech32_hrp().await?;
+        log::debug!("[UPDATE ACCOUNT WITH NEW CLIENT] new bech32_hrp: {}", bech32_hrp);
+        let mut account = self.write().await;
+        for address in &mut account.addresses_with_unspent_outputs {
+            address.address.bech32_hrp = bech32_hrp.clone();
+        }
+        for address in &mut account.public_addresses {
+            address.address.bech32_hrp = bech32_hrp.clone();
+        }
+        for address in &mut account.internal_addresses {
+            address.address.bech32_hrp = bech32_hrp.clone();
+        }
+        // Drop account before syncing because we locked it
+        drop(account);
+        // after we set the new client options we should sync the account because the network could have changed
+        // we sync with all addresses, because otherwise the balance wouldn't get updated if an address doesn't has
+        // balance also in the new network
+        self.sync(Some(SyncOptions {
+            force_syncing: true,
+            ..Default::default()
+        }))
+        .await?;
+        Ok(())
+    }
+
+    /// Update unspent outputs, this function is originally intended for updating recursively synced alias and nft
+    /// address outputs
+    pub(crate) async fn update_unspent_outputs(&self, output_responses: Vec<OutputResponse>) -> crate::Result<()> {
+        let network_id = self.client.get_network_id().await?;
+        let mut account = self.write().await;
+
+        for output_response in output_responses.into_iter() {
+            let transaction_id = TransactionId::from_str(&output_response.metadata.transaction_id)?;
+            let output_id = OutputId::new(transaction_id, output_response.metadata.output_index)?;
+            let (amount, address) = ClientBlockBuilder::get_output_amount_and_address(&output_response.output, None)?;
+            // check if we know the transaction that created this output and if we created it (if we store incoming
+            // transactions separated, then this check wouldn't be required)
+            let remainder = {
+                match account.transactions.get(&transaction_id) {
+                    Some(tx) => !tx.incoming,
+                    None => false,
+                }
+            };
+
+            let output_data = OutputData {
+                output_id,
+                output: Output::try_from(&output_response.output)?,
+                is_spent: output_response.metadata.is_spent,
+                metadata: output_response.metadata,
+                amount,
+                address,
+                network_id,
+                remainder,
+                chain: None,
+            };
+            account.unspent_outputs.entry(output_id).or_insert(output_data);
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
# Description of change

Update pending transaction syncing to use known output data and reduce API requests
Also added a new UnkownPruned InclusionState for the case when the block attachment, inputs and outputs aren't available, because they got pruned.

Also moved a few methods that update the account data into an own module

## Links to any relevant issues

Fixes #1174 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Examples

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
