### PR TITLE
fix: fix nodejs prebuilds

### DIFF
--- a/.changes/fix-prebuild.md
+++ b/.changes/fix-prebuild.md
@@ -1,0 +1,6 @@
+---
+"nodejs-binding": patch
+---
+
+Fixed prebuilds for nodejs bindings.
+Add newer Electron versions for electron build.

--- a/bindings/nodejs/scripts/electron-prebuild.js
+++ b/bindings/nodejs/scripts/electron-prebuild.js
@@ -1,6 +1,6 @@
 const { spawnSync } = require('child_process');
 const { resolve } = require('path');
-const ELECTRON_VERSIONS = ['12.0.18', '13.2.3', '14.0.0'];
+const ELECTRON_VERSIONS = ['13.2.3', '14.0.0', '15.0.0', '16.0.0', '17.0.0', '18.0.0', '19.0.0'];
 
 for (const version of ELECTRON_VERSIONS) {
     // HACK: make electron-build-env aware of the electron version we're targeting

--- a/bindings/nodejs/scripts/move-artifact.js
+++ b/bindings/nodejs/scripts/move-artifact.js
@@ -1,0 +1,15 @@
+const { existsSync, mkdirSync, renameSync } = require('fs');
+const { resolve } = require('path');
+
+// Prebuild requires that the binary be in `build/Release` as though it was built with node-gyp
+
+const moveArtifact = () => {
+    const path = resolve(__dirname, '../build/Release');
+
+    if (!existsSync(path)) {
+        mkdirSync(path, { recursive: true });
+    }
+    renameSync(resolve(__dirname, '../index.node'), resolve(path, 'index.node'));
+};
+
+module.exports = moveArtifact;

--- a/bindings/nodejs/scripts/node-neon-build.js
+++ b/bindings/nodejs/scripts/node-neon-build.js
@@ -1,9 +1,20 @@
 const { resolve } = require('path');
 const { spawnSync } = require('child_process');
+const moveArtifact = require('./move-artifact');
 
 // Passing "--prepack 'npm run build:neon'" causes problems on Windows, so this is a workaround
 
-spawnSync('npm', ['run', 'build:neon'], {
+const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+
+const { status } = spawnSync(npm, ['run', 'build:neon'], {
     stdio: 'inherit',
     cwd: resolve(__dirname, '../'),
 });
+
+if (status === null) {
+    process.exit(1);
+} else if (status > 0) {
+    process.exit(status);
+}
+
+moveArtifact();

--- a/bindings/nodejs/scripts/strip.js
+++ b/bindings/nodejs/scripts/strip.js
@@ -8,6 +8,14 @@ if (process.platform === 'win32') {
     return;
 }
 
-const binaryPath = resolve(__dirname, '../index.node');
+const binaryPath = resolve(__dirname, '../build/Release/index.node');
 const stripArgs = process.platform === 'darwin' ? '-Sx' : '--strip-all';
-spawnSync('strip', [stripArgs, binaryPath], { stdio: 'inherit' });
+const { status } = spawnSync('strip', [stripArgs, binaryPath], {
+    stdio: 'inherit',
+});
+
+if (status === null) {
+    process.exit(1);
+} else if (status > 0) {
+    process.exit(status);
+}


### PR DESCRIPTION
# Description of change
Fix prebuilds for nodejs bindings + add new electron versions. 

## Links to any relevant issues

fixes issue #1360 

## Type of change


- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested
Locally run `npm run prebuild:node` creates a index.node file with ~10MB

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
