### PR TITLE
Use `Uint8Array` over `number[]`

### DIFF
--- a/.changes/uint8array-replace-number-array.md.md
+++ b/.changes/uint8array-replace-number-array.md.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": patch
+---
+
+Use `Uint8Array` over `number[]` in `IAliasOutputBuilderOptions` and other places to better reflect the type requirements.

--- a/bindings/nodejs/types/buildOutputData.ts
+++ b/bindings/nodejs/types/buildOutputData.ts
@@ -9,7 +9,7 @@ import type {
 export interface BuildAliasOutputData extends BuildBasicOutputData {
     aliasId: string;
     stateIndex?: number;
-    stateMetadata?: number[];
+    stateMetadata?: Uint8Array;
     foundryCounter?: number;
     immutableFeatures?: FeatureTypes[];
 }

--- a/bindings/nodejs/types/output.ts
+++ b/bindings/nodejs/types/output.ts
@@ -36,5 +36,5 @@ export interface OutputData {
 /** A Segment of the BIP32 path*/
 export interface Segment {
     hardened: boolean;
-    bs: number[];
+    bs: Uint8Array;
 }


### PR DESCRIPTION
# Description of change

Use `Uint8Array` over `number[]` in `IAliasOutputBuilderOptions` and other places to better reflect the type requirements.

## Links to any relevant issues

Fixes #1439 

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
