### PR TITLE
fix: windows delay load hook set to true

### DIFF
--- a/.changes/add-windows-node-gyp-config.md
+++ b/.changes/add-windows-node-gyp-config.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": patch
+---
+
+Add "win_delay_load_hook": "true" to check if add-on gets compiled correctly.

--- a/bindings/nodejs/binding.gyp
+++ b/bindings/nodejs/binding.gyp
@@ -1,7 +1,8 @@
 {
   "targets": [
     {
-      "target_name": "index"
+      "target_name": "index",
+      "win_delay_load_hook": "true",
     }
   ]
 }


### PR DESCRIPTION
# Description of change

We're currently running into issues with the node.js bindings. This troubleshooting guide suggest setting win_load_delay_hook to true for the node-gyp configuration. node-gyp is responsible for compiling and handling the Node.js add-ons.

## Links to any relevant issues

https://github.com/iotaledger/firefly/issues/4113

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
