### PR TITLE
Add workflow_dispatch to python binding wheels workflow

### DIFF
--- a/.github/workflows/python_binding_publish.yml
+++ b/.github/workflows/python_binding_publish.yml
@@ -1,6 +1,7 @@
 name: Build python binding wheels
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - production


### PR DESCRIPTION
# Description of change

Add workflow_dispatch to python binding wheels workflow so we can build them manually when the artifacts expire again

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
