### PR TITLE
fix: Install Python 3.10 to fix issues with node-gyp

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -130,6 +130,14 @@ jobs:
         with:
           node-version: '14.x'
 
+        # Temporary fix for "ValueError: invalid mode: 'rU' while trying to load binding.gyp"
+        # See <PR link>
+        # This can be removed when "prebuild" updates "node-gyp"
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
       - name: Get current date
         run: echo "CURRENT_DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
         if: matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest'

--- a/.github/workflows/covector-version-or-publish.yml
+++ b/.github/workflows/covector-version-or-publish.yml
@@ -72,6 +72,14 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+        # Temporary fix for "ValueError: invalid mode: 'rU' while trying to load binding.gyp"
+        # See <PR link>
+        # This can be removed when "prebuild" updates "node-gyp"
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
# Description of change

This is a workaround for an [error](https://github.com/iotaledger/wallet.rs/actions/runs/3542056055/jobs/5947095985#step:14:70) while building the Node.js bindings. `node-gyp` is a primarily Python-based tool to build native modules for Node.js and [`prebuild` is using an old version of it](https://github.com/prebuild/prebuild/issues/286). The [root issue](https://github.com/nodejs/node-gyp/issues/2219) is that `node-gyp` is trying to open a file with the deprecated `'U'` mode which was [removed in Python 3.11](https://docs.python.org/3/whatsnew/3.11.html#porting-to-python-3-11). At this time, only macOS is failing because it's using Python 3.11, but I think it's only a matter of time before the default Python version on Windows and Linux runners are updated (they're currently using 3.8.10).

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Building prebuilt binaries succeeds locally using Python 3.10.8

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
