### PR TITLE
Fix restore_accounts

### DIFF
--- a/src/account/operations/mod.rs
+++ b/src/account/operations/mod.rs
@@ -5,8 +5,6 @@
 pub(crate) mod address_generation;
 /// The module to get the accounts balance
 pub(crate) mod balance;
-/// The module to find additional addresses with balance
-pub(crate) mod balance_finder;
 /// Helper functions
 pub(crate) mod helpers;
 /// The module for claiming of outputs with
@@ -15,6 +13,8 @@ pub(crate) mod helpers;
 pub(crate) mod output_claiming;
 /// The module for the output consolidation
 pub(crate) mod output_consolidation;
+/// The module to find additional addresses with unspent outputs
+pub(crate) mod output_finder;
 /// The module for synchronization of an account
 pub(crate) mod syncing;
 /// The module for transactions


### PR DESCRIPTION
# Description of change

Return all accounts with outputs when recovering them, independent of their outputs unlockable status

Changed the checks to use the unspent outputs len() instead of total balance

Also renamed other things, to use outputs instead of balance/funds

## Links to any relevant issues

Fixes #1207 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Example

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
