### PR TITLE
Add option to sync only basic outputs with AddressUnlockCondition

### DIFF
--- a/bindings/nodejs/types/account.ts
+++ b/bindings/nodejs/types/account.ts
@@ -46,6 +46,9 @@ export interface AccountSyncOptions {
     syncPendingTransactions?: boolean;
     /** Specifies if only basic outputs should be synced or also alias and nft outputs. Default: true. */
     syncAliasesAndNfts?: boolean;
+    /** Specifies if only basic outputs with an AddressUnlockCondition alone should be synced, will overwrite
+     * `syncAliasesAndNfts`. Default: false. */
+    syncOnlyMostBasicOutputs?: boolean;
 }
 
 export interface AccountMeta {

--- a/src/account/operations/syncing/addresses.rs
+++ b/src/account/operations/syncing/addresses.rs
@@ -212,6 +212,19 @@ impl AccountHandle {
     ) -> crate::Result<(AddressWithUnspentOutputs, Vec<OutputId>)> {
         let bech32_address_ = &address.address.to_bech32();
 
+        // Only sync outputs with basic unlock conditions and only `AddressUnlockCondition`
+        if sync_options.sync_only_most_basic_outputs {
+            let output_ids = client
+                .basic_output_ids(vec![
+                    QueryParameter::Address(bech32_address_.to_string()),
+                    QueryParameter::HasExpirationCondition(false),
+                    QueryParameter::HasTimelockCondition(false),
+                    QueryParameter::HasStorageReturnCondition(false),
+                ])
+                .await?;
+            return Ok((address, output_ids));
+        }
+
         let mut tasks = vec![
             // Get basic outputs
             async move {

--- a/src/account/operations/syncing/options.rs
+++ b/src/account/operations/syncing/options.rs
@@ -30,6 +30,13 @@ pub struct SyncOptions {
     /// Specifies if only basic outputs should be synced or also alias and nft outputs
     #[serde(rename = "syncAliasesAndNfts", default = "default_sync_aliases_and_nfts")]
     pub sync_aliases_and_nfts: bool,
+    /// Specifies if only basic outputs with an AddressUnlockCondition alone should be synced, will overwrite
+    /// `sync_aliases_and_nfts`
+    #[serde(
+        rename = "syncOnlyMostBasicOutputs",
+        default = "default_sync_only_most_basic_outputs"
+    )]
+    pub sync_only_most_basic_outputs: bool,
 }
 
 fn default_sync_incoming_transactions() -> bool {
@@ -44,6 +51,10 @@ fn default_sync_aliases_and_nfts() -> bool {
     true
 }
 
+fn default_sync_only_most_basic_outputs() -> bool {
+    false
+}
+
 fn default_address_start_index() -> u32 {
     0
 }
@@ -56,6 +67,7 @@ impl Default for SyncOptions {
             sync_incoming_transactions: default_sync_incoming_transactions(),
             sync_pending_transactions: default_sync_pending_transactions(),
             sync_aliases_and_nfts: default_sync_aliases_and_nfts(),
+            sync_only_most_basic_outputs: default_sync_only_most_basic_outputs(),
             force_syncing: false,
         }
     }

--- a/src/account/operations/syncing/options.rs
+++ b/src/account/operations/syncing/options.rs
@@ -3,6 +3,13 @@
 
 use serde::{Deserialize, Serialize};
 
+const DEFAULT_ADDRESS_START_INDEX: u32 = 0;
+const DEFAULT_FORCE_SYNCING: bool = false;
+const DEFAULT_SYNC_ALIASES_AND_NFTS: bool = false;
+const DEFAULT_SYNC_INCOMING_TRANSACTIONS: bool = false;
+const DEFAULT_SYNC_ONLY_MOST_BASIC_OUTPUTS: bool = false;
+const DEFAULT_SYNC_PENDING_TRANSACTIONS: bool = true;
+
 /// The synchronization options
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SyncOptions {
@@ -39,24 +46,28 @@ pub struct SyncOptions {
     pub sync_only_most_basic_outputs: bool,
 }
 
-fn default_sync_incoming_transactions() -> bool {
-    false
+fn default_address_start_index() -> u32 {
+    DEFAULT_ADDRESS_START_INDEX
 }
 
-fn default_sync_pending_transactions() -> bool {
-    true
+fn default_force_syncing() -> bool {
+    DEFAULT_FORCE_SYNCING
 }
 
 fn default_sync_aliases_and_nfts() -> bool {
-    true
+    DEFAULT_SYNC_ALIASES_AND_NFTS
+}
+
+fn default_sync_incoming_transactions() -> bool {
+    DEFAULT_SYNC_INCOMING_TRANSACTIONS
 }
 
 fn default_sync_only_most_basic_outputs() -> bool {
-    false
+    DEFAULT_SYNC_ONLY_MOST_BASIC_OUTPUTS
 }
 
-fn default_address_start_index() -> u32 {
-    0
+fn default_sync_pending_transactions() -> bool {
+    DEFAULT_SYNC_PENDING_TRANSACTIONS
 }
 
 impl Default for SyncOptions {
@@ -68,7 +79,7 @@ impl Default for SyncOptions {
             sync_pending_transactions: default_sync_pending_transactions(),
             sync_aliases_and_nfts: default_sync_aliases_and_nfts(),
             sync_only_most_basic_outputs: default_sync_only_most_basic_outputs(),
-            force_syncing: false,
+            force_syncing: default_force_syncing(),
         }
     }
 }


### PR DESCRIPTION
# Description of change

Add option to sync only basic outputs with AddressUnlockCondition, could be useful for exchanges or others who don't want to handle the other unlock conditions and output types

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Modified example

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
