### PR TITLE
Fix set_client_options to include coin type

### DIFF
--- a/src/account/update.rs
+++ b/src/account/update.rs
@@ -270,16 +270,6 @@ impl AccountHandle {
         for address in &mut account.internal_addresses {
             address.address.bech32_hrp = bech32_hrp.clone();
         }
-        // Drop account before syncing because we locked it
-        drop(account);
-        // after we set the new client options we should sync the account because the network could have changed
-        // we sync with all addresses, because otherwise the balance wouldn't get updated if an address doesn't has
-        // balance also in the new network
-        self.sync(Some(SyncOptions {
-            force_syncing: true,
-            ..Default::default()
-        }))
-        .await?;
         Ok(())
     }
 

--- a/src/account_manager/builder.rs
+++ b/src/account_manager/builder.rs
@@ -4,7 +4,7 @@
 #[cfg(any(feature = "storage", feature = "stronghold"))]
 use std::path::PathBuf;
 use std::sync::{
-    atomic::{AtomicU32, AtomicUsize},
+    atomic::{AtomicU32, AtomicUsize, Ordering},
     Arc,
 };
 
@@ -219,5 +219,14 @@ impl AccountManagerBuilder {
             #[cfg(feature = "storage")]
             storage_manager,
         })
+    }
+
+    pub(crate) async fn from_account_manager(account_manager: &AccountManager) -> Self {
+        Self {
+            client_options: Some(account_manager.client_options.read().await.clone()),
+            coin_type: Some(account_manager.coin_type.load(Ordering::Relaxed)),
+            storage_options: Some(account_manager.storage_options.clone()),
+            secret_manager: Some(account_manager.secret_manager.clone()),
+        }
     }
 }


### PR DESCRIPTION
# Description of change

Fix set_client_options to include coin type
Also removed the syncing part, because the default sync options might not be wanted, if the node is from the same network there shouldn't be a change anyways and the user can sync himself afterwards

## Links to any relevant issues

Fixes https://github.com/iotaledger/cli-wallet/issues/124

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

With changing the node multiple times in the cli wallet

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
