### PR TITLE
Fix min storage deposit in `prepare_output()`

### DIFF
--- a/.changes/fixPrepareOutput.md
+++ b/.changes/fixPrepareOutput.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": patch
+---
+
+Fix min storage deposit amount in prepareOutput().

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Error::IotaClientError` as it was a duplicate;
 
+### Fixed
+
+- min storage deposit amount in `prepare_output()` with expiration unlock condition;
+
 ## 1.0.0-rc.2 - 2022-10-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- min storage deposit amount in `prepare_output()` with expiration unlock condition;
+- Min storage deposit amount in `prepare_output()` with expiration unlock condition;
 
 ## 1.0.0-rc.2 - 2022-10-28
 

--- a/src/account/operations/transaction/prepare_output.rs
+++ b/src/account/operations/transaction/prepare_output.rs
@@ -99,7 +99,6 @@ impl AccountHandle {
 
         let mut second_output_builder = BasicOutputBuilder::from(&first_output);
 
-        let mut min_storage_deposit_return_amount = 0;
         // Update the amount
         match options.amount.cmp(&first_output.amount()) {
             Ordering::Greater | Ordering::Equal => {
@@ -114,7 +113,7 @@ impl AccountHandle {
                     let remainder_address = self.get_remainder_address(transaction_options).await?;
 
                     // Calculate the minimum storage deposit to be returned
-                    min_storage_deposit_return_amount =
+                    let min_storage_deposit_return_amount =
                         BasicOutputBuilder::new_with_minimum_storage_deposit(rent_structure.clone())?
                             .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(
                                 Address::try_from_bech32(options.recipient_address.clone())?.1,
@@ -168,13 +167,7 @@ impl AccountHandle {
         if second_output.amount() < required_storage_deposit {
             third_output_builder = third_output_builder.with_amount(required_storage_deposit)?;
             // add newly added amount also to the storage deposit return unlock condition, if that was added
-            let mut new_sdr_amount = required_storage_deposit - options.amount;
-            // If the new sdr amount is lower than it needs to be, set it to the minimum
-            if new_sdr_amount < min_storage_deposit_return_amount {
-                new_sdr_amount = min_storage_deposit_return_amount;
-                third_output_builder =
-                    third_output_builder.with_amount(min_storage_deposit_return_amount + options.amount)?;
-            }
+            let new_sdr_amount = required_storage_deposit - options.amount;
             if let Some(sdr) = second_output.unlock_conditions().storage_deposit_return() {
                 // create a new sdr unlock_condition with the updated amount and replace it
                 let new_sdr_unlock_condition = UnlockCondition::StorageDepositReturn(
@@ -273,7 +266,6 @@ impl AccountHandle {
 
         let mut second_output_builder = NftOutputBuilder::from(&first_output);
 
-        let mut min_storage_deposit_return_amount = 0;
         // Update the amount
         match options.amount.cmp(&first_output.amount()) {
             Ordering::Greater | Ordering::Equal => {
@@ -288,7 +280,7 @@ impl AccountHandle {
                     let remainder_address = self.get_remainder_address(transaction_options).await?;
 
                     // Calculate the amount to be returned
-                    min_storage_deposit_return_amount =
+                    let min_storage_deposit_return_amount =
                         BasicOutputBuilder::new_with_minimum_storage_deposit(rent_structure.clone())?
                             .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(
                                 Address::try_from_bech32(options.recipient_address.clone())?.1,
@@ -340,13 +332,8 @@ impl AccountHandle {
         // We might have added more unlock conditions, so we check the minimum storage deposit again and update the
         // amounts if needed
         if second_output.amount() < required_storage_deposit {
-            let mut new_sdr_amount = required_storage_deposit - options.amount;
-            // If the new sdr amount is lower than it needs to be, set it to the minimum
-            if new_sdr_amount < min_storage_deposit_return_amount {
-                new_sdr_amount = min_storage_deposit_return_amount;
-                third_output_builder =
-                    third_output_builder.with_amount(min_storage_deposit_return_amount + options.amount)?;
-            }
+            third_output_builder = third_output_builder.with_amount(required_storage_deposit)?;
+            let new_sdr_amount = required_storage_deposit - options.amount;
             if let Some(sdr) = second_output.unlock_conditions().storage_deposit_return() {
                 // create a new sdr unlock_condition with the updated amount and replace it
                 let new_sdr_unlock_condition = UnlockCondition::StorageDepositReturn(


### PR DESCRIPTION
# Description of change

Fix min storage deposit amount in `prepare_output()` with expiration unlock condition

## Links to any relevant issues

https://github.com/iotaledger/wallet.rs/issues/1540

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

```Rust
    let output = account
        .prepare_output(
            OutputOptions {
                recipient_address: "rms1qpszqzadsym6wpppd6z037dvlejmjuke7s24hm95s9fg9vpua7vluaw60xu".to_string(),
                amount: 500,
                assets: None,
                features: Some(Features {
                    metadata: None,
                    tag: None,
                    issuer: None,
                    sender: None,
                }),
                unlocks: Some(Unlocks {
                    expiration_unix_time: None,
                    timelock_unix_time: None,
                }),
                // unlocks: None,
                storage_deposit: None,
            },
            None,
        )
        .await?;

    println!("{:?}", output);
    use iota_client::block::output::Rent;
    let rent_structure = account.client().get_rent_structure().await?;
    println!("{:?}", output.rent_cost(&rent_structure));
```

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
