### PR TITLE
fix: tag-prefix passed as a string

### DIFF
--- a/bindings/nodejs/package.json
+++ b/bindings/nodejs/package.json
@@ -14,7 +14,7 @@
     "prebuild-x64": "prebuild --runtime napi --target 6 --prepack scripts/neon-build.js --strip --arch x64",
     "prebuild-arm64": "prebuild --runtime napi --target 6 --prepack scripts/neon-build.js --strip --arch arm64",
     "rebuild": "node scripts/neon-build && tsc && node scripts/strip.js",
-    "install": "prebuild-install --runtime napi --tag-prefix nodejs-binding-v || npm run rebuild",
+    "install": "prebuild-install --runtime napi --tag-prefix='nodejs-binding-v' || npm run rebuild",
     "test": "cargo test"
   },
   "author": "IOTA Foundation <contact@iota.org>",


### PR DESCRIPTION
# Description of change

Prebuild-install couldn't find the correct package, since it didn't add the prefix when looking for the github release.

https://github.com/iotaledger/firefly/actions/runs/3997595702/jobs/6859134518#step:17:186

In the action above it looks for: https://github.com/iotaledger/wallet.rs/releases/download/v2.0.3-rc.15/wallet-v2.0.3-rc.15-napi-v6-win32-x64.tar.gz

Whereas the actual release is at: https://github.com/iotaledger/wallet.rs/releases/download/nodejs-binding-v2.0.3-rc.15/wallet-v2.0.3-rc.15-napi-v6-linux-x64.tar.gz

**note the `nodejs-binding-` prefix

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested `npm run install` with a clean .npm cache and no `prebuild` folder in the bindings on Ubuntu 22.04.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
