### PR TITLE
Return Account instead of AccountMeta

### DIFF
--- a/.changes/recover-accounts.md
+++ b/.changes/recover-accounts.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": patch
+---
+
+Return correct Account type from recoverAccounts().

--- a/bindings/nodejs/Cargo.lock
+++ b/bindings/nodejs/Cargo.lock
@@ -1126,7 +1126,7 @@ dependencies = [
 [[package]]
 name = "iota-client"
 version = "2.0.0-beta.3"
-source = "git+https://github.com/iotaledger/iota.rs?rev=31c4368705a02c93cc9f23c4cb4b1bd0cf6e1cd4#31c4368705a02c93cc9f23c4cb4b1bd0cf6e1cd4"
+source = "git+https://github.com/iotaledger/iota.rs?rev=f9bc46f9dbf55dad1a6df771e9921646772d88a3#f9bc46f9dbf55dad1a6df771e9921646772d88a3"
 dependencies = [
  "async-trait",
  "backtrace",
@@ -1214,9 +1214,9 @@ dependencies = [
 
 [[package]]
 name = "iota-ledger-nano"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ad1e0dac851bc0fb0ef980cdb05c82a4dfe2468f71cb580d3a7b62c32eab7b"
+checksum = "ef28b65fb2c58b5aa01793c36a33ef3d63333f6760abcba95659c4cb5b4e8fe5"
 dependencies = [
  "bech32 0.7.3",
  "enum-iterator",

--- a/bindings/nodejs/lib/AccountManager.ts
+++ b/bindings/nodejs/lib/AccountManager.ts
@@ -233,7 +233,13 @@ export class AccountManager {
                 syncOptions,
             },
         });
-        return JSON.parse(response).payload;
+
+        const accounts: Account[] = [];
+
+        for (const account of JSON.parse(response).payload) {
+            accounts.push(new Account(account, this.messageHandler));
+        }
+        return accounts;
     }
 
     /**


### PR DESCRIPTION
# Description of change

Return Account instead of AccountMeta

## Links to any relevant issues

Fixes #1387 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Running a modified example with 
```JS
        const accounts = await manager.recoverAccounts(1, 1);
        console.log('Account recovered:', accounts);

        const address = await accounts[0].generateAddress();
        console.log('Address:', address);
```

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
