### PR TITLE
Stop endlessly requesting inaccessible incoming transactions

### DIFF
--- a/.changes/incoming-txs-requests.md
+++ b/.changes/incoming-txs-requests.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": patch
+---
+
+Stop endlessly requesting inaccessible incoming trasactions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SyncOptions::sync_aliases_and_nfts`;
 - `{TransactionOptions, TransactionOptionsDto}::allow_burning`;
 
+### Fixed
+
+- Stop endlessly requesting inaccessible incoming trasactions;
+
 ## 1.0.0-rc.4 - 2022-12-23
 
 ### Added

--- a/src/account/builder.rs
+++ b/src/account/builder.rs
@@ -188,6 +188,7 @@ impl AccountBuilder {
             transactions: HashMap::new(),
             pending_transactions: HashSet::new(),
             incoming_transactions: HashMap::new(),
+            inaccessible_incoming_transactions: HashSet::new(),
             native_token_foundries: HashMap::new(),
         };
 

--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -254,6 +254,7 @@ fn serialize() {
         transactions: HashMap::new(),
         pending_transactions: HashSet::new(),
         incoming_transactions,
+        inaccessible_incoming_transactions: HashSet::new(),
         native_token_foundries: HashMap::new(),
     };
 

--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -59,23 +59,21 @@ use crate::account::types::InclusionState;
 /// An Account.
 #[derive(Clone, Debug, Eq, PartialEq, Getters, Setters, Serialize, Deserialize)]
 #[getset(get = "pub")]
+#[serde(rename_all = "camelCase")]
 pub struct Account {
     /// The account index
     index: u32,
     /// The coin type
-    #[serde(rename = "coinType")]
     coin_type: u32,
     /// The account alias.
     alias: String,
     /// Public addresses
-    #[serde(rename = "publicAddresses")]
     pub(crate) public_addresses: Vec<AccountAddress>,
     /// Internal addresses
-    #[serde(rename = "internalAddresses")]
     pub(crate) internal_addresses: Vec<AccountAddress>,
     /// Addresses with unspent outputs
-    // used to improve performance for syncing and get balance because it's in most cases only a subset of all addresses
-    #[serde(rename = "addressesWithUnspentOutputs")]
+    // used to improve performance for syncing and get balance because it's in most cases only a subset of all
+    // addresses
     addresses_with_unspent_outputs: Vec<AddressWithUnspentOutputs>,
     /// Outputs
     // stored separated from the account for performance?
@@ -83,11 +81,9 @@ pub struct Account {
     /// Unspent outputs that are currently used as input for transactions
     // outputs used in transactions should be locked here so they don't get used again, which would result in a
     // conflicting transaction
-    #[serde(rename = "lockedOutputs")]
     locked_outputs: HashSet<OutputId>,
     /// Unspent outputs
     // have unspent outputs in a separated hashmap so we don't need to iterate over all outputs we have
-    #[serde(rename = "unspentOutputs")]
     unspent_outputs: HashMap<OutputId, OutputData>,
     /// Sent transactions
     // stored separated from the account for performance and only the transaction id here? where to add the network id?
@@ -95,15 +91,18 @@ pub struct Account {
     transactions: HashMap<TransactionId, types::Transaction>,
     /// Pending transactions
     // Maybe pending transactions even additionally separated?
-    #[serde(rename = "pendingTransactions")]
     pending_transactions: HashSet<TransactionId>,
     /// Transaction payloads for received outputs with inputs when not pruned before syncing, can be used to determine
     /// the sender address/es
-    #[serde(rename = "incomingTransactions")]
     #[serde(deserialize_with = "deserialize_or_convert")]
     incoming_transactions: HashMap<TransactionId, Transaction>,
+    /// Some incoming transactions can be pruned by the node before we requested them, then this node can never return
+    /// it. To avoid useless requestes these transaction ids are stored here and cleared when new client options are
+    /// set, because another node might still have them.
+    #[serde(default)]
+    inaccessible_incoming_transactions: HashSet<TransactionId>,
     /// Foundries for native tokens in outputs
-    #[serde(rename = "nativeTokenFoundries", default)]
+    #[serde(default)]
     native_token_foundries: HashMap<FoundryId, FoundryOutput>,
 }
 

--- a/src/account/operations/syncing/outputs.rs
+++ b/src/account/operations/syncing/outputs.rs
@@ -98,7 +98,7 @@ impl AccountHandle {
             }
         }
         // known output is unspent, so insert it to the unspent outputs again, because if it was an
-        // alias/nft/foundry output it could have been removed when syncing without `sync_aliases_and_nfts`
+        // alias/nft/foundry output it could have been removed when syncing without them
         for (output_id, output_data) in unspent_outputs {
             account.unspent_outputs.insert(output_id, output_data);
         }
@@ -121,16 +121,19 @@ impl AccountHandle {
         &self,
         transaction_ids: Vec<TransactionId>,
     ) -> crate::Result<()> {
-        let transactions = self.read().await.transactions.clone();
-        let incoming_transactions = self.read().await.incoming_transactions.clone();
+        log::debug!("[SYNC] request_incoming_transaction_data");
 
         // Limit parallel requests to 100, to avoid timeouts
         for transaction_ids_chunk in transaction_ids.chunks(100).map(|x: &[TransactionId]| x.to_vec()) {
             let mut tasks = Vec::new();
+            let account = self.read().await;
 
             for transaction_id in transaction_ids_chunk {
-                // Don't request known transactions again
-                if transactions.contains_key(&transaction_id) || incoming_transactions.contains_key(&transaction_id) {
+                // Don't request known or inaccessible transactions again
+                if account.transactions.contains_key(&transaction_id)
+                    || account.incoming_transactions.contains_key(&transaction_id)
+                    || account.inaccessible_incoming_transactions.contains(&transaction_id)
+                {
                     continue;
                 }
 
@@ -149,12 +152,12 @@ impl AccountHandle {
                                         inputs,
                                     )?;
 
-                                    Ok(Some((transaction_id, transaction)))
+                                    Ok((transaction_id, Some(transaction)))
                                 } else {
-                                    Ok(None)
+                                    Ok((transaction_id, None))
                                 }
                             }
-                            Err(iota_client::Error::NotFound(_)) => Ok(None),
+                            Err(iota_client::Error::NotFound(_)) => Ok((transaction_id, None)),
                             Err(e) => Err(crate::Error::Client(e.into())),
                         }
                     })
@@ -162,12 +165,22 @@ impl AccountHandle {
                 });
             }
 
+            drop(account);
+
             let results = futures::future::try_join_all(tasks).await?;
             // Update account with new transactions
             let mut account = self.write().await;
             for res in results {
-                if let Some((transaction_id, transaction_data)) = res? {
-                    account.incoming_transactions.insert(transaction_id, transaction_data);
+                match res? {
+                    (transaction_id, Some(transaction)) => {
+                        account.incoming_transactions.insert(transaction_id, transaction);
+                    }
+                    (transaction_id, None) => {
+                        log::debug!("[SYNC] adding {transaction_id} to inaccessible_incoming_transactions");
+                        // Save transactions that weren't found by the node to avoid requesting them endlessly.
+                        // Will be cleared when new client options are provided.
+                        account.inaccessible_incoming_transactions.insert(transaction_id);
+                    }
                 }
             }
         }

--- a/src/account/update.rs
+++ b/src/account/update.rs
@@ -268,6 +268,7 @@ impl AccountHandle {
     }
 
     // Should only be called from the AccountManager so all accounts are on the same state
+    // Will update the addresses with a possible new Bech32 HRP and clear the inaccessible_incoming_transactions.
     pub(crate) async fn update_account_with_new_client(&mut self, client: Client) -> crate::Result<()> {
         self.client = client;
         let bech32_hrp = self.client.get_bech32_hrp().await?;
@@ -282,6 +283,8 @@ impl AccountHandle {
         for address in &mut account.internal_addresses {
             address.address.bech32_hrp = bech32_hrp.clone();
         }
+
+        account.inaccessible_incoming_transactions.clear();
         Ok(())
     }
 }


### PR DESCRIPTION
# Description of change

Stop endlessly requesting inaccessible incoming transactions

## Links to any relevant issues

Fixes #1719 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Synced with transactions that were pruned and checked if they get requested multiple times or not and also that they get requested again when new client options are set

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
