### PR TITLE
fix: correctly type participationOverview

### DIFF
--- a/bindings/nodejs/types/participation.ts
+++ b/bindings/nodejs/types/participation.ts
@@ -1,7 +1,7 @@
 import type { OutputId } from './output';
 
 export interface ParticipationOverview {
-    participations: [EventId, [OutputId, TrackedParticipationOverview]];
+    participations: {[eventId: EventId]: { [outputId: OutputId]: TrackedParticipationOverview }};
 }
 
 export interface TrackedParticipationOverview {


### PR DESCRIPTION
# Description of change

Instead of a dictionary type, we had a tuple defined for the typescript type of ParticipationOverview.

I don't think a .change file is required here, since this fits under the `export participation types` change.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
