### PR TITLE
Update prepublish commands to dasel v2

### DIFF
--- a/.changes/config.json
+++ b/.changes/config.json
@@ -13,28 +13,16 @@
       "getPublishedVersion": "npm view ${ pkgFile.pkg.name } version",
       "prepublish": [
         {
-          "command": "false || dasel put object -f Cargo.toml '.dependencies.iota-wallet' -t string -t string git='https://github.com/iotaledger/wallet.rs' rev=$GITHUB_SHA"
+          "command": "false || dasel put -f Cargo.toml '.dependencies.iota-wallet.rev' -v $GITHUB_SHA"
         },
         {
-          "command": "dasel put string -f Cargo.toml '.dependencies.iota-wallet.features.[0]' mnemonic"
+          "command": "dasel put -f Cargo.toml '.dependencies.iota-wallet.git' -v https://github.com/iotaledger/wallet.rs"
         },
         {
-          "command": "dasel put string -f Cargo.toml '.dependencies.iota-wallet.features.[1]' events"
+          "command": "dasel delete -f Cargo.toml '.dependencies.iota-wallet.path'"
         },
         {
-          "command": "dasel put string -f Cargo.toml '.dependencies.iota-wallet.features.[2]' ledger_nano"
-        },
-        {
-          "command": "dasel put string -f Cargo.toml '.dependencies.iota-wallet.features.[3]' storage"
-        },
-        {
-          "command": "dasel put string -f Cargo.toml '.dependencies.iota-wallet.features.[4]' stronghold"
-        },
-        {
-          "command": "dasel put string -f Cargo.toml '.dependencies.iota-wallet.features.[5]' message_interface"
-        },
-        {
-          "command": "dasel put string -f Cargo.toml '.dependencies.iota-wallet.features.[6]' participation"
+          "command": "dasel delete -f Cargo.toml '.dependencies.iota-wallet.default-features'"
         },
         {
           "command": "yarn --ignore-scripts"

--- a/.github/workflows/covector-version-or-publish.yml
+++ b/.github/workflows/covector-version-or-publish.yml
@@ -29,7 +29,7 @@ jobs:
       
       - name: Install Dasel
         run: |
-          curl -sSLf "$(curl -sSLf https://api.github.com/repos/tomwright/dasel/releases/80229218 | grep browser_download_url | grep linux_amd64 | grep -v .gz | cut -d\" -f 4)" -L -o dasel && chmod +x dasel
+          curl -sSLf "$(curl -sSLf https://api.github.com/repos/tomwright/dasel/releases/latest | grep browser_download_url | grep linux_amd64 | grep -v .gz | cut -d\" -f 4)" -L -o dasel && chmod +x dasel
           mv ./dasel /usr/local/bin/dasel
 
       - name: covector version or publish (publish when no change files present)


### PR DESCRIPTION
# Description of change
Breaking changes in `dasel` (used to manipulate the `Cargo.toml` for the Node.js bindings so they can be built from source)  caused the publish process to fail, so it had to be reverted to a previous version (#1651). This PR updates the `dasel` commands so they work with v2 (they are now simpler as well). After the `dasel` commands are run, the `Cargo.toml` looks like this:

```toml
[dependencies.iota-wallet]
    features = ["mnemonic", "events", "ledger_nano", "storage", "stronghold", "message_interface", "participation"]
    git = "https://github.com/iotaledger/wallet.rs"
    rev = "some-git-rev"
```

This matches what is [currently published](https://www.runpkg.com/?@iota/wallet@2.0.3-rc.9/Cargo.toml#8)

## Links to any relevant issues

iotaledger/iota-sdk#96 

## Type of change

- Chore

## How the change has been tested

Tested commands locally:

```bash
cd bindings/nodejs
export GITHUB_SHA=some-git-rev
dasel put -f Cargo.toml '.dependencies.iota-wallet.rev' -v $GITHUB_SHA
dasel put -f Cargo.toml '.dependencies.iota-wallet.git' -v https://github.com/iotaledger/wallet.rs
dasel delete -f Cargo.toml '.dependencies.iota-wallet.path'
dasel delete -f Cargo.toml '.dependencies.iota-wallet.default-features'
```

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have checked that new and existing unit tests pass locally with my changes
