### PR TITLE
Move coin type to AccountManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ async fn main() -> Result<()> {
     let manager = AccountManager::builder()
         .with_secret_manager(SecretManager::Stronghold(secret_manager))
         .with_client_options(client_options)
+        .with_coin_type(SHIMMER_COIN_TYPE)
         .finish()
         .await?;
 

--- a/bindings/nodejs/examples/1-create-account.js
+++ b/bindings/nodejs/examples/1-create-account.js
@@ -13,7 +13,6 @@ async function run() {
         // The coin type only needs to be set on the first account
         const account = await manager.createAccount({
             alias: 'Alice',
-            coinType: CoinType.IOTA,
         });
         console.log('Account created:', account);
 
@@ -38,6 +37,7 @@ async function createAccountManager() {
             ],
             localPow: true,
         },
+        coinType: CoinType.Shimmer,
         secretManager: {
             Stronghold: {
                 snapshotPath: `./wallet.stronghold`,

--- a/bindings/nodejs/types/account.ts
+++ b/bindings/nodejs/types/account.ts
@@ -71,5 +71,4 @@ export enum CoinType {
 
 export interface CreateAccountPayload {
     alias?: string;
-    coinType?: CoinType;
 }

--- a/bindings/nodejs/types/accountManager.ts
+++ b/bindings/nodejs/types/accountManager.ts
@@ -1,8 +1,10 @@
+import type { CoinType } from './account';
 import type { ClientOptions } from './network';
 import type { SecretManager } from './secretManager';
 
 export interface AccountManagerOptions {
     storagePath?: string;
     clientOptions?: ClientOptions;
+    coinType?: CoinType;
     secretManager?: SecretManager;
 }

--- a/bindings/python/native/example/1-create-account.py
+++ b/bindings/python/native/example/1-create-account.py
@@ -9,6 +9,6 @@ client_options = {
 secret_manager = ("flame fever pig forward exact dash body idea link scrub tennis minute " +
           "surge unaware prosper over waste kitten ceiling human knife arch situate civil")
 
-wallet = IotaWallet('./alice-database', client_options, secret_manager)
+wallet = IotaWallet('./alice-database', client_options, coin_type: 4219, secret_manager)
 account = wallet.create_account('Alice')
 print(account)

--- a/bindings/python/native/example/2-generate-address.py
+++ b/bindings/python/native/example/2-generate-address.py
@@ -9,7 +9,7 @@ client_options = {
 secret_manager = ("flame fever pig forward exact dash body idea link scrub tennis minute " +
           "surge unaware prosper over waste kitten ceiling human knife arch situate civil")
 
-wallet = IotaWallet('./alice-database', client_options, secret_manager)
+wallet = IotaWallet('./alice-database', client_options, coin_type: 4219, secret_manager)
 account = wallet.get_account('Alice')
 print(f'Account: {account}')
 

--- a/bindings/python/native/example/3-check-balance.py
+++ b/bindings/python/native/example/3-check-balance.py
@@ -9,7 +9,7 @@ client_options = {
 secret_manager = ("flame fever pig forward exact dash body idea link scrub tennis minute " +
           "surge unaware prosper over waste kitten ceiling human knife arch situate civil")
 
-wallet = IotaWallet('./alice-database', client_options, secret_manager)
+wallet = IotaWallet('./alice-database', client_options, coin_type: 4219, secret_manager)
 account = wallet.get_account('Alice')
 print(f'Account: {account}')
 

--- a/bindings/python/native/iota_wallet/wallet.py
+++ b/bindings/python/native/iota_wallet/wallet.py
@@ -5,7 +5,7 @@ from json import loads, dumps
 
 
 class IotaWallet():
-    def __init__(self, storage_path='./walletdb', client_options=None, secret_manager=None):
+    def __init__(self, storage_path='./walletdb', client_options=None, coin_type=None, secret_manager=None):
         """Initialize the IOTA Wallet.
         """
 
@@ -13,6 +13,8 @@ class IotaWallet():
         options = {'storagePath': storage_path}
         if client_options:
             options['clientOptions'] = dumps(client_options)
+        if coin_type:
+            options['coinType'] = dumps(coin_type)
         if secret_manager:
             options['secretManager'] = dumps({'Mnemonic': secret_manager})
 

--- a/bindings/swift/xcode/IotaWallet/IotaWalletTests/await.swift
+++ b/bindings/swift/xcode/IotaWallet/IotaWalletTests/await.swift
@@ -11,6 +11,7 @@ class SwiftAwait: XCTestCase {
     struct ManagerOptions: Codable {
         var storagePath: String?
         var clientOptions: String?
+        var coinType: Int?
         var secretManager: String?
     }
 
@@ -42,7 +43,7 @@ class SwiftAwait: XCTestCase {
         }
         """
         
-        return ManagerOptions(storagePath: "teststorage", clientOptions: client_options, secretManager: secret_manager)
+        return ManagerOptions(storagePath: "teststorage", clientOptions: client_options, coinType: 4219, secretManager: secret_manager)
     }
     
     func testCreateAccount() async throws {

--- a/bindings/swift/xcode/IotaWallet/IotaWalletTests/callback.m
+++ b/bindings/swift/xcode/IotaWallet/IotaWalletTests/callback.m
@@ -24,7 +24,7 @@
     
     XCTAssert(wallet, @"%@", [error localizedDescription]);
     
-    NSString *message = @"{\"cmd\": \"CreateAccount\", \"payload\": { \"clientOptions\": { \"node\": \"https://nodes.devnet.iota.org:443\" } }, \"secretManager\": { \"type\": \"Stronghold\" } }";
+    NSString *message = @"{\"cmd\": \"CreateAccount\", \"payload\": { \"clientOptions\": { \"node\": \"https://nodes.devnet.iota.org:443\" } }, \"coinType\": 4219, \"secretManager\": { \"type\": \"Stronghold\" } }";
     
     XCTestExpectation *expectation = [self expectationWithDescription:@"CreateAccount"];
     [wallet sendMessage:message completion:^(NSString * _Nullable message, NSError * _Nullable error) {

--- a/documentation/docs/libraries/rust/getting_started.md
+++ b/documentation/docs/libraries/rust/getting_started.md
@@ -74,6 +74,7 @@ use std::path::PathBuf;
 
 use iota_wallet::{
     account_manager::AccountManager,
+    iota_client::constants::SHIMMER_COIN_TYPE,
     secret::{stronghold::StrongholdSecretManager, SecretManager},
     ClientOptions, Result,
 };
@@ -103,6 +104,7 @@ async fn main() -> Result<()> {
     let manager = AccountManager::builder()
         .with_secret_manager(SecretManager::Stronghold(secret_manager))
         .with_client_options(client_options)
+        .with_coin_type(SHIMMER_COIN_TYPE)
         .finish()
         .await?;
 

--- a/examples/01_create_wallet.rs
+++ b/examples/01_create_wallet.rs
@@ -10,6 +10,7 @@ use std::{env, path::PathBuf};
 use dotenv::dotenv;
 use iota_wallet::{
     account_manager::AccountManager,
+    iota_client::constants::SHIMMER_COIN_TYPE,
     secret::{stronghold::StrongholdSecretManager, SecretManager},
     ClientOptions, Result,
 };
@@ -36,6 +37,7 @@ async fn main() -> Result<()> {
     let manager = AccountManager::builder()
         .with_secret_manager(SecretManager::Stronghold(secret_manager))
         .with_client_options(client_options)
+        .with_coin_type(SHIMMER_COIN_TYPE)
         .finish()
         .await?;
 

--- a/examples/accounts.rs
+++ b/examples/accounts.rs
@@ -8,6 +8,7 @@ use std::time::Instant;
 use iota_client::utils::request_funds_from_faucet;
 use iota_wallet::{
     account_manager::AccountManager,
+    iota_client::constants::SHIMMER_COIN_TYPE,
     secret::{mnemonic::MnemonicSecretManager, SecretManager},
     ClientOptions, Result,
 };
@@ -25,6 +26,7 @@ async fn main() -> Result<()> {
     let manager = AccountManager::builder()
         .with_secret_manager(SecretManager::Mnemonic(secret_manager))
         .with_client_options(client_options)
+        .with_coin_type(SHIMMER_COIN_TYPE)
         .finish()
         .await?;
 

--- a/examples/background_syncing.rs
+++ b/examples/background_syncing.rs
@@ -5,6 +5,7 @@
 
 use iota_wallet::{
     account_manager::AccountManager,
+    iota_client::constants::SHIMMER_COIN_TYPE,
     secret::{mnemonic::MnemonicSecretManager, SecretManager},
     ClientOptions, Result,
 };
@@ -23,6 +24,7 @@ async fn main() -> Result<()> {
     let manager = AccountManager::builder()
         .with_secret_manager(SecretManager::Mnemonic(secret_manager))
         .with_client_options(client_options)
+        .with_coin_type(SHIMMER_COIN_TYPE)
         .finish()
         .await?;
 

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -12,6 +12,7 @@ use iota_client::bee_block::{
 };
 use iota_wallet::{
     account_manager::AccountManager,
+    iota_client::constants::SHIMMER_COIN_TYPE,
     secret::{mnemonic::MnemonicSecretManager, SecretManager},
     ClientOptions, Result,
 };
@@ -29,6 +30,7 @@ async fn main() -> Result<()> {
     let manager = AccountManager::builder()
         .with_secret_manager(SecretManager::Mnemonic(secret_manager))
         .with_client_options(client_options)
+        .with_coin_type(SHIMMER_COIN_TYPE)
         .finish()
         .await?;
 

--- a/examples/logger.rs
+++ b/examples/logger.rs
@@ -7,6 +7,7 @@ use std::time::Instant;
 
 use iota_wallet::{
     account_manager::AccountManager,
+    iota_client::constants::SHIMMER_COIN_TYPE,
     secret::{mnemonic::MnemonicSecretManager, SecretManager},
     ClientOptions, Result,
 };
@@ -28,6 +29,7 @@ async fn main() -> Result<()> {
     let manager = AccountManager::builder()
         .with_secret_manager(SecretManager::Mnemonic(secret_manager))
         .with_client_options(client_options)
+        .with_coin_type(SHIMMER_COIN_TYPE)
         .finish()
         .await?;
 

--- a/examples/ping.rs
+++ b/examples/ping.rs
@@ -15,6 +15,7 @@ use iota_client::{
 };
 use iota_wallet::{
     account_manager::AccountManager,
+    iota_client::constants::SHIMMER_COIN_TYPE,
     secret::{mnemonic::MnemonicSecretManager, SecretManager},
     ClientOptions, Result,
 };
@@ -34,6 +35,7 @@ async fn main() -> Result<()> {
     let manager = AccountManager::builder()
         .with_secret_manager(SecretManager::Mnemonic(secret_manager))
         .with_client_options(client_options)
+        .with_coin_type(SHIMMER_COIN_TYPE)
         .with_storage_path("pingdb")
         .finish()
         .await?;

--- a/examples/pong.rs
+++ b/examples/pong.rs
@@ -15,6 +15,7 @@ use iota_client::{
 };
 use iota_wallet::{
     account_manager::AccountManager,
+    iota_client::constants::SHIMMER_COIN_TYPE,
     secret::{mnemonic::MnemonicSecretManager, SecretManager},
     ClientOptions, Result,
 };
@@ -34,6 +35,7 @@ async fn main() -> Result<()> {
     let manager = AccountManager::builder()
         .with_secret_manager(SecretManager::Mnemonic(secret_manager))
         .with_client_options(client_options)
+        .with_coin_type(SHIMMER_COIN_TYPE)
         .with_storage_path("pongdb")
         .finish()
         .await?;

--- a/examples/recover_accounts.rs
+++ b/examples/recover_accounts.rs
@@ -7,6 +7,7 @@ use std::time::Instant;
 
 use iota_wallet::{
     account_manager::AccountManager,
+    iota_client::constants::SHIMMER_COIN_TYPE,
     secret::{mnemonic::MnemonicSecretManager, SecretManager},
     ClientOptions, Result,
 };
@@ -24,6 +25,7 @@ async fn main() -> Result<()> {
     let manager = AccountManager::builder()
         .with_secret_manager(SecretManager::Mnemonic(secret_manager))
         .with_client_options(client_options)
+        .with_coin_type(SHIMMER_COIN_TYPE)
         .finish()
         .await?;
 

--- a/examples/split_funds.rs
+++ b/examples/split_funds.rs
@@ -11,6 +11,7 @@ use iota_client::bee_block::output::{
 };
 use iota_wallet::{
     account_manager::AccountManager,
+    iota_client::constants::SHIMMER_COIN_TYPE,
     secret::{mnemonic::MnemonicSecretManager, SecretManager},
     ClientOptions, Result,
 };
@@ -28,6 +29,7 @@ async fn main() -> Result<()> {
     let manager = AccountManager::builder()
         .with_secret_manager(SecretManager::Mnemonic(secret_manager))
         .with_client_options(client_options)
+        .with_coin_type(SHIMMER_COIN_TYPE)
         .finish()
         .await?;
 

--- a/examples/storage.rs
+++ b/examples/storage.rs
@@ -7,8 +7,9 @@ use std::time::Instant;
 
 use iota_wallet::{
     account_manager::AccountManager,
+    iota_client::constants::SHIMMER_COIN_TYPE,
     secret::{mnemonic::MnemonicSecretManager, SecretManager},
-    Result,
+    ClientOptions, Result,
 };
 
 #[tokio::main]
@@ -17,8 +18,14 @@ async fn main() -> Result<()> {
         "flame fever pig forward exact dash body idea link scrub tennis minute surge unaware prosper over waste kitten ceiling human knife arch situate civil",
     )?;
 
+    let client_options = ClientOptions::new()
+        .with_node("http://localhost:14265")?
+        .with_node_sync_disabled();
+
     let manager = AccountManager::builder()
         .with_secret_manager(SecretManager::Mnemonic(secret_manager))
+        .with_client_options(client_options)
+        .with_coin_type(SHIMMER_COIN_TYPE)
         .with_storage_path("wallet-database")
         .finish()
         .await?;

--- a/examples/threads.rs
+++ b/examples/threads.rs
@@ -8,9 +8,12 @@
 use std::env;
 
 use dotenv::dotenv;
-use iota_client::bee_block::output::{
-    unlock_condition::{AddressUnlockCondition, UnlockCondition},
-    BasicOutputBuilder,
+use iota_client::{
+    bee_block::output::{
+        unlock_condition::{AddressUnlockCondition, UnlockCondition},
+        BasicOutputBuilder,
+    },
+    constants::SHIMMER_COIN_TYPE,
 };
 use iota_wallet::{
     account::TransactionOptions,
@@ -33,6 +36,7 @@ async fn main() -> Result<()> {
     let manager = AccountManager::builder()
         .with_secret_manager(SecretManager::Mnemonic(secret_manager))
         .with_client_options(client_options)
+        .with_coin_type(SHIMMER_COIN_TYPE)
         .finish()
         .await?;
 

--- a/examples/wallet.rs
+++ b/examples/wallet.rs
@@ -7,6 +7,7 @@ use std::time::Instant;
 
 use iota_wallet::{
     account_manager::AccountManager,
+    iota_client::constants::SHIMMER_COIN_TYPE,
     secret::{mnemonic::MnemonicSecretManager, SecretManager},
     AddressWithAmount, ClientOptions, Result,
 };
@@ -24,6 +25,7 @@ async fn main() -> Result<()> {
     let manager = AccountManager::builder()
         .with_secret_manager(SecretManager::Mnemonic(secret_manager))
         .with_client_options(client_options)
+        .with_coin_type(SHIMMER_COIN_TYPE)
         .finish()
         .await?;
 

--- a/src/account_manager/mod.rs
+++ b/src/account_manager/mod.rs
@@ -39,6 +39,7 @@ pub struct AccountManager {
     // 0 = not running, 1 = running, 2 = stopping
     pub(crate) background_syncing_status: Arc<AtomicUsize>,
     pub(crate) client_options: Arc<RwLock<ClientOptions>>,
+    pub(crate) coin_type: u32,
     pub(crate) secret_manager: Arc<RwLock<SecretManager>>,
     #[cfg(feature = "events")]
     pub(crate) event_emitter: Arc<Mutex<EventEmitter>>,
@@ -60,6 +61,7 @@ impl AccountManager {
         AccountBuilder::new(
             self.accounts.clone(),
             self.client_options.clone(),
+            self.coin_type,
             self.secret_manager.clone(),
             #[cfg(feature = "events")]
             self.event_emitter.clone(),

--- a/src/message_interface/message.rs
+++ b/src/message_interface/message.rs
@@ -23,9 +23,6 @@ use crate::{
 pub struct AccountToCreate {
     /// The account alias.
     pub alias: Option<String>,
-    /// The account coin type.
-    #[serde(rename = "coinType")]
-    pub coin_type: Option<u32>,
 }
 
 /// The messages that can be sent to the actor.

--- a/src/message_interface/message_handler.rs
+++ b/src/message_interface/message_handler.rs
@@ -679,10 +679,6 @@ impl WalletMessageHandler {
             builder = builder.with_alias(alias.clone());
         }
 
-        if let Some(coin_type) = &account.coin_type {
-            builder = builder.with_coin_type(*coin_type);
-        }
-
         match builder.finish().await {
             Ok(account_handle) => {
                 let account = account_handle.read().await;

--- a/src/message_interface/mod.rs
+++ b/src/message_interface/mod.rs
@@ -30,6 +30,8 @@ pub struct ManagerOptions {
     storage_path: Option<String>,
     #[serde(rename = "clientOptions")]
     client_options: Option<String>,
+    #[serde(rename = "coinType")]
+    pub coin_type: Option<u32>,
     #[serde(rename = "secretManager", serialize_with = "secret_manager_serialize")]
     secret_manager: Option<String>,
 }
@@ -63,6 +65,10 @@ pub async fn create_message_handler(options: Option<ManagerOptions>) -> crate::R
             builder = builder.with_client_options(ClientOptions::new().from_json(&client_options)?);
         }
 
+        if let Some(coin_type) = options.coin_type {
+            builder = builder.with_coin_type(coin_type);
+        }
+
         builder.finish().await?
     } else {
         AccountManager::builder().finish().await?
@@ -94,13 +100,16 @@ pub async fn clear_listeners(handle: &WalletMessageHandler, events: Vec<WalletEv
 
 #[cfg(test)]
 mod tests {
-    use iota_client::bee_block::{
-        address::Address,
-        output::{
-            dto::OutputDto,
-            unlock_condition::{AddressUnlockCondition, UnlockCondition},
-            BasicOutputBuilder,
+    use iota_client::{
+        bee_block::{
+            address::Address,
+            output::{
+                dto::OutputDto,
+                unlock_condition::{AddressUnlockCondition, UnlockCondition},
+                BasicOutputBuilder,
+            },
         },
+        constants::SHIMMER_COIN_TYPE,
     };
 
     #[cfg(feature = "events")]
@@ -136,16 +145,14 @@ mod tests {
             #[cfg(feature = "storage")]
             storage_path: Some("test-storage/message_interface_create_account".to_string()),
             client_options: Some(client_options),
+            coin_type: Some(SHIMMER_COIN_TYPE),
             secret_manager: Some(secret_manager),
         };
 
         let wallet_handle = super::create_message_handler(Some(options)).await.unwrap();
 
         // create an account
-        let account = AccountToCreate {
-            alias: None,
-            coin_type: None,
-        };
+        let account = AccountToCreate { alias: None };
         let response = message_interface::send_message(&wallet_handle, Message::CreateAccount(Box::new(account))).await;
         match response {
             Response::Account(account) => {
@@ -177,6 +184,7 @@ mod tests {
             #[cfg(feature = "storage")]
             storage_path: Some("test-storage/message_interface_events".to_string()),
             client_options: Some(client_options),
+            coin_type: Some(SHIMMER_COIN_TYPE),
             secret_manager: Some(secret_manager),
         };
 
@@ -193,7 +201,6 @@ mod tests {
         // create an account
         let account = AccountToCreate {
             alias: Some("alias".to_string()),
-            coin_type: None,
         };
         let _ = message_interface::send_message(&wallet_handle, Message::CreateAccount(Box::new(account))).await;
 
@@ -239,6 +246,7 @@ mod tests {
             #[cfg(feature = "storage")]
             storage_path: Some("test-storage/message_interface_stronghold".to_string()),
             client_options: Some(client_options),
+            coin_type: Some(SHIMMER_COIN_TYPE),
             secret_manager: Some(secret_manager),
         };
 
@@ -278,6 +286,7 @@ mod tests {
             #[cfg(feature = "storage")]
             storage_path: Some("test-storage/address_conversion_methods".to_string()),
             client_options: Some(client_options),
+            coin_type: Some(SHIMMER_COIN_TYPE),
             secret_manager: Some(secret_manager),
         };
 

--- a/tests/account_manager.rs
+++ b/tests/account_manager.rs
@@ -1,7 +1,10 @@
 // Copyright 2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_client::node_manager::node::{Node, NodeDto, Url};
+use iota_client::{
+    constants::{IOTA_COIN_TYPE, SHIMMER_COIN_TYPE},
+    node_manager::node::{Node, NodeDto, Url},
+};
 use iota_wallet::{
     account_manager::AccountManager,
     secret::{mnemonic::MnemonicSecretManager, SecretManager},
@@ -21,6 +24,7 @@ async fn stored_account_manager_data() -> Result<()> {
     let manager = AccountManager::builder()
         .with_secret_manager(SecretManager::Mnemonic(secret_manager))
         .with_client_options(client_options)
+        .with_coin_type(SHIMMER_COIN_TYPE)
         .with_storage_path("test-storage/stored_account_manager_data")
         .finish()
         .await?;
@@ -62,6 +66,7 @@ async fn different_seed() -> Result<()> {
     let manager = AccountManager::builder()
         .with_secret_manager(SecretManager::Mnemonic(secret_manager))
         .with_client_options(client_options)
+        .with_coin_type(SHIMMER_COIN_TYPE)
         .with_storage_path("test-storage/different_seed")
         .finish()
         .await?;
@@ -81,6 +86,7 @@ async fn different_seed() -> Result<()> {
     )?;
     let manager = AccountManager::builder()
         .with_secret_manager(SecretManager::Mnemonic(secret_manager2))
+        .with_coin_type(SHIMMER_COIN_TYPE)
         .with_storage_path("test-storage/different_seed")
         .finish()
         .await?;
@@ -96,5 +102,126 @@ async fn different_seed() -> Result<()> {
     );
 
     std::fs::remove_dir_all("test-storage/different_seed").unwrap_or(());
+    Ok(())
+}
+
+#[tokio::test]
+async fn changed_coin_type() -> Result<()> {
+    std::fs::remove_dir_all("test-storage/changed_coin_type").unwrap_or(());
+    let client_options = ClientOptions::new()
+        .with_node("http://localhost:14265")?
+        .with_node_sync_disabled();
+    // mnemonic without balance
+    let secret_manager = MnemonicSecretManager::try_from_mnemonic(
+        "inhale gorilla deny three celery song category owner lottery rent author wealth penalty crawl hobby obtain glad warm early rain clutch slab august bleak",
+    )?;
+
+    let manager = AccountManager::builder()
+        .with_secret_manager(SecretManager::Mnemonic(secret_manager))
+        .with_client_options(client_options)
+        .with_coin_type(SHIMMER_COIN_TYPE)
+        .with_storage_path("test-storage/changed_coin_type")
+        .finish()
+        .await?;
+
+    let _account = manager
+        .create_account()
+        .with_alias("Alice".to_string())
+        .finish()
+        .await?;
+
+    drop(_account);
+    drop(manager);
+
+    // Recreate AccountManager with same mnemonic
+    let secret_manager2 = MnemonicSecretManager::try_from_mnemonic(
+        "inhale gorilla deny three celery song category owner lottery rent author wealth penalty crawl hobby obtain glad warm early rain clutch slab august bleak",
+    )?;
+    let manager = AccountManager::builder()
+        .with_secret_manager(SecretManager::Mnemonic(secret_manager2))
+        .with_coin_type(IOTA_COIN_TYPE)
+        .with_storage_path("test-storage/changed_coin_type")
+        .finish()
+        .await?;
+
+    // Generating a new account needs to return an error, because a different coin type was set and we require all
+    // accounts to have the same coin type
+    assert!(
+        manager
+            .create_account()
+            .with_alias("Bob".to_string())
+            .finish()
+            .await
+            .is_err()
+    );
+
+    std::fs::remove_dir_all("test-storage/changed_coin_type").unwrap_or(());
+    Ok(())
+}
+
+#[tokio::test]
+async fn shimmer_coin_type() -> Result<()> {
+    std::fs::remove_dir_all("test-storage/shimmer_coin_type").unwrap_or(());
+    let client_options = ClientOptions::new()
+        .with_node("http://localhost:14265")?
+        .with_node_sync_disabled();
+
+    // mnemonic without balance
+    let secret_manager = MnemonicSecretManager::try_from_mnemonic(
+        "inhale gorilla deny three celery song category owner lottery rent author wealth penalty crawl hobby obtain glad warm early rain clutch slab august bleak",
+    )?;
+
+    let manager = AccountManager::builder()
+        .with_secret_manager(SecretManager::Mnemonic(secret_manager))
+        .with_client_options(client_options)
+        .with_coin_type(SHIMMER_COIN_TYPE)
+        .with_coin_type(SHIMMER_COIN_TYPE)
+        .with_storage_path("test-storage/shimmer_coin_type")
+        .finish()
+        .await?;
+
+    let account = manager.create_account().finish().await?;
+
+    // Creating a new account with providing a coin type will use the Shimmer coin type with shimmer testnet bech32 hrp
+    assert_eq!(
+        &account.list_addresses().await?[0].address().to_bech32(),
+        // Address generated with bip32 path: [44, 4219, 0, 0, 0]
+        "rms1qq724zgvdujt3jdcd3xzsuqq7wl9pwq3dvsa5zvx49rj9tme8cat6qptyfm"
+    );
+
+    std::fs::remove_dir_all("test-storage/shimmer_coin_type").unwrap_or(());
+    Ok(())
+}
+
+#[tokio::test]
+async fn iota_coin_type() -> Result<()> {
+    std::fs::remove_dir_all("test-storage/iota_coin_type").unwrap_or(());
+    let client_options = ClientOptions::new()
+        .with_node("http://localhost:14265")?
+        .with_node_sync_disabled();
+
+    // mnemonic without balance
+    let secret_manager = MnemonicSecretManager::try_from_mnemonic(
+        "inhale gorilla deny three celery song category owner lottery rent author wealth penalty crawl hobby obtain glad warm early rain clutch slab august bleak",
+    )?;
+
+    let manager = AccountManager::builder()
+        .with_secret_manager(SecretManager::Mnemonic(secret_manager))
+        .with_client_options(client_options)
+        .with_coin_type(IOTA_COIN_TYPE)
+        .with_storage_path("test-storage/iota_coin_type")
+        .finish()
+        .await?;
+
+    let account = manager.create_account().finish().await?;
+
+    // Creating a new account with providing a coin type will use the iota coin type with shimmer testnet bech32 hrp
+    assert_eq!(
+        &account.list_addresses().await?[0].address().to_bech32(),
+        // Address generated with bip32 path: [44, 4218, 0, 0, 0]
+        "rms1qrpwecegav7eh0z363ca69laxej64rrt4e3u0rtycyuh0mam3vq3utrrg7c"
+    );
+
+    std::fs::remove_dir_all("test-storage/iota_coin_type").unwrap_or(());
     Ok(())
 }

--- a/tests/account_manager.rs
+++ b/tests/account_manager.rs
@@ -175,7 +175,6 @@ async fn shimmer_coin_type() -> Result<()> {
         .with_secret_manager(SecretManager::Mnemonic(secret_manager))
         .with_client_options(client_options)
         .with_coin_type(SHIMMER_COIN_TYPE)
-        .with_coin_type(SHIMMER_COIN_TYPE)
         .with_storage_path("test-storage/shimmer_coin_type")
         .finish()
         .await?;

--- a/tests/account_recovery.rs
+++ b/tests/account_recovery.rs
@@ -5,6 +5,7 @@
 
 use iota_wallet::{
     account_manager::AccountManager,
+    iota_client::constants::SHIMMER_COIN_TYPE,
     secret::{mnemonic::MnemonicSecretManager, SecretManager},
     ClientOptions, Result,
 };
@@ -25,6 +26,7 @@ async fn account_recovery_empty() -> Result<()> {
     let manager = AccountManager::builder()
         .with_secret_manager(SecretManager::Mnemonic(secret_manager))
         .with_client_options(client_options)
+        .with_coin_type(SHIMMER_COIN_TYPE)
         .with_storage_path("test-storage/account_recovery_empty")
         .finish()
         .await?;
@@ -52,6 +54,7 @@ async fn account_recovery_existing_accounts() -> Result<()> {
     let manager = AccountManager::builder()
         .with_secret_manager(SecretManager::Mnemonic(secret_manager))
         .with_client_options(client_options)
+        .with_coin_type(SHIMMER_COIN_TYPE)
         .finish()
         .await?;
 
@@ -86,6 +89,7 @@ async fn account_recovery_with_balance() -> Result<()> {
     let manager = AccountManager::builder()
         .with_secret_manager(SecretManager::Mnemonic(secret_manager))
         .with_client_options(client_options)
+        .with_coin_type(SHIMMER_COIN_TYPE)
         .finish()
         .await?;
 
@@ -123,6 +127,7 @@ async fn account_recovery_with_balance_and_empty_addresses() -> Result<()> {
     let manager = AccountManager::builder()
         .with_secret_manager(SecretManager::Mnemonic(secret_manager))
         .with_client_options(client_options)
+        .with_coin_type(SHIMMER_COIN_TYPE)
         .finish()
         .await?;
 

--- a/tests/accounts.rs
+++ b/tests/accounts.rs
@@ -4,7 +4,7 @@
 #[cfg(feature = "stronghold")]
 use std::path::PathBuf;
 
-use iota_client::constants::{IOTA_COIN_TYPE, SHIMMER_COIN_TYPE};
+use iota_client::constants::SHIMMER_COIN_TYPE;
 #[cfg(feature = "stronghold")]
 use iota_client::secret::stronghold::StrongholdSecretManager;
 use iota_wallet::{
@@ -28,6 +28,7 @@ async fn account_ordering() -> Result<()> {
     let manager = AccountManager::builder()
         .with_secret_manager(SecretManager::Mnemonic(secret_manager))
         .with_client_options(client_options)
+        .with_coin_type(SHIMMER_COIN_TYPE)
         .with_storage_path("test-storage/account_ordering")
         .finish()
         .await?;
@@ -58,6 +59,7 @@ async fn remove_latest_account() -> Result<()> {
         let manager = AccountManager::builder()
             .with_secret_manager(SecretManager::Mnemonic(secret_manager))
             .with_client_options(client_options.clone())
+            .with_coin_type(SHIMMER_COIN_TYPE)
             .with_storage_path("test-storage/remove_latest_account")
             .finish()
             .await?;
@@ -149,6 +151,7 @@ async fn account_alias_already_exists() -> Result<()> {
     let manager = AccountManager::builder()
         .with_secret_manager(SecretManager::Mnemonic(secret_manager))
         .with_client_options(client_options)
+        .with_coin_type(SHIMMER_COIN_TYPE)
         .with_storage_path("test-storage/account_alias_already_exists")
         .finish()
         .await?;
@@ -210,6 +213,7 @@ async fn account_rename_alias() -> Result<()> {
     let manager = AccountManager::builder()
         .with_secret_manager(SecretManager::Mnemonic(secret_manager))
         .with_client_options(client_options)
+        .with_coin_type(SHIMMER_COIN_TYPE)
         .with_storage_path("test-storage/account_rename_alias")
         .finish()
         .await?;
@@ -245,6 +249,7 @@ async fn account_first_address_exists() -> Result<()> {
     let manager = AccountManager::builder()
         .with_secret_manager(SecretManager::Mnemonic(secret_manager))
         .with_client_options(client_options)
+        .with_coin_type(SHIMMER_COIN_TYPE)
         .with_storage_path("test-storage/account_first_address_exists")
         .finish()
         .await?;
@@ -261,116 +266,6 @@ async fn account_first_address_exists() -> Result<()> {
     assert_eq!(account.list_addresses().await?.first().unwrap().internal(), &false);
 
     std::fs::remove_dir_all("test-storage/account_first_address_exists").unwrap_or(());
-    Ok(())
-}
-
-#[tokio::test]
-async fn account_default_coin_type() -> Result<()> {
-    std::fs::remove_dir_all("test-storage/account_default_coin_type").unwrap_or(());
-    let client_options = ClientOptions::new()
-        .with_node("http://localhost:14265")?
-        .with_node_sync_disabled();
-
-    // mnemonic without balance
-    let secret_manager = MnemonicSecretManager::try_from_mnemonic(
-        "inhale gorilla deny three celery song category owner lottery rent author wealth penalty crawl hobby obtain glad warm early rain clutch slab august bleak",
-    )?;
-
-    let manager = AccountManager::builder()
-        .with_secret_manager(SecretManager::Mnemonic(secret_manager))
-        .with_client_options(client_options)
-        .with_storage_path("test-storage/account_default_coin_type")
-        .finish()
-        .await?;
-
-    let account = manager.create_account().finish().await?;
-
-    // Creating a new account with providing a coin type will use the Shimmer coin type with shimmer testnet bech32 hrp
-    assert_eq!(
-        &account.list_addresses().await?[0].address().to_bech32(),
-        // Address generated with bip32 path: [44, 4219, 0, 0, 0]
-        "rms1qq724zgvdujt3jdcd3xzsuqq7wl9pwq3dvsa5zvx49rj9tme8cat6qptyfm"
-    );
-
-    std::fs::remove_dir_all("test-storage/account_default_coin_type").unwrap_or(());
-    Ok(())
-}
-
-#[tokio::test]
-async fn account_coin_type_shimmer() -> Result<()> {
-    std::fs::remove_dir_all("test-storage/account_coin_type_shimmer").unwrap_or(());
-    let client_options = ClientOptions::new()
-        .with_node("http://localhost:14265")?
-        .with_node_sync_disabled();
-
-    // mnemonic without balance
-    let secret_manager = MnemonicSecretManager::try_from_mnemonic(
-        "inhale gorilla deny three celery song category owner lottery rent author wealth penalty crawl hobby obtain glad warm early rain clutch slab august bleak",
-    )?;
-
-    let manager = AccountManager::builder()
-        .with_secret_manager(SecretManager::Mnemonic(secret_manager))
-        .with_client_options(client_options)
-        .with_storage_path("test-storage/account_coin_type_shimmer")
-        .finish()
-        .await?;
-
-    let _account = manager
-        .create_account()
-        .with_coin_type(SHIMMER_COIN_TYPE)
-        .finish()
-        .await?;
-    let _account = manager
-        .create_account()
-        .with_coin_type(SHIMMER_COIN_TYPE)
-        .finish()
-        .await?;
-    // Creating a new account with a different coin type fails
-    assert!(
-        manager
-            .create_account()
-            .with_coin_type(IOTA_COIN_TYPE)
-            .finish()
-            .await
-            .is_err()
-    );
-
-    std::fs::remove_dir_all("test-storage/account_coin_type_shimmer").unwrap_or(());
-    Ok(())
-}
-
-#[tokio::test]
-async fn account_coin_type_iota() -> Result<()> {
-    std::fs::remove_dir_all("test-storage/account_coin_type_iota").unwrap_or(());
-    let client_options = ClientOptions::new()
-        .with_node("http://localhost:14265")?
-        .with_node_sync_disabled();
-
-    // mnemonic without balance
-    let secret_manager = MnemonicSecretManager::try_from_mnemonic(
-        "inhale gorilla deny three celery song category owner lottery rent author wealth penalty crawl hobby obtain glad warm early rain clutch slab august bleak",
-    )?;
-
-    let manager = AccountManager::builder()
-        .with_secret_manager(SecretManager::Mnemonic(secret_manager))
-        .with_client_options(client_options)
-        .with_storage_path("test-storage/account_coin_type_iota")
-        .finish()
-        .await?;
-
-    let _account = manager.create_account().with_coin_type(IOTA_COIN_TYPE).finish().await?;
-    let _account = manager.create_account().with_coin_type(IOTA_COIN_TYPE).finish().await?;
-    // Creating a new account with a different coin type fails
-    assert!(
-        manager
-            .create_account()
-            .with_coin_type(SHIMMER_COIN_TYPE)
-            .finish()
-            .await
-            .is_err()
-    );
-
-    std::fs::remove_dir_all("test-storage/account_coin_type_iota").unwrap_or(());
     Ok(())
 }
 
@@ -399,15 +294,12 @@ async fn account_creation_stronghold() -> Result<()> {
     let manager = AccountManager::builder()
         .with_secret_manager(secret_manager)
         .with_client_options(client_options)
+        .with_coin_type(SHIMMER_COIN_TYPE)
         .with_storage_path(folder_path)
         .finish()
         .await?;
 
-    let _account = manager
-        .create_account()
-        .with_coin_type(SHIMMER_COIN_TYPE)
-        .finish()
-        .await?;
+    let _account = manager.create_account().finish().await?;
 
     std::fs::remove_dir_all(folder_path).unwrap_or(());
     Ok(())

--- a/tests/backup_restore.rs
+++ b/tests/backup_restore.rs
@@ -4,6 +4,7 @@
 use std::path::PathBuf;
 
 use iota_client::{
+    constants::SHIMMER_COIN_TYPE,
     node_manager::node::{Node, NodeDto, Url},
     secret::{mnemonic::MnemonicSecretManager, stronghold::StrongholdSecretManager, SecretManager},
 };
@@ -30,6 +31,7 @@ async fn backup_and_restore() -> Result<()> {
     let manager = AccountManager::builder()
         .with_secret_manager(SecretManager::Stronghold(stronghold_secmngr))
         .with_client_options(client_options.clone())
+        .with_coin_type(SHIMMER_COIN_TYPE)
         .with_storage_path("test-storage/backup_and_restore/1")
         .finish()
         .await?;
@@ -57,6 +59,7 @@ async fn backup_and_restore() -> Result<()> {
         .with_storage_path("test-storage/backup_and_restore/2")
         .with_secret_manager(SecretManager::Stronghold(stronghold_secmngr))
         .with_client_options(ClientOptions::new().with_node("http://some-other-node:14265")?)
+        .with_coin_type(SHIMMER_COIN_TYPE)
         .finish()
         .await?;
 
@@ -114,6 +117,7 @@ async fn backup_and_restore_mnemonic_secret_manager() -> Result<()> {
     let manager = AccountManager::builder()
         .with_secret_manager(SecretManager::Mnemonic(secret_manager))
         .with_client_options(client_options.clone())
+        .with_coin_type(SHIMMER_COIN_TYPE)
         .with_storage_path("test-storage/backup_and_restore_mnemonic_secret_manager/1")
         .finish()
         .await?;
@@ -144,6 +148,7 @@ async fn backup_and_restore_mnemonic_secret_manager() -> Result<()> {
     let restore_manager = AccountManager::builder()
         .with_storage_path("test-storage/backup_and_restore_mnemonic_secret_manager/2")
         .with_secret_manager(SecretManager::Mnemonic(secret_manager))
+        .with_coin_type(SHIMMER_COIN_TYPE)
         .with_client_options(ClientOptions::new().with_node("http://some-other-node:14265")?)
         .finish()
         .await?;

--- a/tests/burn_outputs.rs
+++ b/tests/burn_outputs.rs
@@ -9,6 +9,7 @@ use iota_client::{
 };
 use iota_wallet::{
     account_manager::AccountManager,
+    iota_client::constants::SHIMMER_COIN_TYPE,
     secret::{mnemonic::MnemonicSecretManager, SecretManager},
     ClientOptions, Error, NativeTokenOptions, NftOptions, Result, U256,
 };
@@ -30,6 +31,7 @@ async fn mint_and_burn_nft() -> Result<()> {
     let manager = AccountManager::builder()
         .with_secret_manager(SecretManager::Mnemonic(secret_manager))
         .with_client_options(client_options)
+        .with_coin_type(SHIMMER_COIN_TYPE)
         .with_storage_path(storage_path)
         .finish()
         .await
@@ -102,6 +104,7 @@ async fn mint_and_melt_native_token() -> Result<()> {
     let manager = AccountManager::builder()
         .with_secret_manager(SecretManager::Mnemonic(secret_manager))
         .with_client_options(client_options)
+        .with_coin_type(SHIMMER_COIN_TYPE)
         .with_storage_path(storage_path)
         .finish()
         .await
@@ -198,6 +201,7 @@ async fn destroy_foundry() -> Result<()> {
     let manager = AccountManager::builder()
         .with_secret_manager(SecretManager::Mnemonic(secret_manager))
         .with_client_options(client_options)
+        .with_coin_type(SHIMMER_COIN_TYPE)
         .with_storage_path(storage_path)
         .finish()
         .await
@@ -256,6 +260,7 @@ async fn destroy_alias() -> Result<()> {
     let manager = AccountManager::builder()
         .with_secret_manager(SecretManager::Mnemonic(secret_manager))
         .with_client_options(client_options)
+        .with_coin_type(SHIMMER_COIN_TYPE)
         .finish()
         .await?;
 

--- a/tests/output_preparation.rs
+++ b/tests/output_preparation.rs
@@ -6,7 +6,10 @@ use std::str::FromStr;
 use iota_wallet::{
     account::{Assets, Features, OutputOptions},
     account_manager::AccountManager,
-    iota_client::bee_block::output::{NativeToken, NftId, TokenId},
+    iota_client::{
+        bee_block::output::{NativeToken, NftId, TokenId},
+        constants::SHIMMER_COIN_TYPE,
+    },
     secret::{mnemonic::MnemonicSecretManager, SecretManager},
     ClientOptions, Result, U256,
 };
@@ -27,6 +30,7 @@ async fn output_preparation() -> Result<()> {
     let manager = AccountManager::builder()
         .with_secret_manager(SecretManager::Mnemonic(secret_manager))
         .with_client_options(client_options)
+        .with_coin_type(SHIMMER_COIN_TYPE)
         .with_storage_path("test-storage/output_preparation")
         .finish()
         .await?;


### PR DESCRIPTION
# Description of change

Move coin type to AccountManager so it's clearer, that all accounts share the same

## Links to any relevant issues

Fixes #1217 

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

Tests

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
