### PR TITLE
fix: statically link Windows CRT in Node.js prebuilt binaries

### DIFF
--- a/.changes/static-link-win-crt.md
+++ b/.changes/static-link-win-crt.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": patch
+---
+
+Statically link the Windows C Runtime when building prebuilt binaries.

--- a/bindings/nodejs/.cargo/config.toml
+++ b/bindings/nodejs/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]


### PR DESCRIPTION
# Description of change

Statically link Windows C Runtime in Node.js prebuilt binaries so that users don't need to install it themselves. This was previously added but seems to have been removed at some point.

See [Rust docs](https://doc.rust-lang.org/reference/linkage.html#static-and-dynamic-c-runtimes)

## Links to any relevant issues

Reports in Discord about white screens when using Firefly on Windows

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested



## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
