### PR TITLE
Remove broken delete_accounts_and_database()

### DIFF
--- a/.changes/remove-deleteAccountsAndDatabase.md
+++ b/.changes/remove-deleteAccountsAndDatabase.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": patch
+---
+
+Remove broken deleteAccountsAndDatabase().

--- a/bindings/nodejs/examples/5-backup.js
+++ b/bindings/nodejs/examples/5-backup.js
@@ -10,11 +10,7 @@ async function run() {
     try {
         const manager = await getUnlockedManager();
         const path = await manager.backup('./backup', process.env.SH_PASSWORD);
-        console.log('Backup created at:', path);
-
-        await manager.deleteAccountsAndDatabase();
-
-        console.log('Successfully created backup');
+        console.log('Successfully created backup at:', path);
     } catch (error) {
         console.log('Error: ', error);
     }

--- a/bindings/nodejs/lib/AccountManager.ts
+++ b/bindings/nodejs/lib/AccountManager.ts
@@ -86,15 +86,6 @@ export class AccountManager {
     }
 
     /**
-     * Delete all accounts and the database folder.
-     */
-    async deleteAccountsAndDatabase(): Promise<void> {
-        await this.messageHandler.sendMessage({
-            cmd: 'DeleteAccountsAndDatabase',
-        });
-    }
-
-    /**
      * Destroy the AccountManager and drop its database connection.
      */
     destroy(): void {

--- a/bindings/nodejs/types/bridge/accountManager.ts
+++ b/bindings/nodejs/types/bridge/accountManager.ts
@@ -36,10 +36,6 @@ export type __CreateAccountMessage__ = {
     payload: CreateAccountPayload;
 };
 
-export type __DeleteAccountsAndDatabaseMessage__ = {
-    cmd: 'DeleteAccountsAndDatabase';
-};
-
 export type __EmitTestEventMessage__ = {
     cmd: 'EmitTestEvent';
     payload: WalletEvent;

--- a/bindings/nodejs/types/bridge/index.ts
+++ b/bindings/nodejs/types/bridge/index.ts
@@ -48,7 +48,6 @@ import type {
     __ChangeStrongholdPasswordMessage__,
     __ClearStrongholdPasswordMessage__,
     __CreateAccountMessage__,
-    __DeleteAccountsAndDatabaseMessage__,
     __EmitTestEventMessage__,
     __GenerateMnemonicMessage__,
     __GetAccountMessage__,
@@ -127,7 +126,6 @@ export type __Message__ =
     | __ChangeStrongholdPasswordMessage__
     | __ClearStrongholdPasswordMessage__
     | __CreateAccountMessage__
-    | __DeleteAccountsAndDatabaseMessage__
     | __EmitTestEventMessage__
     | __GenerateMnemonicMessage__
     | __GetAccountMessage__

--- a/bindings/python/native/iota_wallet/wallet.py
+++ b/bindings/python/native/iota_wallet/wallet.py
@@ -130,13 +130,6 @@ class IotaWallet():
             }
         )
 
-    def delete_accounts_and_database(self):
-        """Deletes the accounts and database.
-        """
-        return self._send_cmd_routine(
-            'DeleteAccountsAndDatabase'
-        )
-
     def generate_mnemonic(self):
         """Generates a new mnemonic.
         """

--- a/bindings/python/native/tests/address_generation_test.py
+++ b/bindings/python/native/tests/address_generation_test.py
@@ -26,9 +26,6 @@ def test_address_generation_iota():
 
     addresses = account.list_addresses()
 
-    # Clear up
-    wallet.delete_accounts_and_database()
-
     assert 'rms1qpg2xkj66wwgn8p2ggnp7p582gj8g6p79us5hve2tsudzpsr2ap4s4k35lq' == addresses[
         0]['address']
 
@@ -53,9 +50,6 @@ def test_address_generation_shimmer():
     account = wallet.get_account('Alice')
 
     addresses = account.list_addresses()
-
-    # Clear up
-    wallet.delete_accounts_and_database()
 
     assert 'rms1qzev36lk0gzld0k28fd2fauz26qqzh4hd4cwymlqlv96x7phjxcw6v3ea5a' == addresses[
         0]['address']

--- a/documentation/docs/references/nodejs/classes/AccountManager.md
+++ b/documentation/docs/references/nodejs/classes/AccountManager.md
@@ -11,7 +11,6 @@ The AccountManager class.
 - [changeStrongholdPassword](AccountManager.md#changestrongholdpassword)
 - [clearStrongholdPassword](AccountManager.md#clearstrongholdpassword)
 - [createAccount](AccountManager.md#createaccount)
-- [deleteAccountsAndDatabase](AccountManager.md#deleteaccountsanddatabase)
 - [destroy](AccountManager.md#destroy)
 - [emitTestEvent](AccountManager.md#emittestevent)
 - [generateMnemonic](AccountManager.md#generatemnemonic)
@@ -119,18 +118,6 @@ Create a new account.
 #### Returns
 
 `Promise`<[`Account`](Account.md)\>
-
-___
-
-### deleteAccountsAndDatabase
-
-▸ **deleteAccountsAndDatabase**(): `Promise`<`void`\>
-
-Delete all accounts and the database folder.
-
-#### Returns
-
-`Promise`<`void`\>
 
 ___
 

--- a/src/account_manager/mod.rs
+++ b/src/account_manager/mod.rs
@@ -246,12 +246,4 @@ impl AccountManager {
         self.event_emitter.lock().await.emit(0, event);
         Ok(())
     }
-
-    /// Deletes the accounts and database folder.
-    #[cfg(feature = "storage")]
-    pub async fn delete_accounts_and_database(&self) -> crate::Result<()> {
-        self.accounts.write().await.clear();
-        std::fs::remove_dir_all(self.storage_options.storage_path.clone())?;
-        Ok(())
-    }
 }

--- a/src/message_interface/message.rs
+++ b/src/message_interface/message.rs
@@ -107,10 +107,6 @@ pub enum Message {
     /// Removes the latest account (account with the largest account index).
     /// Expected response: [`Ok`](crate::message_interface::Response::Ok)
     RemoveLatestAccount,
-    /// Deletes the storage.
-    /// Expected response: [`Ok`](crate::message_interface::Response::Ok)
-    #[cfg(feature = "storage")]
-    DeleteAccountsAndDatabase,
     /// Generates a new mnemonic.
     /// Expected response: [`GeneratedMnemonic`](crate::message_interface::Response::GeneratedMnemonic)
     GenerateMnemonic,
@@ -214,8 +210,6 @@ impl Debug for Message {
             Message::RemoveLatestAccount => write!(f, "RemoveLatestAccount"),
             #[cfg(feature = "stronghold")]
             Message::RestoreBackup { source, password: _ } => write!(f, "RestoreBackup{{ source: {:?} }}", source),
-            #[cfg(feature = "storage")]
-            Message::DeleteAccountsAndDatabase => write!(f, "DeleteAccountsAndDatabase"),
             Message::GenerateMnemonic => write!(f, "GenerateMnemonic"),
             Message::VerifyMnemonic(_) => write!(f, "VerifyMnemonic(<omitted>)"),
             Message::SetClientOptions(options) => write!(f, "SetClientOptions({:?})", options),
@@ -264,9 +258,6 @@ impl Serialize for Message {
             Message::RestoreBackup { .. } => serializer.serialize_unit_variant("Message", 7, "RestoreBackup"),
             Message::GenerateMnemonic => serializer.serialize_unit_variant("Message", 8, "GenerateMnemonic"),
             Message::VerifyMnemonic(_) => serializer.serialize_unit_variant("Message", 9, "VerifyMnemonic"),
-            Message::DeleteAccountsAndDatabase => {
-                serializer.serialize_unit_variant("Message", 10, "DeleteAccountsAndDatabase")
-            }
             Message::SetClientOptions(_) => serializer.serialize_unit_variant("Message", 11, "SetClientOptions"),
             Message::GetNodeInfo { .. } => serializer.serialize_unit_variant("Message", 12, "GetNodeInfo"),
             #[cfg(feature = "stronghold")]

--- a/src/message_interface/message_handler.rs
+++ b/src/message_interface/message_handler.rs
@@ -194,14 +194,6 @@ impl WalletMessageHandler {
             Message::RestoreBackup { source, password } => {
                 convert_async_panics(|| async { self.restore_backup(source.to_path_buf(), password).await }).await
             }
-            #[cfg(feature = "storage")]
-            Message::DeleteAccountsAndDatabase => {
-                convert_async_panics(|| async {
-                    self.account_manager.delete_accounts_and_database().await?;
-                    Ok(Response::Ok(()))
-                })
-                .await
-            }
             Message::GenerateMnemonic => convert_panics(|| {
                 self.account_manager
                     .generate_mnemonic()

--- a/src/message_interface/response.rs
+++ b/src/message_interface/response.rs
@@ -130,7 +130,6 @@ pub enum Response {
     /// [`Backup`](crate::message_interface::Message::Backup),
     /// [`ClearStrongholdPassword`](crate::message_interface::Message::ClearStrongholdPassword),
     /// [`RestoreBackup`](crate::message_interface::Message::RestoreBackup),
-    /// [`DeleteAccountsAndDatabase`](crate::message_interface::Message::DeleteAccountsAndDatabase),
     /// [`VerifyMnemonic`](crate::message_interface::Message::VerifyMnemonic),
     /// [`SetClientOptions`](crate::message_interface::Message::SetClientOptions),
     /// [`SetStrongholdPassword`](crate::message_interface::Message::SetStrongholdPassword),


### PR DESCRIPTION
# Description of change

Remove broken delete_accounts_and_database(), didn't work on Windows because of the db lock

## Links to any relevant issues

Fixes #1436 

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
