### PR TITLE
Stop stop_background_syncing faster

### DIFF
--- a/.changes/stop-background-syncing.md
+++ b/.changes/stop-background-syncing.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": patch
+---
+
+Make stopBackgroundSync() faster.

--- a/src/account_manager/mod.rs
+++ b/src/account_manager/mod.rs
@@ -208,8 +208,7 @@ impl AccountManager {
         self.background_syncing_status.store(2, Ordering::Relaxed);
         // wait until it stopped
         while self.background_syncing_status.load(Ordering::Relaxed) != 0 {
-            log::debug!("[stop_background_syncing]: waiting for the background syncing to stop");
-            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
         }
         Ok(())
     }


### PR DESCRIPTION
# Description of change

Stop stop_background_syncing faster, because the 1 second is already noticeable for users

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
