### PR TITLE
feat: create arm64 builds

### DIFF
--- a/.github/workflows/covector-version-or-publish.yml
+++ b/.github/workflows/covector-version-or-publish.yml
@@ -143,8 +143,12 @@ jobs:
         run: npm install typescript && npm ci
         working-directory: bindings/nodejs
       
-      - name: Build Node.js prebuild
-        run: npm run prebuild
+      - name: Build Node.js prebuild (x64)
+        run: npm run prebuild-x64
+        working-directory: bindings/nodejs
+
+      - name: Build Node.js prebuild (arm64)
+        run: npm run prebuild-arm64
         working-directory: bindings/nodejs
       
       - name: Upload prebuild to GitHub release

--- a/bindings/nodejs/package.json
+++ b/bindings/nodejs/package.json
@@ -11,7 +11,8 @@
     "build": "node scripts/neon-build && tsc",
     "build:neon": "cargo-cp-artifact -nc ./index.node -- cargo build --release --message-format=json-render-diagnostics",
     "docs-wiki-build": "typedoc --githubPages false --disableSources --excludePrivate --excludeInternal --excludeNotDocumented --plugin typedoc-plugin-markdown --theme markdown --hideBreadcrumbs --entryDocument api_ref.md --readme none --hideGenerator --sort source-order --exclude ./**/src/index.ts --out ../../documentation/docs/references/nodejs ./lib/index.ts ",
-    "prebuild": "prebuild --runtime napi --target 6 --prepack scripts/neon-build.js --strip",
+    "prebuild-x64": "prebuild --runtime napi --target 6 --prepack scripts/neon-build.js --strip --arch x64",
+    "prebuild-arm64": "prebuild --runtime napi --target 6 --prepack scripts/neon-build.js --strip --arch arm64",
     "rebuild": "node scripts/neon-build && tsc && node scripts/strip.js",
     "install": "prebuild-install --runtime napi --tag-prefix nodejs-binding-v || npm run rebuild",
     "test": "cargo test"


### PR DESCRIPTION
# Description of change

Creates arm64 builds for windows/mac/linux.

## Links to any relevant issues

closes: https://github.com/iotaledger/iota-sdk/issues/97

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Cross-compiled the binaries locally by running the following commands:

`npm run prebuild-x64`
`npm run prebuild-arm64`

The prebuilds should appear in the `bindings/nodejs/prebuilds/@iota` folder

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
