### PR TITLE
Let Native Tokens be in the remainder output

### DIFF
--- a/src/account/operations/transaction/high_level/minting/mint_native_token.rs
+++ b/src/account/operations/transaction/high_level/minting/mint_native_token.rs
@@ -172,13 +172,7 @@ impl AccountHandle {
                     }
 
                     foundry_builder.finish_output()?
-                },
-                BasicOutputBuilder::new_with_minimum_storage_deposit(byte_cost_config)?
-                    .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(
-                        controller_address,
-                    )))
-                    .add_native_token(NativeToken::new(token_id, native_token_options.circulating_supply)?)
-                    .finish_output()?,
+                }, // Native Tokens will be added automatically in the remainder output in try_select_inputs()
             ];
             self.send(outputs, options)
                 .await

--- a/src/account/operations/transaction/high_level/minting/mint_native_token.rs
+++ b/src/account/operations/transaction/high_level/minting/mint_native_token.rs
@@ -6,11 +6,10 @@ use iota_client::block::{
     output::{
         feature::{Feature, MetadataFeature},
         unlock_condition::{
-            AddressUnlockCondition, GovernorAddressUnlockCondition, ImmutableAliasAddressUnlockCondition,
+            GovernorAddressUnlockCondition, ImmutableAliasAddressUnlockCondition,
             StateControllerAddressUnlockCondition, UnlockCondition,
         },
-        AliasId, AliasOutputBuilder, BasicOutputBuilder, FoundryId, FoundryOutputBuilder, NativeToken, Output,
-        SimpleTokenScheme, TokenId, TokenScheme,
+        AliasId, AliasOutputBuilder, FoundryId, FoundryOutputBuilder, Output, SimpleTokenScheme, TokenId, TokenScheme,
     },
 };
 use primitive_types::U256;


### PR DESCRIPTION
# Description of change

Let Native Tokens be in the remainder output, to reduce the amount of outputs

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

In the cli wallet, minted a native token https://explorer.shimmer.network/testnet/transaction/0x1e8470f8ff5f57624586bf656c0f02cc2c5ae69f1d5eb6f9efd03566c3608537

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
