### PR TITLE
Attempt to fix deadlock

### DIFF
--- a/src/account/sync/mod.rs
+++ b/src/account/sync/mod.rs
@@ -2508,6 +2508,7 @@ async fn perform_transfer(
                 .await;
         }
         log::debug!("[TRANSFER] Checking confirmation for {} finished", message_id);
+        drop(new_account_handle);
     });
 
     let mut account_ = account_handle.write().await;
@@ -2586,6 +2587,12 @@ async fn perform_transfer(
                 .await?;
         }
     }
+
+    // Drop account handle to prevent deadlock from `new_account_handle` in the spawned task
+    drop(account_handle);
+
+    log::debug!("[TRANSFER] perform_transfer finished");
+
     Ok(message)
 }
 


### PR DESCRIPTION
# Description of change

Attempt to fix deadlock

## Links to any relevant issues

Log which shows the latest log before nothing happend anymore in the wallet
```
2022-08-10 11:14:59 (UTC) iota_wallet::account_manager               [94mDEBUG[0m [AccountsSynchronizer] synced existing accounts
2022-08-10 11:14:59 (UTC) reqwest::async_impl::client                [94mDEBUG[0m response '200 OK' for http://some-iota-node-url/api/v1/outputs/q3q3tdtjs5ezaw4grva3wtrvq3t5vqw3v53vtw3tgdxthhhhes5jhsrj0000
2022-08-10 11:14:59 (UTC) iota_client::node_manager                  [94mDEBUG[0m GET request took 0 ms for http://some-iota-node-url/api/v1/outputs/q3q3tdtjs5ezaw4grva3wtrvq3t5vqw3v53vtw3tgdxthhhhes5jhsrj0000
2022-08-10 11:14:59 (UTC) reqwest::async_impl::client                [94mDEBUG[0m response '200 OK' for http://some-iota-node-url/api/v1/messages/asw4zxrgyeuhjdt3t3qrhnrc8q27rz5nq987rzm9286tgn97qc2ng/metadata
2022-08-10 11:14:59 (UTC) iota_client::node_manager                  [94mDEBUG[0m GET request took 0 ms for http://some-iota-node-url/api/v1/messages/asw4zxrgyeuhjdt3t3qrhnrc8q27rz5nq987rzm9286tgn97qc2ng/metadata
2022-08-10 11:14:59 (UTC) iota_wallet::account::sync                 [94mDEBUG[0m get_events
2022-08-10 11:14:59 (UTC) iota_wallet::account::sync                 [94mDEBUG[0m [SYNC] address iota1... balance changed from 51942531 to 51942511
2022-08-10 11:14:59 (UTC) iota_wallet::account::sync                 [92mINFO [0m [SYNC] remaining balance change on iota1 BalanceChange { spent: 0, received: 95439 }
2022-08-10 11:14:59 (UTC) iota_wallet::account::sync                 [92mINFO [0m [SYNC] new message: MessageId(...)
2022-08-10 11:15:00 (UTC) reqwest::connect                           [94mDEBUG[0m starting new connection: http://some-iota-node-url/
2022-08-10 11:15:00 (UTC) reqwest::async_impl::client                [94mDEBUG[0m response '200 OK' for http://some-iota-node-url/api/v1/info
2022-08-10 11:15:00 (UTC) iota_client::node_manager                  [94mDEBUG[0m GET request took 3 ms for http://some-iota-node-url/api/v1/info
2022-08-10 11:15:00 (UTC) reqwest::async_impl::client                [94mDEBUG[0m response '201 Created' for http://some-iota-node-url/api/v1/messages
2022-08-10 11:15:00 (UTC) iota_wallet::account::sync                 [94mDEBUG[0m [TRANSFER] Checking confirmation for ag2er5hxh4ws8f2f730d45f9774as4a5ssfh3c2c4dy4zy4aegag
2022-08-10 11:15:05 (UTC) reqwest::async_impl::client                [94mDEBUG[0m response '200 OK' for http://some-iota-node-url/api/v1/messages/ag2er5hxh4ws8f2f730d45f9774as4a5ssfh3c2c4dy4zy4aegag/metadata
2022-08-10 11:15:05 (UTC) iota_client::node_manager                  [94mDEBUG[0m GET request took 0 ms for http://some-iota-node-url/api/v1/messages/ag2er5hxh4ws8f2f730d45f9774as4a5ssfh3c2c4dy4zy4aegag/metadata
2022-08-10 11:15:10 (UTC) reqwest::async_impl::client                [94mDEBUG[0m response '200 OK' for http://some-iota-node-url/api/v1/messages/ag2er5hxh4ws8f2f730d45f9774as4a5ssfh3c2c4dy4zy4aegag/metadata
2022-08-10 11:15:10 (UTC) iota_client::node_manager                  [94mDEBUG[0m GET request took 0 ms for http://some-iota-node-url/api/v1/messages/ag2er5hxh4ws8f2f730d45f9774as4a5ssfh3c2c4dy4zy4aegag/metadata
2022-08-10 11:15:10 (UTC) reqwest::async_impl::client                [94mDEBUG[0m response '200 OK' for http://some-iota-node-url/api/v1/messages/ag2er5hxh4ws8f2f730d45f9774as4a5ssfh3c2c4dy4zy4aegag
2022-08-10 11:15:10 (UTC) iota_client::node_manager                  [94mDEBUG[0m GET request took 0 ms for http://some-iota-node-url/api/v1/messages/ag2er5hxh4ws8f2f730d45f9774as4a5ssfh3c2c4dy4zy4aegag
2022-08-10 11:16:00 (UTC) reqwest::connect                           [94mDEBUG[0m starting new connection: http://some-iota-node-url/
2022-08-10 11:16:00 (UTC) reqwest::async_impl::client                [94mDEBUG[0m response '200 OK' for http://some-iota-node-url/api/v1/info
2022-08-10 11:16:00 (UTC) iota_client::node_manager                  [94mDEBUG[0m GET request took 1 ms for http://some-iota-node-url/api/v1/info
// from here only more get info requests which come from the iota.rs node syncing
```

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
