### PR TITLE
Get foundry output by native token ID

### DIFF
--- a/bindings/nodejs/examples/22-mint-native-tokens.js
+++ b/bindings/nodejs/examples/22-mint-native-tokens.js
@@ -1,0 +1,30 @@
+/**
+ * This example mints native tokens
+ */
+const getUnlockedManager = require('./account-manager');
+
+async function run() {
+    try {
+        const manager = await getUnlockedManager();
+
+        const account = await manager.getAccount('0');
+
+        // If we omit the AccountAddress field the first address of the account is used by default
+        const nativeTokenOptions = {
+            // Hello in bytes
+            foundryMetadata: [72, 101, 108, 108, 111],
+            circulatingSupply: '0x64',
+            maximumSupply: '0x64',
+        };
+
+        let transactionResult = await account.mintNativeToken(
+            nativeTokenOptions,
+        );
+        console.log('Transaction ID: {}', transactionResult.transactionId);
+    } catch (error) {
+        console.log('Error: ' + error);
+    }
+    process.exit(0);
+}
+
+run();

--- a/bindings/nodejs/examples/23-get-foundry-output.js
+++ b/bindings/nodejs/examples/23-get-foundry-output.js
@@ -1,0 +1,37 @@
+/**
+ * This example will get a foundry output by native token id. It will first
+ * try to get the foundry from the account, and if it isn't in the account
+ * it will try to get it from the node
+ */
+const getUnlockedManager = require('./account-manager');
+
+async function run() {
+    try {
+        const manager = await getUnlockedManager();
+
+        const account = await manager.getAccount('0');
+
+        // Get a tokenId from your account balance after running example
+        // 22-mint-native-tokens.js
+        let tokenId =
+            '0x08a08898630b0a76a455c85c5e8d13ec56fa905c3bf1b619625c5dab45ddf02f620100000000';
+
+        let foundryOutput = await account.getFoundryOutput(tokenId);
+        console.log('Foundry output from account:\n', foundryOutput);
+
+        // Use a different account
+        const secondAccount = await manager.getAccount('1');
+
+        // Retrieve the foundry output again, this time the output is not
+        // in the account so it will be retrieved from the node
+        console.log(
+            'Foundry output from node:\n',
+            await secondAccount.getFoundryOutput(tokenId),
+        );
+    } catch (error) {
+        console.log('Error: ' + error);
+    }
+    process.exit(0);
+}
+
+run();

--- a/bindings/nodejs/lib/Account.ts
+++ b/bindings/nodejs/lib/Account.ts
@@ -175,6 +175,23 @@ export class Account {
         return JSON.parse(response).payload;
     }
 
+    /**
+     * Get a foundry output by native token ID. It will try to get the foundry from
+     * the account, if it isn't in the account it will try to get it from the node
+     */
+    async getFoundryOutput(tokenId: string): Promise<IFoundryOutput> {
+        const response = await this.messageHandler.callAccountMethod(
+            this.meta.index,
+            {
+                name: 'GetFoundryOutput',
+                data: {
+                    tokenId,
+                },
+            },
+        );
+        return JSON.parse(response).payload;
+    }
+
     async getOutputsWithAdditionalUnlockConditions(
         outputs: OutputsToClaim,
     ): Promise<string[]> {
@@ -331,11 +348,11 @@ export class Account {
                 name: 'PrepareOutput',
                 data: {
                     options,
-                    transactionOptions
-                }
-            }
-        )
-        return JSON.parse(response).payload
+                    transactionOptions,
+                },
+            },
+        );
+        return JSON.parse(response).payload;
     }
 
     async prepareSendAmount(
@@ -354,7 +371,7 @@ export class Account {
         );
         return JSON.parse(response).payload;
     }
