### PR TITLE
Add output_types to FilterOptions

### DIFF
--- a/.changes/outputTypesFilter.md
+++ b/.changes/outputTypesFilter.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": patch
+---
+
+Add `outputTypes` to `FilterOptions` and make `lowerBoundBookedTimestamp` and `lowerBoundBookedTimestamp` optional.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Account::retry_transaction_until_included()`;
 - `RetryTransactionUntilIncluded` to message interface account methods;
 - `AccountMethod::RequestFundsFromFaucet` to message interface;
+- `FilterOptions::output_types` field;
 
 ### Changed
 
@@ -42,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `clear_listeners` from message interface;
 - `listen` from message interface;
 - default bech32 HRP in account builder;
+- `copy` from `FilterOptions`;
 
 ## 1.0.0-rc.3 - 2022-11-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `clear_listeners` from message interface;
 - `listen` from message interface;
 - default bech32 HRP in account builder;
-- `copy` from `FilterOptions`;
+- `Copy` from `FilterOptions`;
 
 ## 1.0.0-rc.3 - 2022-11-24
 

--- a/bindings/java/CHANGELOG.md
+++ b/bindings/java/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+## 1.0.0-rc.2 - 202x-xx-xx
+
+### Added
+
+- `FilterOptions::outputTypes`;
+
 ## 1.0.0-rc.1 - 2022-12-06
 
 ### Added

--- a/bindings/java/lib/src/main/java/org/iota/types/FilterOptions.java
+++ b/bindings/java/lib/src/main/java/org/iota/types/FilterOptions.java
@@ -8,6 +8,8 @@ public class FilterOptions extends AbstractObject {
     private Integer lowerBoundBookedTimestamp;
     /// Filter all outputs where the booked milestone index is above the specified timestamp
     private Integer upperBoundBookedTimestamp;
+    /// Filter all outputs for the provided types (Basic = 3, Alias = 4, Foundry = 5, NFT = 6)
+    private Integer[] outputTypes;
 
     public FilterOptions withLowerBoundBookedTimestamp(Integer lowerBoundBookedTimestamp) {
         this.lowerBoundBookedTimestamp = lowerBoundBookedTimestamp;
@@ -19,11 +21,20 @@ public class FilterOptions extends AbstractObject {
         return this;
     }
 
+    public FilterOptions withOutputTypes(Integer[] outputTypes) {
+        this.outputTypes = outputTypes;
+        return this;
+    }
+
     public Integer getLowerBoundBookedTimestamp() {
         return lowerBoundBookedTimestamp;
     }
 
     public Integer getUpperBoundBookedTimestamp() {
         return upperBoundBookedTimestamp;
+    }
+
+    public Integer[] getOutputTypes() {
+        return outputTypes;
     }
 }

--- a/bindings/nodejs/types/account.ts
+++ b/bindings/nodejs/types/account.ts
@@ -138,7 +138,9 @@ export interface CreateAccountPayload {
 /** Options to filter outputs */
 export interface FilterOptions {
     /** Filter all outputs where the booked milestone index is below the specified timestamp */
-    lowerBoundBookedTimestamp: number;
+    lowerBoundBookedTimestamp?: number;
     /** Filter all outputs where the booked milestone index is above the specified timestamp */
-    upperBoundBookedTimestamp: number;
+    upperBoundBookedTimestamp?: number;
+    /** Filter all outputs for the provided types (Basic = 3, Alias = 4, Foundry = 5, NFT = 6) */
+    outputTypes?: Uint8Array;
 }

--- a/documentation/docs/references/nodejs/api_ref.md
+++ b/documentation/docs/references/nodejs/api_ref.md
@@ -7,10 +7,6 @@
 - [Account](classes/Account.md)
 - [AccountManager](classes/AccountManager.md)
 
-### Functions
-
-- [initLogger](api_ref.md#initlogger)
-
 ### Type Aliases
 
 - [AccountId](api_ref.md#accountid)
@@ -26,11 +22,12 @@
 ### Interfaces
 
 - [AccountBalance](interfaces/AccountBalance.md)
+- [BaseCoinBalance](interfaces/BaseCoinBalance.md)
+- [RequiredStorageDeposit](interfaces/RequiredStorageDeposit.md)
+- [NativeTokenBalance](interfaces/NativeTokenBalance.md)
 - [AccountSyncOptions](interfaces/AccountSyncOptions.md)
 - [AccountMeta](interfaces/AccountMeta.md)
 - [AccountMetadata](interfaces/AccountMetadata.md)
-- [BaseCoinBalance](interfaces/BaseCoinBalance.md)
-- [NativeTokenBalance](interfaces/NativeTokenBalance.md)
 - [CreateAccountPayload](interfaces/CreateAccountPayload.md)
 - [FilterOptions](interfaces/FilterOptions.md)
 - [AccountManagerOptions](interfaces/AccountManagerOptions.md)
@@ -85,24 +82,6 @@
 - [ReturnStrategy](enums/ReturnStrategy.md)
 - [LedgerDeviceType](enums/LedgerDeviceType.md)
 - [InclusionState](enums/InclusionState.md)
-
-## Functions
-
-### initLogger
-
-▸ **initLogger**(`config`): `any`
-
-Function to create wallet logs
-
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `config` | [`LoggerConfig`](interfaces/LoggerConfig.md) |
-
-#### Returns
-
-`any`
 
 ## Type Aliases
 

--- a/documentation/docs/references/nodejs/classes/Account.md
+++ b/documentation/docs/references/nodejs/classes/Account.md
@@ -689,7 +689,7 @@ Prepare an output for sending, useful for offline signing.
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `options` | [`OutputOptions`](../interfaces/OutputOptions.md) | The options for preparing an output. If the amount is below the minimum required storage deposit, by default the remaining amount will automatically be added with a `StorageDepositReturn` `UnlockCondition`, when setting the `ReturnStrategy` to `gift`, the full minimum required storage deposit will be sent  to the recipient. When the assets contain an nft id, the data from the existing `NftOutput` will be used, just with the address unlock conditions replaced. |
+| `options` | [`OutputOptions`](../interfaces/OutputOptions.md) | The options for preparing an output. If the amount is below the minimum required storage deposit, by default the remaining amount will automatically be added with a `StorageDepositReturn` `UnlockCondition`, when setting the `ReturnStrategy` to `gift`, the full minimum required storage deposit will be sent to the recipient. When the assets contain an nft id, the data from the existing `NftOutput` will be used, just with the address unlock conditions replaced. |
 | `transactionOptions?` | [`TransactionOptions`](../interfaces/TransactionOptions.md) | The options to define a `RemainderValueStrategy` or custom inputs. |
 
 #### Returns

--- a/documentation/docs/references/nodejs/interfaces/AccountBalance.md
+++ b/documentation/docs/references/nodejs/interfaces/AccountBalance.md
@@ -26,7 +26,7 @@ ___
 
 ### requiredStorageDeposit
 
-• **requiredStorageDeposit**: `string`
+• **requiredStorageDeposit**: [`RequiredStorageDeposit`](RequiredStorageDeposit.md)
 
 The required storage deposit for the outputs
 

--- a/documentation/docs/references/nodejs/interfaces/FilterOptions.md
+++ b/documentation/docs/references/nodejs/interfaces/FilterOptions.md
@@ -8,12 +8,13 @@ Options to filter outputs
 
 - [lowerBoundBookedTimestamp](FilterOptions.md#lowerboundbookedtimestamp)
 - [upperBoundBookedTimestamp](FilterOptions.md#upperboundbookedtimestamp)
+- [outputTypes](FilterOptions.md#outputtypes)
 
 ## Properties
 
 ### lowerBoundBookedTimestamp
 
-• **lowerBoundBookedTimestamp**: `number`
+• `Optional` **lowerBoundBookedTimestamp**: `number`
 
 Filter all outputs where the booked milestone index is below the specified timestamp
 
@@ -21,6 +22,14 @@ ___
 
 ### upperBoundBookedTimestamp
 
-• **upperBoundBookedTimestamp**: `number`
+• `Optional` **upperBoundBookedTimestamp**: `number`
 
 Filter all outputs where the booked milestone index is above the specified timestamp
+
+___
+
+### outputTypes
+
+• `Optional` **outputTypes**: `Uint8Array`
+
+Filter all outputs for the provided types (Basic = 3, Alias = 4, Foundry = 5, NFT = 6)

--- a/documentation/docs/references/nodejs/interfaces/RequiredStorageDeposit.md
+++ b/documentation/docs/references/nodejs/interfaces/RequiredStorageDeposit.md
@@ -1,0 +1,3 @@
+# Interface: RequiredStorageDeposit
+
+The required storage deposit per output type

--- a/src/account/handle.rs
+++ b/src/account/handle.rs
@@ -31,7 +31,7 @@ use crate::{
 };
 
 /// Options to filter outputs
-#[derive(Debug, Copy, Clone, Serialize, Deserialize, Eq, PartialEq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, Hash)]
 pub struct FilterOptions {
     /// Filter all outputs where the booked milestone index is below the specified timestamp
     #[serde(rename = "lowerBoundBookedTimestamp")]
@@ -39,6 +39,9 @@ pub struct FilterOptions {
     /// Filter all outputs where the booked milestone index is above the specified timestamp
     #[serde(rename = "upperBoundBookedTimestamp")]
     pub upper_bound_booked_timestamp: Option<u32>,
+    /// Filter all outputs for the provided types (Basic = 3, Alias = 4, Foundry = 5, NFT = 6).
+    #[serde(rename = "outputTypes")]
+    pub output_types: Option<Vec<u8>>,
 }
 
 /// A thread guard over an account, so we can lock the account during operations.
@@ -158,7 +161,7 @@ impl AccountHandle {
         let account = self.read().await;
         let mut outputs = Vec::new();
         for output in account.outputs.values() {
-            if let Some(filter_options) = filter {
+            if let Some(filter_options) = &filter {
                 if let Some(lower_bound_booked_timestamp) = filter_options.lower_bound_booked_timestamp {
                     if output.metadata.milestone_timestamp_booked < lower_bound_booked_timestamp {
                         continue;
@@ -166,6 +169,11 @@ impl AccountHandle {
                 }
                 if let Some(upper_bound_booked_timestamp) = filter_options.upper_bound_booked_timestamp {
                     if output.metadata.milestone_timestamp_booked > upper_bound_booked_timestamp {
+                        continue;
+                    }
+                }
+                if let Some(output_types) = &filter_options.output_types {
+                    if !output_types.contains(&output.output.kind()) {
                         continue;
                     }
                 }
@@ -180,7 +188,7 @@ impl AccountHandle {
         let account = self.read().await;
         let mut outputs = Vec::new();
         for output in account.unspent_outputs.values() {
-            if let Some(filter_options) = filter {
+            if let Some(filter_options) = &filter {
                 if let Some(lower_bound_booked_timestamp) = filter_options.lower_bound_booked_timestamp {
                     if output.metadata.milestone_timestamp_booked < lower_bound_booked_timestamp {
                         continue;
@@ -188,6 +196,11 @@ impl AccountHandle {
                 }
                 if let Some(upper_bound_booked_timestamp) = filter_options.upper_bound_booked_timestamp {
                     if output.metadata.milestone_timestamp_booked > upper_bound_booked_timestamp {
+                        continue;
+                    }
+                }
+                if let Some(output_types) = &filter_options.output_types {
+                    if !output_types.contains(&output.output.kind()) {
                         continue;
                     }
                 }


### PR DESCRIPTION
# Description of change

Add output_types to FilterOptions

## Links to any relevant issues

Fixes https://github.com/iotaledger/wallet.rs/issues/1575

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Manually with a nodejs modified example
```JS
        const basicOutputs = await account.outputs({outputTypes: [3]})
        console.log('basicOutputs:', basicOutputs.length); 
        const basicAndAliasOutputs = await account.outputs({outputTypes: [3, 4]})
        console.log('basicAndAliasOutputs:', basicAndAliasOutputs.length); 
        const allOutputsFilter = await account.outputs({outputTypes: [3, 4, 5, 6]})
        console.log('allOutputsFilter:', allOutputsFilter.length); 
        const allOutputs = await account.outputs()
        console.log('allOutputs:', allOutputs.length); 
```
->
```
basicOutputs: 3
basicAndAliasOutputs: 6
allOutputsFilter: 8
allOutputs: 8
```

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
