### PR TITLE
fix: support macOS 10.12+ in Node.js prebuilt binaries

### DIFF
--- a/.changes/macos-deployment-target.md
+++ b/.changes/macos-deployment-target.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": patch
+---
+
+Support macOS 10.12+

--- a/.github/workflows/covector-version-or-publish.yml
+++ b/.github/workflows/covector-version-or-publish.yml
@@ -89,6 +89,10 @@ jobs:
         run: echo "LIBCLANG_PATH=$((gcm clang).source -replace "clang.exe")" >> $env:GITHUB_ENV
         if: matrix.os == 'windows-2019'
 
+      - name: Set deployment target (macOS)
+        run: echo "MACOSX_DEPLOYMENT_TARGET=10.12" >> $GITHUB_ENV
+        if: matrix.os == 'macos-11'
+
       - name: Get current date
         run: echo "CURRENT_DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
         if: matrix.os == 'macos-11' || ${{ startsWith(matrix.os, 'ubuntu') }}


### PR DESCRIPTION
# Description of change

Set macOS minimum deployment target to 10.12 (High Sierra). Previously, versions before 10.15 were not supported.

See https://github.com/iotaledger/firefly/pull/1012

## Links to any relevant issues

https://github.com/iotaledger/firefly/issues/4766

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

See test notes in https://github.com/iotaledger/firefly/pull/1012

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