-    
+
     async prepareTransaction(
         outputs: OutputTypes[],
         options?: TransactionOptions,
@@ -507,7 +524,7 @@ export class Account {
             {
                 name: 'SyncAccount',
                 data: {
-                    options: options ?? {}
+                    options: options ?? {},
                 },
             },
         );

--- a/bindings/nodejs/lib/AccountManager.ts
+++ b/bindings/nodejs/lib/AccountManager.ts
@@ -45,7 +45,10 @@ export class AccountManager {
         return JSON.parse(response).payload;
     }
 
-    async changeStrongholdPassword(currentPassword: string, newPassword: string): Promise<void> {
+    async changeStrongholdPassword(
+        currentPassword: string,
+        newPassword: string,
+    ): Promise<void> {
         await this.messageHandler.sendMessage({
             cmd: 'ChangeStrongholdPassword',
             payload: {

--- a/bindings/nodejs/lib/MessageHandler.ts
+++ b/bindings/nodejs/lib/MessageHandler.ts
@@ -32,11 +32,13 @@ export class MessageHandler {
     }
 
     async sendMessage(message: __Message__): Promise<string> {
-        return sendMessageAsync(JSON.stringify(message), this.messageHandler)
-            .catch((error) => {
-                const _error = JSON.parse(error);
-                return Promise.reject(_error.payload);
-            });
+        return sendMessageAsync(
+            JSON.stringify(message),
+            this.messageHandler,
+        ).catch((error) => {
+            const _error = JSON.parse(error);
+            return Promise.reject(_error.payload);
+        });
     }
 
     async callAccountMethod(

--- a/bindings/nodejs/types/bridge/account.ts
+++ b/bindings/nodejs/types/bridge/account.ts
@@ -77,6 +77,13 @@ export type __GetOutputMethod__ = {
     };
 };
 
+export type __GetFoundryOutputMethod__ = {
+    name: 'GetFoundryOutput';
+    data: {
+        tokenId: string;
+    };
+};
+
 export type __GetOutputsWithAdditionalUnlockConditionsMethod__ = {
     name: 'GetOutputsWithAdditionalUnlockConditions';
     data: {
@@ -142,9 +149,9 @@ export type __PrepareOutputMethod__ = {
     name: 'PrepareOutput';
     data: {
         options: OutputOptions;
-        transactionOptions?: TransactionOptions
-    }
-}
+        transactionOptions?: TransactionOptions;
+    };
+};
 
 export type __PrepareSendAmountMethod__ = {
     name: 'PrepareSendAmount';
@@ -227,7 +234,7 @@ export type __SyncAccountMethod__ = {
     name: 'SyncAccount';
     data: {
         options?: AccountSyncOptions;
-    }
+    };
 };
 
 export type __TryClaimOutputsMethod__ = {

--- a/bindings/nodejs/types/bridge/index.ts
+++ b/bindings/nodejs/types/bridge/index.ts
@@ -9,6 +9,7 @@ import type {
     __GenerateAddressesMethod__,
     __GetBalanceMethod__,
     __GetOutputMethod__,
+    __GetFoundryOutputMethod__,
     __GetOutputsWithAdditionalUnlockConditionsMethod__,
     __GetTransactionMethod__,
     __ListAddressesMethod__,
@@ -71,6 +72,7 @@ export type __AccountMethod__ =
     | __GenerateAddressesMethod__
     | __GetBalanceMethod__
     | __GetOutputMethod__
+    | __GetFoundryOutputMethod__
     | __GetOutputsWithAdditionalUnlockConditionsMethod__
     | __GetTransactionMethod__
     | __ListAddressesMethod__

--- a/bindings/nodejs/types/index.ts
+++ b/bindings/nodejs/types/index.ts
@@ -4,7 +4,7 @@ export * from './address';
 export * from './bridge';
 export * from './buildOutputData';
 export * from './event';
-export * from './loggerConfig'
+export * from './loggerConfig';
 export * from './network';
 export * from './output';
 export * from './outputOptions';

--- a/bindings/nodejs/types/outputOptions.ts
+++ b/bindings/nodejs/types/outputOptions.ts
@@ -6,7 +6,7 @@ export interface OutputOptions {
     assets?: Assets;
     features?: Features;
     unlocks?: Unlocks;
-    storageDeposit?: StorageDeposit
+    storageDeposit?: StorageDeposit;
 }
 
 export interface Assets {
@@ -25,7 +25,7 @@ export interface Unlocks {
 }
 
 export interface StorageDeposit {
-    returnStrategy?: ReturnStrategy
+    returnStrategy?: ReturnStrategy;
     useExcessIfLow?: boolean;
 }
 

--- a/bindings/nodejs/types/transactionOptions.ts
+++ b/bindings/nodejs/types/transactionOptions.ts
@@ -29,8 +29,10 @@ export type CustomAddress = {
 
 export interface NativeTokenOptions {
     accountAddress?: string;
-    circulatingSupply: number;
-    maximumSupply: number;
+    /** Hex encoded number */
+    circulatingSupply: string;
+    /** Hex encoded number */
+    maximumSupply: string;
     foundryMetadata?: number[];
 }
 

--- a/src/account/handle.rs
+++ b/src/account/handle.rs
@@ -88,6 +88,7 @@ impl AccountHandle {
                 }
             }
         }
+        drop(account);
 
         // Foundry was not found in the account, try to get it from the node
         let foundry_output_id = self.client.foundry_output_id(foundry_id).await?;

--- a/src/message_interface/account_method.rs
+++ b/src/message_interface/account_method.rs
@@ -31,7 +31,7 @@ use crate::{
 #[serde(tag = "name", content = "data")]
 pub enum AccountMethod {
     /// Build an AliasOutput.
-    /// Expected response: [`OutputDto`](crate::message_interface::Response::OutputDto)
+    /// Expected response: [`Output`](crate::message_interface::Response::Output)
     #[allow(missing_docs)]
     BuildAliasOutput {
         // If not provided, minimum storage deposit will be used
@@ -53,7 +53,7 @@ pub enum AccountMethod {
         immutable_features: Option<Vec<FeatureDto>>,
     },
     /// Build a BasicOutput.
-    /// Expected response: [`OutputDto`](crate::message_interface::Response::OutputDto)
+    /// Expected response: [`Output`](crate::message_interface::Response::Output)
     #[allow(missing_docs)]
     BuildBasicOutput {
         // If not provided, minimum storage deposit will be used
@@ -65,7 +65,7 @@ pub enum AccountMethod {
         features: Option<Vec<FeatureDto>>,
     },
     /// Build a FoundryOutput.
-    /// Expected response: [`OutputDto`](crate::message_interface::Response::OutputDto)
+    /// Expected response: [`Output`](crate::message_interface::Response::Output)
     #[allow(missing_docs)]
     BuildFoundryOutput {
         // If not provided, minimum storage deposit will be used
@@ -83,7 +83,7 @@ pub enum AccountMethod {
         immutable_features: Option<Vec<FeatureDto>>,
     },
     /// Build an NftOutput.
-    /// Expected response: [`OutputDto`](crate::message_interface::Response::OutputDto)
+    /// Expected response: [`Output`](crate::message_interface::Response::Output)
     #[allow(missing_docs)]
     BuildNftOutput {
         // If not provided, minimum storage deposit will be used
@@ -112,13 +112,13 @@ pub enum AccountMethod {
         options: Option<AddressGenerationOptions>,
     },
     /// Get the [`OutputData`](crate::account::types::OutputData) of an output stored in the account
-    /// Expected response: [`Output`](crate::message_interface::Response::Output)
+    /// Expected response: [`OutputData`](crate::message_interface::Response::OutputData)
     GetOutput {
         #[serde(rename = "outputId")]
         output_id: OutputId,
     },
     /// Get the [`Output`](crate::account::types::Output) that minted a native token by its TokenId
-    /// Expected response: [`OutputDto`](crate::message_interface::Response::OutputDto)
+    /// Expected response: [`Output`](crate::message_interface::Response::Output)
     GetFoundryOutput {
         #[serde(rename = "tokenId")]
         token_id: TokenIdDto,
@@ -150,10 +150,10 @@ pub enum AccountMethod {
     /// [`AddressesWithUnspentOutputs`](crate::message_interface::Response::AddressesWithUnspentOutputs)
     ListAddressesWithUnspentOutputs,
     /// Returns all outputs of the account
-    /// Expected response: [`Outputs`](crate::message_interface::Response::Outputs)
+    /// Expected response: [`OutputsData`](crate::message_interface::Response::OutputsData)
     ListOutputs,
     /// Returns all unspent outputs of the account
-    /// Expected response: [`Outputs`](crate::message_interface::Response::Outputs)
+    /// Expected response: [`OutputsData`](crate::message_interface::Response::OutputsData)
     ListUnspentOutputs,
     /// Returns all transaction of the account
     /// Expected response: [`Transactions`](crate::message_interface::Response::Transactions)

--- a/src/message_interface/account_method.rs
+++ b/src/message_interface/account_method.rs
@@ -5,7 +5,7 @@ use iota_client::{
     api::{PreparedTransactionDataDto, SignedTransactionDataDto},
     bee_block::{
         output::{
-            dto::{AliasIdDto, NativeTokenDto, NftIdDto, OutputDto, TokenSchemeDto},
+            dto::{AliasIdDto, NativeTokenDto, NftIdDto, OutputDto, TokenIdDto, TokenSchemeDto},
             feature::dto::FeatureDto,
             unlock_condition::dto::UnlockConditionDto,
             OutputId,
@@ -31,7 +31,7 @@ use crate::{
 #[serde(tag = "name", content = "data")]
 pub enum AccountMethod {
     /// Build an AliasOutput.
-    /// Expected response: [`BuiltOutput`](crate::message_interface::Response::BuiltOutput)
+    /// Expected response: [`OutputDto`](crate::message_interface::Response::OutputDto)
     #[allow(missing_docs)]
     BuildAliasOutput {
         // If not provided, minimum storage deposit will be used
@@ -53,7 +53,7 @@ pub enum AccountMethod {
         immutable_features: Option<Vec<FeatureDto>>,
     },
     /// Build a BasicOutput.
-    /// Expected response: [`BuiltOutput`](crate::message_interface::Response::BuiltOutput)
+    /// Expected response: [`OutputDto`](crate::message_interface::Response::OutputDto)
     #[allow(missing_docs)]
     BuildBasicOutput {
         // If not provided, minimum storage deposit will be used
@@ -65,7 +65,7 @@ pub enum AccountMethod {
         features: Option<Vec<FeatureDto>>,
     },
     /// Build a FoundryOutput.
-    /// Expected response: [`BuiltOutput`](crate::message_interface::Response::BuiltOutput)
+    /// Expected response: [`OutputDto`](crate::message_interface::Response::OutputDto)
     #[allow(missing_docs)]
     BuildFoundryOutput {
         // If not provided, minimum storage deposit will be used
@@ -83,7 +83,7 @@ pub enum AccountMethod {
         immutable_features: Option<Vec<FeatureDto>>,
     },
     /// Build an NftOutput.
-    /// Expected response: [`BuiltOutput`](crate::message_interface::Response::BuiltOutput)
+    /// Expected response: [`OutputDto`](crate::message_interface::Response::OutputDto)
     #[allow(missing_docs)]
     BuildNftOutput {
         // If not provided, minimum storage deposit will be used
@@ -116,6 +116,12 @@ pub enum AccountMethod {
     GetOutput {
         #[serde(rename = "outputId")]
         output_id: OutputId,
+    },
+    /// Get the [`Output`](crate::account::types::Output) that minted a native token by its TokenId
+    /// Expected response: [`OutputDto`](crate::message_interface::Response::OutputDto)
+    GetFoundryOutput {
+        #[serde(rename = "tokenId")]
+        token_id: TokenIdDto,
     },
     /// Get outputs with additional unlock conditions
     /// Expected response: [`OutputIds`](crate::message_interface::Response::OutputIds)
@@ -177,7 +183,7 @@ pub enum AccountMethod {
     /// Expected response: [`Balance`](crate::message_interface::Response::Balance)
     GetBalance,
     /// Prepare an output.
-    /// Expected response: [`Output`](crate::message_interface::Response::Output)
+    /// Expected response: [`OutputDto`](crate::message_interface::Response::OutputDto)
     PrepareOutput {
         options: OutputOptionsDto,
         transaction_options: Option<TransactionOptions>,

--- a/src/message_interface/message_handler.rs
+++ b/src/message_interface/message_handler.rs
@@ -13,7 +13,7 @@ use futures::{Future, FutureExt};
 use iota_client::{
     api::{PreparedTransactionData, PreparedTransactionDataDto, SignedTransactionData, SignedTransactionDataDto},
     bee_block::{
-        output::{dto::OutputDto, ByteCost, Output},
+        output::{dto::OutputDto, ByteCost, Output, TokenId},
         payload::transaction::dto::TransactionPayloadDto,
     },
     constants::SHIMMER_TESTNET_BECH32_HRP,
@@ -354,7 +354,7 @@ impl WalletMessageHandler {
                     immutable_features.clone(),
                 )
                 .await?;
-                Ok(Response::BuiltOutput(output_dto))
+                Ok(Response::OutputDto(output_dto))
             }
             AccountMethod::BuildBasicOutput {
                 amount,
@@ -370,7 +370,7 @@ impl WalletMessageHandler {
                     features.clone(),
                 )
                 .await?;
-                Ok(Response::BuiltOutput(output_dto))
+                Ok(Response::OutputDto(output_dto))
             }
             AccountMethod::BuildFoundryOutput {
                 amount,
@@ -392,7 +392,7 @@ impl WalletMessageHandler {
                     immutable_features.clone(),
                 )
                 .await?;
-                Ok(Response::BuiltOutput(output_dto))
+                Ok(Response::OutputDto(output_dto))
             }
             AccountMethod::BuildNftOutput {
                 amount,
@@ -412,7 +412,7 @@ impl WalletMessageHandler {
                     immutable_features.clone(),
                 )
                 .await?;
-                Ok(Response::BuiltOutput(output_dto))
+                Ok(Response::OutputDto(output_dto))
             }
             AccountMethod::ConsolidateOutputs {
                 force,
@@ -441,6 +441,11 @@ impl WalletMessageHandler {
                 Ok(Response::Output(
                     output_data.as_ref().map(OutputDataDto::from).map(Box::new),
                 ))
+            }
+            AccountMethod::GetFoundryOutput { token_id } => {
+                let token_id = TokenId::try_from(token_id)?;
+                let output = account_handle.get_foundry_output(token_id).await?;
+                Ok(Response::OutputDto(OutputDto::from(&output)))
             }
             AccountMethod::GetTransaction { transaction_id } => {
                 let transaction = account_handle.get_transaction(transaction_id).await;
@@ -531,7 +536,7 @@ impl WalletMessageHandler {
                     let output = account_handle
                         .prepare_output(OutputOptions::try_from(options)?, transaction_options.clone())
                         .await?;
-                    Ok(Response::BuiltOutput(OutputDto::from(&output)))
+                    Ok(Response::OutputDto(OutputDto::from(&output)))
                 })
                 .await
             }

--- a/src/message_interface/message_handler.rs
+++ b/src/message_interface/message_handler.rs
@@ -354,7 +354,7 @@ impl WalletMessageHandler {
                     immutable_features.clone(),
                 )
                 .await?;
-                Ok(Response::OutputDto(output_dto))
+                Ok(Response::Output(output_dto))
             }
             AccountMethod::BuildBasicOutput {
                 amount,
@@ -370,7 +370,7 @@ impl WalletMessageHandler {
                     features.clone(),
                 )
                 .await?;
-                Ok(Response::OutputDto(output_dto))
+                Ok(Response::Output(output_dto))
             }
             AccountMethod::BuildFoundryOutput {
                 amount,
@@ -392,7 +392,7 @@ impl WalletMessageHandler {
                     immutable_features.clone(),
                 )
                 .await?;
-                Ok(Response::OutputDto(output_dto))
+                Ok(Response::Output(output_dto))
             }
             AccountMethod::BuildNftOutput {
                 amount,
@@ -412,7 +412,7 @@ impl WalletMessageHandler {
                     immutable_features.clone(),
                 )
                 .await?;
-                Ok(Response::OutputDto(output_dto))
+                Ok(Response::Output(output_dto))
             }
             AccountMethod::ConsolidateOutputs {
                 force,
@@ -438,14 +438,14 @@ impl WalletMessageHandler {
             }
             AccountMethod::GetOutput { output_id } => {
                 let output_data = account_handle.get_output(output_id).await;
-                Ok(Response::Output(
+                Ok(Response::OutputData(
                     output_data.as_ref().map(OutputDataDto::from).map(Box::new),
                 ))
             }
             AccountMethod::GetFoundryOutput { token_id } => {
                 let token_id = TokenId::try_from(token_id)?;
                 let output = account_handle.get_foundry_output(token_id).await?;
-                Ok(Response::OutputDto(OutputDto::from(&output)))
+                Ok(Response::Output(OutputDto::from(&output)))
             }
             AccountMethod::GetTransaction { transaction_id } => {
                 let transaction = account_handle.get_transaction(transaction_id).await;
@@ -475,11 +475,11 @@ impl WalletMessageHandler {
             }
             AccountMethod::ListOutputs => {
                 let outputs = account_handle.list_outputs().await?;
-                Ok(Response::Outputs(outputs.iter().map(OutputDataDto::from).collect()))
+                Ok(Response::OutputsData(outputs.iter().map(OutputDataDto::from).collect()))
             }
             AccountMethod::ListUnspentOutputs => {
                 let outputs = account_handle.list_unspent_outputs().await?;
-                Ok(Response::Outputs(outputs.iter().map(OutputDataDto::from).collect()))
+                Ok(Response::OutputsData(outputs.iter().map(OutputDataDto::from).collect()))
             }
             AccountMethod::ListTransactions => {
                 let transactions = account_handle.list_transactions().await?;
@@ -536,7 +536,7 @@ impl WalletMessageHandler {
                     let output = account_handle
                         .prepare_output(OutputOptions::try_from(options)?, transaction_options.clone())
                         .await?;
-                    Ok(Response::OutputDto(OutputDto::from(&output)))
+                    Ok(Response::Output(OutputDto::from(&output)))
                 })
                 .await
             }

--- a/src/message_interface/response.rs
+++ b/src/message_interface/response.rs
@@ -51,7 +51,7 @@ pub enum Response {
     /// [`BuildNftOutput`](crate::message_interface::AccountMethod::BuildNftOutput)
     /// [`GetFoundryOutput`](crate::message_interface::AccountMethod::GetFoundryOutput)
     /// [`PrepareOutput`](crate::message_interface::AccountMethod::PrepareOutput)
-    OutputDto(OutputDto),
+    Output(OutputDto),
     /// Response for
     /// [`MinimumRequiredStorageDeposit`](crate::message_interface::AccountMethod::MinimumRequiredStorageDeposit)
     MinimumRequiredStorageDeposit(String),
@@ -60,11 +60,11 @@ pub enum Response {
     /// GetOutputsWithAdditionalUnlockConditions)
     OutputIds(Vec<OutputId>),
     /// Response for [`GetOutput`](crate::message_interface::AccountMethod::GetOutput)
-    Output(Option<Box<OutputDataDto>>),
+    OutputData(Option<Box<OutputDataDto>>),
     /// Response for
     /// [`ListOutputs`](crate::message_interface::AccountMethod::ListOutputs),
     /// [`ListUnspentOutputs`](crate::message_interface::AccountMethod::ListUnspentOutputs)
-    Outputs(Vec<OutputDataDto>),
+    OutputsData(Vec<OutputDataDto>),
     /// Response for
     /// [`PrepareSendAmount`](crate::message_interface::AccountMethod::PrepareSendAmount),
     /// [`PrepareTransaction`](crate::message_interface::AccountMethod::PrepareTransaction)
@@ -151,11 +151,11 @@ impl Debug for Response {
             Response::AddressesWithUnspentOutputs(addresses) => {
                 write!(f, "AddressesWithUnspentOutputs({:?})", addresses)
             }
-            Response::OutputDto(output) => write!(f, "OutputDto({:?})", output),
+            Response::Output(output) => write!(f, "Output({:?})", output),
             Response::MinimumRequiredStorageDeposit(amount) => write!(f, "MinimumRequiredStorageDeposit({:?})", amount),
             Response::OutputIds(output_ids) => write!(f, "OutputIds({:?})", output_ids),
-            Response::Output(output) => write!(f, "Output({:?})", output),
-            Response::Outputs(outputs) => write!(f, "Outputs{:?}", outputs),
+            Response::OutputData(output) => write!(f, "OutputData({:?})", output),
+            Response::OutputsData(outputs) => write!(f, "OutputsData{:?}", outputs),
             Response::PreparedTransaction(transaction_data) => {
                 write!(f, "PreparedTransaction({:?})", transaction_data)
             }

--- a/src/message_interface/response.rs
+++ b/src/message_interface/response.rs
@@ -49,7 +49,9 @@ pub enum Response {
     /// [`BuildBasicOutput`](crate::message_interface::AccountMethod::BuildBasicOutput)
     /// [`BuildFoundryOutput`](crate::message_interface::AccountMethod::BuildFoundryOutput)
     /// [`BuildNftOutput`](crate::message_interface::AccountMethod::BuildNftOutput)
-    BuiltOutput(OutputDto),
+    /// [`GetFoundryOutput`](crate::message_interface::AccountMethod::GetFoundryOutput)
+    /// [`PrepareOutput`](crate::message_interface::AccountMethod::PrepareOutput)
+    OutputDto(OutputDto),
     /// Response for
     /// [`MinimumRequiredStorageDeposit`](crate::message_interface::AccountMethod::MinimumRequiredStorageDeposit)
     MinimumRequiredStorageDeposit(String),
@@ -149,7 +151,7 @@ impl Debug for Response {
             Response::AddressesWithUnspentOutputs(addresses) => {
                 write!(f, "AddressesWithUnspentOutputs({:?})", addresses)
             }
-            Response::BuiltOutput(output) => write!(f, "BuiltOutput({:?})", output),
+            Response::OutputDto(output) => write!(f, "OutputDto({:?})", output),
             Response::MinimumRequiredStorageDeposit(amount) => write!(f, "MinimumRequiredStorageDeposit({:?})", amount),
             Response::OutputIds(output_ids) => write!(f, "OutputIds({:?})", output_ids),
             Response::Output(output) => write!(f, "Output({:?})", output),


### PR DESCRIPTION
# Description of change

- Implement a method on `AccountHandle` to get `FoundryOutput` by `TokenId`: `get_foundry_output`. It first tries to get the foundry output from the account, and if it isn't in the account it will try to get it from the node
- Expose the new method in the message interface.
- Replace `BuiltOutput` `Response` variant with `OutputDto` and use it for the new method.
- Add examples to nodejs bindings: `22-mint-native-tokens` and `23-get-foundry-output`.
- Fix incorrect type in nodejs `NativeTokenOptions`.

## Links to any relevant issues

Fixes issue #1221.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Breaking change

## How the change has been tested

I added an example in the nodejs bindings to mint native tokens, and then I tested the new method with various `TokenId`s, verifying that the returned foundry output is the same that minted the `NativeToken`.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
