### PR TITLE
fix: Build Node.js bindings from source on CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -183,7 +183,7 @@ jobs:
             ${{ matrix.os }}-stable-cargo-build-node-target-
 
       - name: Build nodejs binding
-        run: npm ci
+        run: npm ci --build-from-source
         working-directory: bindings/nodejs
 
   python-bindings:


### PR DESCRIPTION
# Description of change

Forces CI to build the Node.js bindings from source. Currently, there are cases where it may use the prebuilt binaries instead.

## Links to any relevant issues

Fixes #1614 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
