### PR TITLE
Fix NFT id in `prepare_output()`

### DIFF
--- a/.changes/fixNftPrepareOutput.md
+++ b/.changes/fixNftPrepareOutput.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": patch
+---
+
+Use correct NFT id for existing NFT in prepareOutput().

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Min storage deposit amount in `prepare_output()` with expiration unlock condition;
+- NFT id in `prepare_output()` when the NFT output still has the null id;
 
 ## 1.0.0-rc.2 - 2022-10-28
 

--- a/src/account/operations/transaction/prepare_output.rs
+++ b/src/account/operations/transaction/prepare_output.rs
@@ -203,7 +203,7 @@ impl AccountHandle {
             }
         }) {
             if let Output::Nft(nft_output) = &nft_output_data.output {
-                NftOutputBuilder::from(nft_output)
+                NftOutputBuilder::from(nft_output).with_nft_id(nft_output.nft_id_non_null(&nft_output_data.output_id))
             } else {
                 unreachable!("We checked before if it's an nft output")
             }


### PR DESCRIPTION
# Description of change

Fix NFT id in `prepare_output()` when the NFT output still has the null id

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Sending an nft output with null id with an example

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
