### PR TITLE
Increase max allowed time difference 

### DIFF
--- a/.changes/max-time-difference.md
+++ b/.changes/max-time-difference.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": patch
+---
+
+Increase max allowed time difference between local clock and latest milestone to 30 minutes.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ backtrace = { version = "0.3.66", default-features = false, features = [ "std" ]
 futures = { version = "0.3.25", default-features = false }
 getset = { version = "0.1.2", default-features = false }
 # iota-client = { version = "2.0.1-rc.4", default-features = false, features = [ "message_interface", "tls" ] }
-iota-client = { git = "https://github.com/iotaledger/iota.rs", rev = "7a147ac8ffaeb8dba24ea3cf579c7b7f7783a192", default-features = false, features = [ "message_interface", "tls" ] }
+iota-client = { git = "https://github.com/iotaledger/iota.rs", rev = "55d2d66f96838a950e4b45dd6a15ab99a5d27db8", default-features = false, features = [ "message_interface", "tls" ] }
 iota-crypto = { version = "0.15.3", default-features = false, features = [ "std", "chacha", "blake2b", "ed25519", "random", "slip10", "bip39", "bip39-en" ] }
 log = { version = "0.4.17", default-features = false }
 packable = { version = "0.7.0", default-features = false, features = [ "serde", "primitive-types" ] }

--- a/bindings/nodejs/Cargo.lock
+++ b/bindings/nodejs/Cargo.lock
@@ -1051,7 +1051,7 @@ dependencies = [
 [[package]]
 name = "iota-client"
 version = "2.0.1-rc.4"
-source = "git+https://github.com/iotaledger/iota.rs?rev=7a147ac8ffaeb8dba24ea3cf579c7b7f7783a192#7a147ac8ffaeb8dba24ea3cf579c7b7f7783a192"
+source = "git+https://github.com/iotaledger/iota.rs?rev=55d2d66f96838a950e4b45dd6a15ab99a5d27db8#55d2d66f96838a950e4b45dd6a15ab99a5d27db8"
 dependencies = [
  "async-trait",
  "backtrace",
@@ -1131,7 +1131,7 @@ dependencies = [
 [[package]]
 name = "iota-pow"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/iotaledger/iota.rs?rev=7a147ac8ffaeb8dba24ea3cf579c7b7f7783a192#7a147ac8ffaeb8dba24ea3cf579c7b7f7783a192"
+source = "git+https://github.com/iotaledger/iota.rs?rev=55d2d66f96838a950e4b45dd6a15ab99a5d27db8#55d2d66f96838a950e4b45dd6a15ab99a5d27db8"
 dependencies = [
  "iota-crypto",
  "thiserror",
@@ -1140,7 +1140,7 @@ dependencies = [
 [[package]]
 name = "iota-types"
 version = "1.0.0-rc.3"
-source = "git+https://github.com/iotaledger/iota.rs?rev=7a147ac8ffaeb8dba24ea3cf579c7b7f7783a192#7a147ac8ffaeb8dba24ea3cf579c7b7f7783a192"
+source = "git+https://github.com/iotaledger/iota.rs?rev=55d2d66f96838a950e4b45dd6a15ab99a5d27db8#55d2d66f96838a950e4b45dd6a15ab99a5d27db8"
 dependencies = [
  "bech32 0.9.1",
  "bitflags",


### PR DESCRIPTION
# Description of change

Increase max allowed time difference between local clock and latest milestone to 30 minutes

## Type of change

- Temporary workaround until https://github.com/iotaledger/iota.rs/issues/1385 is fixed

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
