### PR TITLE
Use .iter().any() instead of binary_search_by_key().is_err()

### DIFF
--- a/src/account/operations/transaction/high_level/minting/mint_native_token.rs
+++ b/src/account/operations/transaction/high_level/minting/mint_native_token.rs
@@ -85,7 +85,7 @@ impl AccountHandle {
         let controller_address = match &native_token_options.account_address {
             Some(bech32_address) => {
                 let (_bech32_hrp, address) = Address::try_from_bech32(&bech32_address)?;
-                if account_addresses.iter().any(|addr| addr.address.inner == address) {
+                if !account_addresses.iter().any(|addr| addr.address.inner == address) {
                     return Err(Error::AddressNotFoundInAccount(bech32_address.to_string()));
                 }
                 address

--- a/src/account/operations/transaction/high_level/minting/mint_native_token.rs
+++ b/src/account/operations/transaction/high_level/minting/mint_native_token.rs
@@ -85,10 +85,7 @@ impl AccountHandle {
         let controller_address = match &native_token_options.account_address {
             Some(bech32_address) => {
                 let (_bech32_hrp, address) = Address::try_from_bech32(&bech32_address)?;
-                if account_addresses
-                    .binary_search_by_key(&address, |address| address.address.inner)
-                    .is_err()
-                {
+                if account_addresses.iter().any(|addr| addr.address.inner == address) {
                     return Err(Error::AddressNotFoundInAccount(bech32_address.to_string()));
                 }
                 address

--- a/src/message_interface/mod.rs
+++ b/src/message_interface/mod.rs
@@ -201,11 +201,15 @@ mod tests {
         let outputs = vec![OutputDto::from(
             &BasicOutputBuilder::new_with_amount(1_000_000)
                 .unwrap()
-                .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(
-                    Address::try_from_bech32("rms1qpszqzadsym6wpppd6z037dvlejmjuke7s24hm95s9fg9vpua7vluaw60xu")
-                        .unwrap()
-                        .1,
-                )))
+                .add_unlock_condition(
+                    UnlockCondition::Address(
+                        AddressUnlockCondition::new(
+                            Address::try_from_bech32("rms1qpszqzadsym6wpppd6z037dvlejmjuke7s24hm95s9fg9vpua7vluaw60xu")
+                                .unwrap()
+                                .1,
+                        ),
+                    ),
+                )
                 .finish_output()
                 .unwrap(),
         )];

--- a/src/message_interface/mod.rs
+++ b/src/message_interface/mod.rs
@@ -201,15 +201,11 @@ mod tests {
         let outputs = vec![OutputDto::from(
             &BasicOutputBuilder::new_with_amount(1_000_000)
                 .unwrap()
-                .add_unlock_condition(
-                    UnlockCondition::Address(
-                        AddressUnlockCondition::new(
-                            Address::try_from_bech32("rms1qpszqzadsym6wpppd6z037dvlejmjuke7s24hm95s9fg9vpua7vluaw60xu")
-                                .unwrap()
-                                .1,
-                        ),
-                    ),
-                )
+                .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(
+                    Address::try_from_bech32("rms1qpszqzadsym6wpppd6z037dvlejmjuke7s24hm95s9fg9vpua7vluaw60xu")
+                        .unwrap()
+                        .1,
+                )))
                 .finish_output()
                 .unwrap(),
         )];


### PR DESCRIPTION
# Description of change

Use .iter().any() instead of binary_search_by_key().is_err(), because the account addresses aren't sorted by address

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
