### PR TITLE
Limit max parallel request in request_incoming_transaction_data()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Message interface methods to accept `TransactionOptionsDto` instead of `TransactionOptions`;
 - `send_message` to return Option which is None when no message response is received;
 - Moved `init_logger` to message interface mod;
+- Limit max parallel requests for incoming transactions;
 
 ### Removed
 

--- a/src/account/operations/syncing/outputs.rs
+++ b/src/account/operations/syncing/outputs.rs
@@ -122,40 +122,44 @@ impl AccountHandle {
         let transactions = self.read().await.transactions.clone();
         let incoming_transactions = self.read().await.incoming_transactions.clone();
 
-        let mut tasks = Vec::new();
+        // Limit parallel requests to 100, to avoid timeouts
+        for transaction_ids_chunk in transaction_ids.chunks(100).map(|x: &[TransactionId]| x.to_vec()) {
+            let mut tasks = Vec::new();
 
-        for transaction_id in transaction_ids {
-            // Don't request known transactions again
-            if transactions.contains_key(&transaction_id) || incoming_transactions.contains_key(&transaction_id) {
-                continue;
+            for transaction_id in transaction_ids_chunk {
+                // Don't request known transactions again
+                if transactions.contains_key(&transaction_id) || incoming_transactions.contains_key(&transaction_id) {
+                    continue;
+                }
+
+                let client = self.client.clone();
+                tasks.push(async move {
+                    tokio::spawn(async move {
+                        match client.get_included_block(&transaction_id).await {
+                            Ok(block) => {
+                                if let Some(Payload::Transaction(transaction_payload)) = block.payload().as_ref() {
+                                    let inputs =
+                                        get_inputs_for_transaction_payload(&client, transaction_payload).await?;
+                                    Ok(Some((transaction_id, (*transaction_payload.clone(), inputs))))
+                                } else {
+                                    Ok(None)
+                                }
+                            }
+                            Err(iota_client::Error::NotFound(_)) => Ok(None),
+                            Err(e) => Err(crate::Error::Client(e.into())),
+                        }
+                    })
+                    .await
+                });
             }
 
-            let client = self.client.clone();
-            tasks.push(async move {
-                tokio::spawn(async move {
-                    match client.get_included_block(&transaction_id).await {
-                        Ok(block) => {
-                            if let Some(Payload::Transaction(transaction_payload)) = block.payload().as_ref() {
-                                let inputs = get_inputs_for_transaction_payload(&client, transaction_payload).await?;
-                                Ok(Some((transaction_id, (*transaction_payload.clone(), inputs))))
-                            } else {
-                                Ok(None)
-                            }
-                        }
-                        Err(iota_client::Error::NotFound(_)) => Ok(None),
-                        Err(e) => Err(crate::Error::Client(e.into())),
-                    }
-                })
-                .await
-            });
-        }
-
-        let results = futures::future::try_join_all(tasks).await?;
-        // Update account with new transactions
-        let mut account = self.write().await;
-        for res in results {
-            if let Some((transaction_id, transaction_data)) = res? {
-                account.incoming_transactions.insert(transaction_id, transaction_data);
+            let results = futures::future::try_join_all(tasks).await?;
+            // Update account with new transactions
+            let mut account = self.write().await;
+            for res in results {
+                if let Some((transaction_id, transaction_data)) = res? {
+                    account.incoming_transactions.insert(transaction_id, transaction_data);
+                }
             }
         }
 


### PR DESCRIPTION
# Description of change

Limit max parallel request in request_incoming_transaction_data() because I got many different network connection and timeout errors for ~10k tx ids and with this change syncing didn't fail anymore

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Running an example which syncs also incoming transactions

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
