### PR TITLE
fix: statically link c runtime when building windows binaries

### DIFF
--- a/bindings/nodejs/.cargo/config.toml
+++ b/bindings/nodejs/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]


### PR DESCRIPTION
# Description of change

We have an issue where windows users that don't have the latest VC C++ Redistributables installed cannot run the native binaries. This PR introduces static linking of the C runtime through correctly setting the cargo flags for the GH runners.

## Links to any relevant issues

Fixed for FF v1 here: https://github.com/iotaledger/firefly/pull/812

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
