### PR TITLE
Implemented getters for RequiredStorageDeposit struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+## 1.0.0-rc.5 - 2022-XX-XX
+
+### Added
+
+- `RequiredStorageDeposit::{alias(), basic(), foundry(), nft()}` getters;
+
 ## 1.0.0-rc.4 - 2022-12-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 1.0.0-rc.5 - YYYY-MM-DD
 
+### Added
+
+- `RequiredStorageDeposit::{alias(), basic(), foundry(), nft()}` getters;
+
 ### Changed
 
 - Updated dependencies;
-- `RequiredStorageDeposit::{alias(), basic(), foundry(), nft()}` getters;
 
 ## 1.0.0-rc.4 - 2022-12-23
 

--- a/src/account/operations/syncing/mod.rs
+++ b/src/account/operations/syncing/mod.rs
@@ -43,7 +43,7 @@ impl AccountHandle {
             .as_millis();
         let mut last_synced = self.last_synced.lock().await;
         log::debug!("[SYNC] last time synced before {}ms", time_now - *last_synced);
-        if !options.force_syncing && time_now - *last_synced < MIN_SYNC_INTERVAL   {
+        if !options.force_syncing && time_now - *last_synced < MIN_SYNC_INTERVAL {
             log::debug!(
                 "[SYNC] synced within the latest {} ms, only calculating balance",
                 MIN_SYNC_INTERVAL

--- a/src/account/operations/syncing/mod.rs
+++ b/src/account/operations/syncing/mod.rs
@@ -43,7 +43,7 @@ impl AccountHandle {
             .as_millis();
         let mut last_synced = self.last_synced.lock().await;
         log::debug!("[SYNC] last time synced before {}ms", time_now - *last_synced);
-        if time_now - *last_synced < MIN_SYNC_INTERVAL && !options.force_syncing {
+        if !options.force_syncing && time_now - *last_synced < MIN_SYNC_INTERVAL   {
             log::debug!(
                 "[SYNC] synced within the latest {} ms, only calculating balance",
                 MIN_SYNC_INTERVAL

--- a/src/account/types/balance.rs
+++ b/src/account/types/balance.rs
@@ -119,15 +119,19 @@ impl RequiredStorageDeposit {
     pub fn new() -> RequiredStorageDeposit {
         RequiredStorageDeposit::default()
     }
+
     pub fn alias(&self) -> u64 {
         self.alias
     }
+
     pub fn basic(&self) -> u64 {
         self.basic
     }
+
     pub fn foundry(&self) -> u64 {
         self.foundry
     }
+
     pub fn nft(&self) -> u64 {
         self.nft
     }

--- a/src/account/types/balance.rs
+++ b/src/account/types/balance.rs
@@ -119,6 +119,18 @@ impl RequiredStorageDeposit {
     pub fn new() -> RequiredStorageDeposit {
         RequiredStorageDeposit::default()
     }
+    pub fn alias(&self) -> u64 {
+        self.alias
+    }
+    pub fn basic(&self) -> u64 {
+        self.basic
+    }
+    pub fn foundry(&self) -> u64 {
+        self.foundry
+    }
+    pub fn nft(&self) -> u64 {
+        self.nft
+    }
 }
 
 impl std::ops::AddAssign for RequiredStorageDeposit {


### PR DESCRIPTION
Implementing getters for the RequiredStorageDeposit struct or else you couldn't access them.

See issue https://github.com/iotaledger/wallet.rs/issues/#1703

fixes issue #1703

`required_storage_deposit: account_balance.required_storage_deposit.basic(),`

is possible again, with basic(),alias(),foundry() and nft()

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Compiled and runned it myself in my own written software.


## Change checklist

- [X] I have followed the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
