### PR TITLE
Remove skip_sync option, reduce MIN_SYNC_INTERVAL

### DIFF
--- a/bindings/nodejs/types/transactionOptions.ts
+++ b/bindings/nodejs/types/transactionOptions.ts
@@ -3,7 +3,6 @@ import type { ITaggedDataPayload } from '@iota/types';
 export interface TransactionOptions {
     remainderValueStrategy?: RemainderValueStrategy;
     taggedDataPayload?: ITaggedDataPayload;
-    skipSync?: boolean;
     customInputs?: string[];
 }
 

--- a/bindings/swift/xcode/IotaWallet/IotaWalletTests/await.swift
+++ b/bindings/swift/xcode/IotaWallet/IotaWalletTests/await.swift
@@ -75,7 +75,7 @@ class SwiftAwait: XCTestCase {
             expectation.fulfill()
         }
         
-        let test_event = "{\"cmd\": \"EmitTestEvent\", \"payload\": { \"TransactionProgress\": \"SyncingAccount\" } }"
+        let test_event = "{\"cmd\": \"EmitTestEvent\", \"payload\": { \"TransactionProgress\": \"SelectingInputs\" } }"
         try! await wallet.sendMessage(test_event)
         
         await self.waitForExpectations(timeout: 2) { error in

--- a/examples/threads.rs
+++ b/examples/threads.rs
@@ -16,7 +16,6 @@ use iota_client::{
     constants::SHIMMER_COIN_TYPE,
 };
 use iota_wallet::{
-    account::TransactionOptions,
     account_manager::AccountManager,
     secret::{mnemonic::MnemonicSecretManager, SecretManager},
     ClientOptions, Result,
@@ -81,16 +80,7 @@ async fn main() -> Result<()> {
                         // amount of outputs in the transaction (one additional output might be added for the remaining amount)
                         1
                     ];
-                    // Skip sync here, we already synced before and don't need to do it again for every transaction
-                    let tx = account_
-                        .send(
-                            outputs,
-                            Some(TransactionOptions {
-                                skip_sync: true,
-                                ..Default::default()
-                            }),
-                        )
-                        .await?;
+                    let tx = account_.send(outputs, None).await?;
                     if let Some(block_id) = tx.block_id {
                         println!(
                             "Block from thread {} sent: http://localhost:14265/api/v2/blocks/{}",

--- a/src/account/constants.rs
+++ b/src/account/constants.rs
@@ -13,7 +13,7 @@ pub(crate) const PARALLEL_REQUESTS_AMOUNT: usize = 500;
 
 /// ms before an account actually syncs with the network, before it just returns the previous syncing result
 /// this is done to prevent unnecessary simultaneous synchronizations
-pub(crate) const MIN_SYNC_INTERVAL: u128 = 3000;
+pub(crate) const MIN_SYNC_INTERVAL: u128 = 200;
 
 // Default expiration time for [ExpirationUnlockCondition] when sending native tokens, one day in seconds
 pub(crate) const DEFAULT_EXPIRATION_TIME: u32 = 86400;

--- a/src/account/operations/output_claiming.rs
+++ b/src/account/operations/output_claiming.rs
@@ -338,7 +338,6 @@ impl AccountHandle {
                 .finish_transaction(
                     outputs_to_send,
                     Some(TransactionOptions {
-                        skip_sync: true,
                         custom_inputs: Some(
                             outputs
                                 .iter()

--- a/src/account/operations/output_consolidation.rs
+++ b/src/account/operations/output_consolidation.rs
@@ -111,7 +111,6 @@ impl AccountHandle {
                     .finish_transaction(
                         consolidation_output,
                         Some(TransactionOptions {
-                            skip_sync: true,
                             custom_inputs: Some(custom_inputs),
                             ..Default::default()
                         }),

--- a/src/account/operations/transaction/high_level/minting/mint_nfts.rs
+++ b/src/account/operations/transaction/high_level/minting/mint_nfts.rs
@@ -114,6 +114,6 @@ impl AccountHandle {
             outputs.push(nft_builder.finish_output()?);
         }
 
-        self.sync_and_prepare_transaction(outputs, options).await
+        self.prepare_transaction(outputs, options).await
     }
 }

--- a/src/account/operations/transaction/high_level/send_amount.rs
+++ b/src/account/operations/transaction/high_level/send_amount.rs
@@ -69,6 +69,6 @@ impl AccountHandle {
             )
         }
 
-        self.sync_and_prepare_transaction(outputs, options).await
+        self.prepare_transaction(outputs, options).await
     }
 }

--- a/src/account/operations/transaction/high_level/send_micro_transaction.rs
+++ b/src/account/operations/transaction/high_level/send_micro_transaction.rs
@@ -123,6 +123,6 @@ impl AccountHandle {
             )
         }
 
-        self.sync_and_prepare_transaction(outputs, options).await
+        self.prepare_transaction(outputs, options).await
     }
 }

--- a/src/account/operations/transaction/high_level/send_native_tokens.rs
+++ b/src/account/operations/transaction/high_level/send_native_tokens.rs
@@ -135,6 +135,6 @@ impl AccountHandle {
             )
         }
 
-        self.sync_and_prepare_transaction(outputs, options).await
+        self.prepare_transaction(outputs, options).await
     }
 }

--- a/src/account/operations/transaction/high_level/send_nft.rs
+++ b/src/account/operations/transaction/high_level/send_nft.rs
@@ -106,6 +106,6 @@ impl AccountHandle {
             }),
         };
 
-        self.sync_and_prepare_transaction(outputs, options).await
+        self.prepare_transaction(outputs, options).await
     }
 }

--- a/src/account/operations/transaction/options.rs
+++ b/src/account/operations/transaction/options.rs
@@ -13,8 +13,6 @@ pub struct TransactionOptions {
     pub remainder_value_strategy: RemainderValueStrategy,
     #[serde(rename = "taggedDataPayload", default)]
     pub tagged_data_payload: Option<TaggedDataPayload>,
-    #[serde(rename = "skipSync", default)]
-    pub skip_sync: bool,
     #[serde(rename = "customInputs", default)]
     pub custom_inputs: Option<Vec<OutputId>>,
     #[serde(rename = "allowBurning", default)]

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -151,7 +151,7 @@ mod tests {
         emitter.emit(0, WalletEvent::ConsolidationRequired);
         emitter.emit(
             0,
-            WalletEvent::TransactionProgress(TransactionProgressEvent::SyncingAccount),
+            WalletEvent::TransactionProgress(TransactionProgressEvent::SelectingInputs),
         );
         emitter.emit(
             0,
@@ -178,7 +178,7 @@ mod tests {
         // emit events
         emitter.emit(
             0,
-            WalletEvent::TransactionProgress(TransactionProgressEvent::SyncingAccount),
+            WalletEvent::TransactionProgress(TransactionProgressEvent::SelectingInputs),
         );
         emitter.emit(
             0,

--- a/src/events/types.rs
+++ b/src/events/types.rs
@@ -77,8 +77,6 @@ pub struct TransactionInclusionEvent {
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum TransactionProgressEvent {
-    /// Syncing account.
-    SyncingAccount,
     /// Performing input selection.
     SelectingInputs,
     /// Generating remainder value deposit address.


### PR DESCRIPTION
# Description of change

Remove skip_sync option to make it clearer and not need to add also the sync options, reduce MIN_SYNC_INTERVAL since the milestone interval also got reduced and some application might want to sync in a faster interval

## Links to any relevant issues

Fixes #1270 

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
