### PR TITLE
Remove try_claim_outputs()

### DIFF
--- a/.changes/1tx-claiming.md
+++ b/.changes/1tx-claiming.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": patch
+---
+
+Remove tryClaimOutputs() and only do a single transaction when calling the claimOutputs() function.

--- a/bindings/nodejs/lib/Account.ts
+++ b/bindings/nodejs/lib/Account.ts
@@ -894,27 +894,4 @@ export class Account {
         );
         return JSON.parse(resp).payload;
     }
-
-    /**
-     * Try to claim basic outputs that have additional unlock conditions to
-     * their `AddressUnlockCondition` and send them to the first address of the
-     * account.
-     * @param outputsToClaim Outputs to try to claim.
-     * @returns The resulting transactions.
-     */
-    async tryClaimOutputs(
-        outputsToClaim: OutputsToClaim,
-    ): Promise<Transaction[]> {
-        const response = await this.messageHandler.callAccountMethod(
-            this.meta.index,
-            {
-                name: 'TryClaimOutputs',
-                data: {
-                    outputsToClaim,
-                },
-            },
-        );
-
-        return JSON.parse(response).payload;
-    }
 }

--- a/bindings/nodejs/lib/Account.ts
+++ b/bindings/nodejs/lib/Account.ts
@@ -176,9 +176,9 @@ export class Account {
      * Claim basic or nft outputs that have additional unlock conditions
      * to their `AddressUnlockCondition` from the account.
      * @param outputIds The outputs to claim.
-     * @returns The resulting transactions.
+     * @returns The resulting transaction.
      */
-    async claimOutputs(outputIds: string[]): Promise<Transaction[]> {
+    async claimOutputs(outputIds: string[]): Promise<Transaction> {
         const resp = await this.messageHandler.callAccountMethod(
             this.meta.index,
             {

--- a/bindings/nodejs/types/bridge/account.ts
+++ b/bindings/nodejs/types/bridge/account.ts
@@ -295,10 +295,3 @@ export type __SyncAccountMethod__ = {
         options?: AccountSyncOptions;
     };
 };
-
-export type __TryClaimOutputsMethod__ = {
-    name: 'TryClaimOutputs';
-    data: {
-        outputsToClaim: OutputsToClaim;
-    };
-};

--- a/bindings/nodejs/types/bridge/index.ts
+++ b/bindings/nodejs/types/bridge/index.ts
@@ -39,7 +39,6 @@ import type {
     __SignTransactionEssenceMethod__,
     __SubmitAndStoreTransactionMethod__,
     __SyncAccountMethod__,
-    __TryClaimOutputsMethod__,
 } from './account';
 import type {
     __BackupMessage__,
@@ -107,8 +106,7 @@ export type __AccountMethod__ =
     | __SetAliasMethod__
     | __SignTransactionEssenceMethod__
     | __SubmitAndStoreTransactionMethod__
-    | __SyncAccountMethod__
-    | __TryClaimOutputsMethod__;
+    | __SyncAccountMethod__;
 
 export type __CallAccountMethodMessage__ = {
     cmd: 'CallAccountMethod';

--- a/bindings/python/native/iota_wallet/account.py
+++ b/bindings/python/native/iota_wallet/account.py
@@ -439,16 +439,6 @@ class Account:
             }
         )
 
-    def try_claim_outputs(self, outputs_to_claim):
-        """Try to claim outputs.
-        """
-        return self._call_account_method(
-            'TryClaimOutputs', {
-                'outputsToClaim': outputs_to_claim
-
-            }
-        )
-
     def claim_outputs(self, output_ids_to_claim):
         """Claim outputs.
         """

--- a/documentation/docs/libraries/nodejs/references/classes/Account.md
+++ b/documentation/docs/libraries/nodejs/references/classes/Account.md
@@ -46,7 +46,6 @@ The Account class.
 - [signTransactionEssence](Account.md#signtransactionessence)
 - [submitAndStoreTransaction](Account.md#submitandstoretransaction)
 - [sync](Account.md#sync)
-- [tryClaimOutputs](Account.md#tryclaimoutputs)
 
 ## Methods
 
@@ -846,25 +845,3 @@ Will also retry pending transactions if necessary.
 `Promise`<[`AccountBalance`](../interfaces/AccountBalance.md)\>
 
 The account balance.
-
-___
-
-### tryClaimOutputs
-
-▸ **tryClaimOutputs**(`outputsToClaim`): `Promise`<[`Transaction`](../interfaces/Transaction.md)[]\>
-
-Try to claim basic outputs that have additional unlock conditions to
-their `AddressUnlockCondition` and send them to the first address of the
-account.
-
-#### Parameters
-
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `outputsToClaim` | [`OutputsToClaim`](../enums/OutputsToClaim.md) | Outputs to try to claim. |
-
-#### Returns
-
-`Promise`<[`Transaction`](../interfaces/Transaction.md)[]\>
-
-The resulting transactions.

--- a/documentation/docs/libraries/nodejs/references/classes/Account.md
+++ b/documentation/docs/libraries/nodejs/references/classes/Account.md
@@ -178,7 +178,7 @@ ___
 
 ### claimOutputs
 
-▸ **claimOutputs**(`outputIds`): `Promise`<[`Transaction`](../interfaces/Transaction.md)[]\>
+▸ **claimOutputs**(`outputIds`): `Promise`<[`Transaction`](../interfaces/Transaction.md)\>
 
 Claim basic or nft outputs that have additional unlock conditions
 to their `AddressUnlockCondition` from the account.
@@ -193,7 +193,7 @@ to their `AddressUnlockCondition` from the account.
 
 `Promise`<[`Transaction`](../interfaces/Transaction.md)[]\>
 
-The resulting transactions.
+The resulting transaction.
 
 ___
 

--- a/documentation/docs/libraries/python/api_reference.md
+++ b/documentation/docs/libraries/python/api_reference.md
@@ -390,16 +390,6 @@ def submit_and_store_transaction(signed_transaction_data)
 
 Submit and store transaction.
 
-<a id="iota_wallet.account.Account.try_claim_outputs"></a>
-
-#### try\_claim\_outputs
-
-```python
-def try_claim_outputs(outputs_to_claim)
-```
-
-Try to claim outputs.
-
 <a id="iota_wallet.account.Account.claim_outputs"></a>
 
 #### claim\_outputs

--- a/src/account/operations/output_claiming.rs
+++ b/src/account/operations/output_claiming.rs
@@ -30,11 +30,6 @@ pub enum OutputsToClaim {
     All = 4,
 }
 
-/// Defines how many inputs can be claimed with one transaction.
-/// This limit is needed because in addition we might need to create the double amount of outputs because of the storage
-/// deposit return and also consider the remainder output.
-const MAX_CLAIM_INPUTS: usize = 60;
-
 impl AccountHandle {
     /// Get basic and nft outputs that have [`ExpirationUnlockCondition`], [`StorageDepositReturnUnlockCondition`] or
     /// [`TimelockUnlockCondition`] and can be unlocked now and also get basic outputs with only an
@@ -165,7 +160,7 @@ impl AccountHandle {
 
     /// Try to claim basic or nft outputs that have additional unlock conditions to their [AddressUnlockCondition]
     /// from [`AccountHandle::get_unlockable_outputs_with_additional_unlock_conditions()`].
-    pub async fn claim_outputs(&self, output_ids_to_claim: Vec<OutputId>) -> crate::Result<Vec<Transaction>> {
+    pub async fn claim_outputs(&self, output_ids_to_claim: Vec<OutputId>) -> crate::Result<Transaction> {
         log::debug!("[OUTPUT_CLAIMING] claim_outputs");
         let basic_outputs = self.get_basic_outputs_for_additional_inputs().await?;
         self.claim_outputs_internal(output_ids_to_claim, basic_outputs).await
@@ -176,7 +171,7 @@ impl AccountHandle {
         &self,
         output_ids_to_claim: Vec<OutputId>,
         mut possible_additional_inputs: Vec<OutputData>,
-    ) -> crate::Result<Vec<Transaction>> {
+    ) -> crate::Result<Transaction> {
         log::debug!("[OUTPUT_CLAIMING] claim_outputs_internal");
 
         let current_time = self.client.get_time_checked().await?;
@@ -194,8 +189,9 @@ impl AccountHandle {
         }
 
         if outputs_to_claim.is_empty() {
-            // No outputs to claim, return
-            return Ok(Vec::new());
+            return Err(crate::Error::CustomInputError(
+                "provided outputs can't be claimed".to_string(),
+            ));
         }
 
         let first_account_address = account
@@ -205,162 +201,154 @@ impl AccountHandle {
             .clone();
         drop(account);
 
-        let mut claim_results = Vec::new();
         let mut additional_inputs_used = HashSet::new();
 
         // Outputs with expiration and storage deposit return might require two outputs if there is a storage deposit
         // return unlock condition Maybe also more additional inputs are required for the storage deposit, if we
         // have to send the storage deposit back.
-        for outputs in outputs_to_claim.chunks(MAX_CLAIM_INPUTS) {
-            let mut outputs_to_send = Vec::new();
-            // Keep track of the outputs to return, so we only create one output per address
-            let mut required_address_returns: HashMap<Address, u64> = HashMap::new();
-            // Amount we get with the storage deposit return amounts already subtracted
-            let mut new_amount = 0;
-            let mut new_native_tokens = NativeTokensBuilder::new();
-            // check native tokens
-            for output_data in outputs {
-                if let Some(native_tokens) = output_data.output.native_tokens() {
-                    // Skip output if the max native tokens count would be exceeded
-                    if get_new_native_token_count(&new_native_tokens, native_tokens)? > NativeTokens::COUNT_MAX.into() {
-                        log::debug!("[OUTPUT_CLAIMING] skipping output to not exceed the max native tokens count");
-                        continue;
-                    }
-                    new_native_tokens.add_native_tokens(native_tokens.clone())?;
+
+        let mut outputs_to_send = Vec::new();
+        // Keep track of the outputs to return, so we only create one output per address
+        let mut required_address_returns: HashMap<Address, u64> = HashMap::new();
+        // Amount we get with the storage deposit return amounts already subtracted
+        let mut new_amount = 0;
+        let mut new_native_tokens = NativeTokensBuilder::new();
+        // check native tokens
+        for output_data in &outputs_to_claim {
+            if let Some(native_tokens) = output_data.output.native_tokens() {
+                // Skip output if the max native tokens count would be exceeded
+                if get_new_native_token_count(&new_native_tokens, native_tokens)? > NativeTokens::COUNT_MAX.into() {
+                    log::debug!("[OUTPUT_CLAIMING] skipping output to not exceed the max native tokens count");
+                    continue;
                 }
-                if let Some(sdr) = sdr_not_expired(&output_data.output, current_time) {
-                    // for own output subtract the return amount
-                    new_amount += output_data.output.amount() - sdr.amount();
-
-                    // Insert for return output
-                    *required_address_returns.entry(*sdr.return_address()).or_default() += sdr.amount();
-                } else {
-                    new_amount += output_data.output.amount();
-                }
-
-                if let Output::Nft(nft_output) = &output_data.output {
-                    // build new output with same amount, nft_id, immutable/feature blocks and native tokens, just
-                    // updated address unlock conditions
-
-                    let nft_output = NftOutputBuilder::from(nft_output)
-                        .with_minimum_storage_deposit(rent_structure.clone())
-                        .with_nft_id(nft_output.nft_id().or_from_output_id(output_data.output_id))
-                        .with_unlock_conditions([UnlockCondition::Address(AddressUnlockCondition::new(
-                            first_account_address.address.inner,
-                        ))])
-                        // Set native tokens empty, we will collect them from all inputs later
-                        .with_native_tokens([])
-                        .finish_output()?;
-
-                    outputs_to_send.push(nft_output);
-                }
+                new_native_tokens.add_native_tokens(native_tokens.clone())?;
             }
+            if let Some(sdr) = sdr_not_expired(&output_data.output, current_time) {
+                // for own output subtract the return amount
+                new_amount += output_data.output.amount() - sdr.amount();
 
-            let option_native_token = if new_native_tokens.is_empty() {
-                None
+                // Insert for return output
+                *required_address_returns.entry(*sdr.return_address()).or_default() += sdr.amount();
             } else {
-                Some(new_native_tokens.clone().finish()?)
-            };
-
-            // Check if the new amount is enough for the storage deposit, otherwise increase it to this
-            let mut required_storage_deposit = minimum_storage_deposit_basic_output(
-                &rent_structure,
-                &first_account_address.address.inner,
-                &option_native_token,
-            )?;
-
-            let mut additional_inputs = Vec::new();
-            if new_amount < required_storage_deposit {
-                // Sort by amount so we use as less as possible
-                possible_additional_inputs.sort_by_key(|o| o.output.amount());
-
-                // add more inputs
-                for output_data in &possible_additional_inputs {
-                    // Recalculate every time, because new inputs can also add more native tokens, which would increase
-                    // the required storage deposit
-                    required_storage_deposit = minimum_storage_deposit_basic_output(
-                        &rent_structure,
-                        &first_account_address.address.inner,
-                        &option_native_token,
-                    )?;
-                    if new_amount < required_storage_deposit {
-                        if !additional_inputs_used.contains(&output_data.output_id) {
-                            if let Some(native_tokens) = output_data.output.native_tokens() {
-                                // Skip input if the max native tokens count would be exceeded
-                                if get_new_native_token_count(&new_native_tokens, native_tokens)?
-                                    > NativeTokens::COUNT_MAX.into()
-                                {
-                                    log::debug!(
-                                        "[OUTPUT_CLAIMING] skipping input to not exceed the max native tokens count"
-                                    );
-                                    continue;
-                                }
-                                new_native_tokens.add_native_tokens(native_tokens.clone())?;
-                            }
-                            new_amount += output_data.output.amount();
-                            additional_inputs.push(output_data.output_id);
-                            additional_inputs_used.insert(output_data.output_id);
-                        }
-                    } else {
-                        // Break if we have enough inputs
-                        break;
-                    }
-                }
+                new_amount += output_data.output.amount();
             }
 
-            // If we still don't have enough amount we can't create the output
-            if new_amount < required_storage_deposit {
-                return Err(crate::Error::InsufficientFunds(new_amount, required_storage_deposit));
-            }
+            if let Output::Nft(nft_output) = &output_data.output {
+                // build new output with same amount, nft_id, immutable/feature blocks and native tokens, just
+                // updated address unlock conditions
 
-            for (return_address, return_amount) in required_address_returns {
-                outputs_to_send.push(
-                    BasicOutputBuilder::new_with_amount(return_amount)?
-                        .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(return_address)))
-                        .finish_output()?,
-                );
-            }
-
-            // Create output with claimed values
-            outputs_to_send.push(
-                BasicOutputBuilder::new_with_amount(new_amount)?
-                    .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(
+                let nft_output = NftOutputBuilder::from(nft_output)
+                    .with_minimum_storage_deposit(rent_structure.clone())
+                    .with_nft_id(nft_output.nft_id().or_from_output_id(output_data.output_id))
+                    .with_unlock_conditions([UnlockCondition::Address(AddressUnlockCondition::new(
                         first_account_address.address.inner,
-                    )))
-                    .with_native_tokens(new_native_tokens.finish()?)
-                    .finish_output()?,
-            );
+                    ))])
+                    // Set native tokens empty, we will collect them from all inputs later
+                    .with_native_tokens([])
+                    .finish_output()?;
 
-            match self
-                .finish_transaction(
-                    outputs_to_send,
-                    Some(TransactionOptions {
-                        custom_inputs: Some(
-                            outputs
-                                .iter()
-                                .map(|o| o.output_id)
-                                // add additional inputs
-                                .chain(additional_inputs)
-                                .collect::<Vec<OutputId>>(),
-                        ),
-                        ..Default::default()
-                    }),
-                )
-                .await
-            {
-                Ok(tx) => {
-                    log::debug!(
-                        "[OUTPUT_CLAIMING] Claiming transaction created: block_id: {:?} tx_id: {:?}",
-                        tx.block_id,
-                        tx.transaction_id
-                    );
-                    claim_results.push(tx);
-                }
-                Err(e) => log::debug!("Output claim error: {}", e),
-            };
+                outputs_to_send.push(nft_output);
+            }
         }
 
-        Ok(claim_results)
+        let option_native_token = if new_native_tokens.is_empty() {
+            None
+        } else {
+            Some(new_native_tokens.clone().finish()?)
+        };
+
+        // Check if the new amount is enough for the storage deposit, otherwise increase it to this
+        let mut required_storage_deposit = minimum_storage_deposit_basic_output(
+            &rent_structure,
+            &first_account_address.address.inner,
+            &option_native_token,
+        )?;
+
+        let mut additional_inputs = Vec::new();
+        if new_amount < required_storage_deposit {
+            // Sort by amount so we use as less as possible
+            possible_additional_inputs.sort_by_key(|o| o.output.amount());
+
+            // add more inputs
+            for output_data in &possible_additional_inputs {
+                // Recalculate every time, because new inputs can also add more native tokens, which would increase
+                // the required storage deposit
+                required_storage_deposit = minimum_storage_deposit_basic_output(
+                    &rent_structure,
+                    &first_account_address.address.inner,
+                    &option_native_token,
+                )?;
+                if new_amount < required_storage_deposit {
+                    if !additional_inputs_used.contains(&output_data.output_id) {
+                        if let Some(native_tokens) = output_data.output.native_tokens() {
+                            // Skip input if the max native tokens count would be exceeded
+                            if get_new_native_token_count(&new_native_tokens, native_tokens)?
+                                > NativeTokens::COUNT_MAX.into()
+                            {
+                                log::debug!(
+                                    "[OUTPUT_CLAIMING] skipping input to not exceed the max native tokens count"
+                                );
+                                continue;
+                            }
+                            new_native_tokens.add_native_tokens(native_tokens.clone())?;
+                        }
+                        new_amount += output_data.output.amount();
+                        additional_inputs.push(output_data.output_id);
+                        additional_inputs_used.insert(output_data.output_id);
+                    }
+                } else {
+                    // Break if we have enough inputs
+                    break;
+                }
+            }
+        }
+
+        // If we still don't have enough amount we can't create the output
+        if new_amount < required_storage_deposit {
+            return Err(crate::Error::InsufficientFunds(new_amount, required_storage_deposit));
+        }
+
+        for (return_address, return_amount) in required_address_returns {
+            outputs_to_send.push(
+                BasicOutputBuilder::new_with_amount(return_amount)?
+                    .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(return_address)))
+                    .finish_output()?,
+            );
+        }
+
+        // Create output with claimed values
+        outputs_to_send.push(
+            BasicOutputBuilder::new_with_amount(new_amount)?
+                .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(
+                    first_account_address.address.inner,
+                )))
+                .with_native_tokens(new_native_tokens.finish()?)
+                .finish_output()?,
+        );
+
+        let claim_tx = self
+            .finish_transaction(
+                outputs_to_send,
+                Some(TransactionOptions {
+                    custom_inputs: Some(
+                        outputs_to_claim
+                            .iter()
+                            .map(|o| o.output_id)
+                            // add additional inputs
+                            .chain(additional_inputs)
+                            .collect::<Vec<OutputId>>(),
+                    ),
+                    ..Default::default()
+                }),
+            )
+            .await?;
+
+        log::debug!(
+            "[OUTPUT_CLAIMING] Claiming transaction created: block_id: {:?} tx_id: {:?}",
+            claim_tx.block_id,
+            claim_tx.transaction_id
+        );
+        Ok(claim_tx)
     }
 }
 

--- a/src/account/operations/output_claiming.rs
+++ b/src/account/operations/output_claiming.rs
@@ -137,17 +137,6 @@ impl AccountHandle {
         Ok(output_ids_to_claim.into_iter().collect())
     }
 
-    /// Try to claim basic outputs that have additional unlock conditions to their [AddressUnlockCondition].
-    pub async fn try_claim_outputs(&self, outputs_to_claim: OutputsToClaim) -> crate::Result<Vec<Transaction>> {
-        log::debug!("[OUTPUT_CLAIMING] try_claim_outputs");
-
-        let output_ids_to_claim = self
-            .get_unlockable_outputs_with_additional_unlock_conditions(outputs_to_claim)
-            .await?;
-        let basic_outputs = self.get_basic_outputs_for_additional_inputs().await?;
-        self.claim_outputs_internal(output_ids_to_claim, basic_outputs).await
-    }
-
     /// Get basic outputs that have only one unlock condition which is [AddressUnlockCondition], so they can be used as
     /// additional inputs
     pub async fn get_basic_outputs_for_additional_inputs(&self) -> crate::Result<Vec<OutputData>> {

--- a/src/message_interface/account_method.rs
+++ b/src/message_interface/account_method.rs
@@ -338,12 +338,6 @@ pub enum AccountMethod {
         #[serde(rename = "signedTransactionData")]
         signed_transaction_data: SignedTransactionDataDto,
     },
-    /// Try to claim outputs.
-    /// Expected response: [`SentTransactions`](crate::message_interface::Response::SentTransactions)
-    TryClaimOutputs {
-        #[serde(rename = "outputsToClaim")]
-        outputs_to_claim: OutputsToClaim,
-    },
     /// Claim outputs.
     /// Expected response: [`SentTransactions`](crate::message_interface::Response::SentTransactions)
     ClaimOutputs {

--- a/src/message_interface/account_method.rs
+++ b/src/message_interface/account_method.rs
@@ -339,7 +339,7 @@ pub enum AccountMethod {
         signed_transaction_data: SignedTransactionDataDto,
     },
     /// Claim outputs.
-    /// Expected response: [`SentTransactions`](crate::message_interface::Response::SentTransactions)
+    /// Expected response: [`SentTransaction`](crate::message_interface::Response::SentTransaction)
     ClaimOutputs {
         #[serde(rename = "outputIdsToClaim")]
         output_ids_to_claim: Vec<OutputId>,

--- a/src/message_interface/message_handler.rs
+++ b/src/message_interface/message_handler.rs
@@ -800,9 +800,7 @@ impl WalletMessageHandler {
             AccountMethod::ClaimOutputs { output_ids_to_claim } => {
                 convert_async_panics(|| async {
                     let transactions = account_handle.claim_outputs(output_ids_to_claim.to_vec()).await?;
-                    Ok(Response::SentTransactions(
-                        transactions.iter().map(TransactionDto::from).collect(),
-                    ))
+                    Ok(Response::SentTransaction(TransactionDto::from(&transactions)))
                 })
                 .await
             }

--- a/src/message_interface/message_handler.rs
+++ b/src/message_interface/message_handler.rs
@@ -799,8 +799,8 @@ impl WalletMessageHandler {
             }
             AccountMethod::ClaimOutputs { output_ids_to_claim } => {
                 convert_async_panics(|| async {
-                    let transactions = account_handle.claim_outputs(output_ids_to_claim.to_vec()).await?;
-                    Ok(Response::SentTransaction(TransactionDto::from(&transactions)))
+                    let transaction = account_handle.claim_outputs(output_ids_to_claim.to_vec()).await?;
+                    Ok(Response::SentTransaction(TransactionDto::from(&transaction)))
                 })
                 .await
             }

--- a/src/message_interface/message_handler.rs
+++ b/src/message_interface/message_handler.rs
@@ -797,15 +797,6 @@ impl WalletMessageHandler {
                 })
                 .await
             }
-            AccountMethod::TryClaimOutputs { outputs_to_claim } => {
-                convert_async_panics(|| async {
-                    let transactions = account_handle.try_claim_outputs(outputs_to_claim).await?;
-                    Ok(Response::SentTransactions(
-                        transactions.iter().map(TransactionDto::from).collect(),
-                    ))
-                })
-                .await
-            }
             AccountMethod::ClaimOutputs { output_ids_to_claim } => {
                 convert_async_panics(|| async {
                     let transactions = account_handle.claim_outputs(output_ids_to_claim.to_vec()).await?;

--- a/src/message_interface/response.rs
+++ b/src/message_interface/response.rs
@@ -102,7 +102,6 @@ pub enum Response {
     /// [`SubmitAndStoreTransaction`](crate::message_interface::AccountMethod::SubmitAndStoreTransaction)
     SentTransaction(TransactionDto),
     /// Response for
-    /// [`TryClaimOutputs`](crate::message_interface::AccountMethod::TryClaimOutputs),
     /// [`ClaimOutputs`](crate::message_interface::AccountMethod::ClaimOutputs)
     /// [`ConsolidateOutputs`](crate::message_interface::AccountMethod::ConsolidateOutputs)
     SentTransactions(Vec<TransactionDto>),

--- a/tests/burn_outputs.rs
+++ b/tests/burn_outputs.rs
@@ -218,13 +218,6 @@ async fn destroy_foundry() -> Result<()> {
         Err(e) => return Err(e),
     };
 
-    let _account_addresses = account.generate_addresses(1, None).await.unwrap();
-
-    let _ = account
-        .try_claim_outputs(iota_wallet::account::OutputsToClaim::All)
-        .await
-        .unwrap();
-
     let balance = account.sync(None).await.unwrap();
     println!("account balance -> {}", serde_json::to_string(&balance).unwrap());
 


### PR DESCRIPTION
# Description of change

Remove try_claim_outputs() and only do a single claim tx when calling the claim function

## Links to any relevant issues

Partially fixes #1417 

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

cli wallet

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
