### PR TITLE
fix: update covector commands

### DIFF
--- a/.changes/config.json
+++ b/.changes/config.json
@@ -31,6 +31,9 @@
           "command": "dasel put string -f Cargo.toml '.dependencies.iota-wallet.features.[4]' message_interface"
         },
         {
+          "command": "tsc"
+        },
+        {
           "command": "cat Cargo.toml"
         }
       ],

--- a/.changes/config.json
+++ b/.changes/config.json
@@ -16,19 +16,7 @@
           "command": "false || dasel put object -f Cargo.toml '.dependencies.iota-wallet' -t string -t string git='https://github.com/iotaledger/wallet.rs' rev=$GITHUB_SHA"
         },
         {
-          "command": "dasel put string -f Cargo.toml '.dependencies.iota-wallet.features.[0]' mnemonic"
-        },
-        {
-          "command": "dasel put string -f Cargo.toml '.dependencies.iota-wallet.features.[1]' events"
-        },
-        {
-          "command": "dasel put string -f Cargo.toml '.dependencies.iota-wallet.features.[2]' storage"
-        },
-        {
-          "command": "dasel put string -f Cargo.toml '.dependencies.iota-wallet.features.[3]' stronghold"
-        },
-        {
-          "command": "dasel put string -f Cargo.toml '.dependencies.iota-wallet.features.[4]' message_interface"
+          "command": "dasel put document -f Cargo.toml '.dependencies.iota-wallet.features' '[\"mnemonic\", \"events\", \"storage\", \"stronghold\", \"message_interface\"]'"
         },
         {
           "command": "tsc"

--- a/.changes/pre-release.md
+++ b/.changes/pre-release.md
@@ -2,4 +2,4 @@
 "nodejs-binding": patch
 ---
 
-Pre-release of the Stardust bindings of Wallet.rs for Node.JS
+Added typescript declaration files to the package


### PR DESCRIPTION
# Description of change

The npm package is missing the types by default. When running the tests with `yarn --ignore-scripts` they fail, since the namespace declarations are missing. I added the typescript compilation step to mitigate this before the package is released to npm.

Additionally, I replaced the `dasel` command with a shorter version based on the response on this issue (https://github.com/TomWright/dasel/issues/233).

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
