### PR TITLE
Update covector workflow to use windows-2019 and only newer node.js v…

### DIFF
--- a/.github/workflows/covector-version-or-publish.yml
+++ b/.github/workflows/covector-version-or-publish.yml
@@ -56,8 +56,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, macos-latest, windows-latest]
-        node-version: ['10.x', '12.x', '14.x', '15.x', '16.x']
+        # The GitHub hosted Windows 2022 image comes with Visual Studio 2022, but node-gyp
+        # (which is used by neon-sys) sadly fails to recognize it. As a mitigation, we still run the
+        # tests on Windows 2019, until we can figure out a way to fix the problem.
+        # NOTE: Using Ubuntu 18.04 to provide glibc compatibility. (#588)
+        os: [ubuntu-18.04, macos-latest, windows-2019]
+        node-version: ['14.x', '16.x', '18.x']
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
# Description of change

Use windows-2019 and only newer node.js versions

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
