### PR TITLE
fix: explicit installation of typescript as a dependency

### DIFF
--- a/.github/workflows/covector-version-or-publish.yml
+++ b/.github/workflows/covector-version-or-publish.yml
@@ -125,7 +125,7 @@ jobs:
             ${{ matrix.os }}-stable-cargo-index-
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install typescript && npm ci
         working-directory: bindings/nodejs
       
       - name: Build Node.js prebuild


### PR DESCRIPTION
# Description of change

Currently, the runner for macOS fails (https://github.com/iotaledger/wallet.rs/actions/runs/3426765986/jobs/5708964431) , since it cannot find the TS compiler. To fix this we explicitly install typescript on all systems before running the `npm ci` command.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
