### PR TITLE
Emit `PreparedTransaction` only once and when blindsigning is not needed

### DIFF
--- a/.changes/remove-duplicated-event.md
+++ b/.changes/remove-duplicated-event.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": patch
+---
+
+Emit `PreparedTransaction` only once and when blindsigning is not needed.

--- a/src/account/operations/transaction/build_transaction.rs
+++ b/src/account/operations/transaction/build_transaction.rs
@@ -81,16 +81,7 @@ impl AccountHandle {
             inputs_data: inputs_for_signing,
             remainder: selected_transaction_data.remainder,
         };
-        #[cfg(feature = "events")]
-        {
-            let account_index = self.read().await.index;
-            self.event_emitter.lock().await.emit(
-                account_index,
-                WalletEvent::TransactionProgress(TransactionProgressEvent::PreparedTransaction(Box::new(
-                    PreparedTransactionDataDto::from(&prepared_transaction_data),
-                ))),
-            );
-        }
+
         log::debug!(
             "[TRANSACTION] finished build_transaction in {:.2?}",
             build_transaction_essence_start_time.elapsed()

--- a/src/account/operations/transaction/build_transaction.rs
+++ b/src/account/operations/transaction/build_transaction.rs
@@ -3,8 +3,6 @@
 
 use std::time::Instant;
 
-#[cfg(feature = "events")]
-use iota_client::api::PreparedTransactionDataDto;
 use iota_client::{
     api::{input_selection::types::SelectedTransactionData, PreparedTransactionData},
     block::{
@@ -19,8 +17,6 @@ use iota_client::{
 };
 
 use crate::account::{handle::AccountHandle, operations::transaction::TransactionOptions};
-#[cfg(feature = "events")]
-use crate::events::types::{TransactionProgressEvent, WalletEvent};
 
 impl AccountHandle {
     /// Function to build the transaction essence from the selected in and outputs


### PR DESCRIPTION
# Description of change

Emit `PreparedTransaction` only once and when blindsigning is not needed

## Links to any relevant issues

Fixes #1366 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
