### PR TITLE
fix: set minimum macOS version to 10.12

### DIFF
--- a/.github/workflows/covector-version-or-publish.yml
+++ b/.github/workflows/covector-version-or-publish.yml
@@ -89,6 +89,10 @@ jobs:
         run: echo "LIBCLANG_PATH=$((gcm clang).source -replace "clang.exe")" >> $env:GITHUB_ENV
         if: matrix.os == 'windows-2019'
 
+      - name: Set deployment target (macOS)
+        run: echo "MACOSX_DEPLOYMENT_TARGET=10.12" >> $GITHUB_ENV
+        if: matrix.os == 'macos-11'
+
       - name: Get current date
         run: echo "CURRENT_DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
         if: matrix.os == 'macos-11' || ${{ startsWith(matrix.os, 'ubuntu') }}


### PR DESCRIPTION
# Description of change

Currently, macOS users with a version lower than 10.15 experience a white screen when starting Firefly. We need to specify the minimum version of macOS on which the target binaries are to be deployed. Otherwise the compiler will build it for the version on which it is compiled for (and later). This is done through the MACOSX_DEPLOYMENT_TARGET environment variable.

## Links to any relevant issues

Fixed on Firefly v1 here: https://github.com/iotaledger/firefly/pull/1012

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
