### PR TITLE
Voting output mandatory

### DIFF
--- a/.changes/voting-output-mandatory.md
+++ b/.changes/voting-output-mandatory.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": patch
+---
+
+Make the voting output mandatory in input selection for voting functions.

--- a/src/account/operations/participation/voting.rs
+++ b/src/account/operations/participation/voting.rs
@@ -97,6 +97,7 @@ impl AccountHandle {
             Some(TransactionOptions {
                 // Only use previous voting output as input.
                 custom_inputs: Some(vec![voting_output.output_id]),
+                mandatory_inputs: Some(vec![voting_output.output_id]),
                 tagged_data_payload: Some(TaggedDataPayload::new(
                     PARTICIPATION_TAG.as_bytes().to_vec(),
                     participation_bytes,
@@ -166,6 +167,7 @@ impl AccountHandle {
             Some(TransactionOptions {
                 // Only use previous voting output as input.
                 custom_inputs: Some(vec![voting_output.output_id]),
+                mandatory_inputs: Some(vec![voting_output.output_id]),
                 tagged_data_payload: Some(TaggedDataPayload::new(
                     PARTICIPATION_TAG.as_bytes().to_vec(),
                     participation_bytes,


### PR DESCRIPTION
Make the voting output mandatory, because it will otherwise be disallowed in the input selection