### PR TITLE
Sync addresses from confirmed transaction outputs

### DIFF
--- a/src/account/operations/syncing/mod.rs
+++ b/src/account/operations/syncing/mod.rs
@@ -62,7 +62,7 @@ impl AccountHandle {
         log::debug!("[SYNC] addresses_to_sync {}", addresses_to_sync.len());
 
         // get outputs for addresses and add them also the the addresses_with_unspent_outputs
-        let (addresses_with_output_ids, spent_output_ids) =
+        let (addresses_with_output_ids, spent_or_not_synced_output_ids) =
             self.get_address_output_ids(&options, addresses_to_sync.clone()).await?;
 
         // get outputs for addresses and add them also the the addresses_with_unspent_outputs
@@ -70,8 +70,8 @@ impl AccountHandle {
             self.get_addresses_outputs(addresses_with_output_ids.clone()).await?;
 
         // request possible spent outputs
-        let (spent_output_responses, _loaded_output_responses) =
-            self.get_outputs(spent_output_ids.clone(), true).await?;
+        let (spent_or_not_synced_output_responses, _loaded_output_responses) =
+            self.get_outputs(spent_or_not_synced_output_ids.clone(), true).await?;
 
         if options.sync_incoming_transactions {
             let transaction_ids = output_data
@@ -86,8 +86,8 @@ impl AccountHandle {
         self.update_account(
             addresses_with_unspent_outputs_and_outputs,
             output_data,
-            spent_output_ids,
-            spent_output_responses,
+            spent_or_not_synced_output_ids,
+            spent_or_not_synced_output_responses,
             &options,
         )
         .await?;

--- a/src/account/operations/syncing/transactions.rs
+++ b/src/account/operations/syncing/transactions.rs
@@ -30,6 +30,10 @@ impl AccountHandle {
         log::debug!("[SYNC] sync pending transactions");
         let account = self.read().await;
 
+        if account.pending_transactions.is_empty() {
+            return Ok(());
+        }
+
         let network_id = self.client.get_network_id().await?;
 
         let mut updated_transactions = Vec::new();

--- a/src/account/operations/transaction/mod.rs
+++ b/src/account/operations/transaction/mod.rs
@@ -215,15 +215,14 @@ impl AccountHandle {
                                 .outputs()
                                 .iter()
                                 .filter_map(|o| {
-                                    o.unlock_conditions()
-                                        .expect("output needs to have unlock conditions")
-                                        .address()
-                                        .and_then(|output_address| {
+                                    o.unlock_conditions().and_then(|unlock_conditions| {
+                                        unlock_conditions.address().and_then(|output_address| {
                                             account_addresses
                                                 .iter()
                                                 .find(|a| a.address.inner == *output_address.address())
                                                 .map(|acc_address| acc_address.address.to_bech32())
                                         })
+                                    })
                                 })
                                 .collect();
 

--- a/src/account/operations/transaction/mod.rs
+++ b/src/account/operations/transaction/mod.rs
@@ -195,7 +195,7 @@ impl AccountHandle {
     // available for new transactions without manually syncing (which would sync all addresses and be more heavy without
     // extra logic)
     fn monitor_tx_confirmation(&self, block_id: BlockId) {
-        // spawn a thread which tries to get the block confirmed
+        // spawn a task which tries to get the block confirmed
         let account = self.clone();
         tokio::spawn(async move {
             if let Ok(blocks) = account.client().retry_until_included(&block_id, None, None).await {


### PR DESCRIPTION
# Description of change

Sync addresses from confirmed transaction outputs, so the outputs get available without the need of manually syncing
Also handle some output stuff in syncing, so we don't make outputs spent, even though they aren't, just because we don't sync them

## Links to any relevant issues
Fixes #1189 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Running the threads example modified so it doesn't call sync()

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
