### PR TITLE
Add more tests and make the storage not required

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ required-features = [ "stronghold" ]
 [[example]]
 name = "0_generate_addresses"
 path = "examples/offline_signing/0_generate_addresses.rs"
-required-features = [ "stronghold" ]
+required-features = [ "storage", "stronghold" ]
 
 [[example]]
 name = "1_prepare_transaction"

--- a/tests/account_recovery.rs
+++ b/tests/account_recovery.rs
@@ -5,19 +5,15 @@
 
 mod common;
 
-#[cfg(feature = "storage")]
 use std::time::Duration;
 
-#[cfg(feature = "storage")]
 use iota_client::{constants::SHIMMER_COIN_TYPE, Client};
-#[cfg(feature = "storage")]
 use iota_wallet::{
     secret::{mnemonic::MnemonicSecretManager, SecretManager},
     Result,
 };
 
 #[ignore]
-#[cfg(feature = "storage")]
 #[tokio::test]
 async fn account_recovery_empty() -> Result<()> {
     let storage_path = "test-storage/account_recovery_empty";
@@ -32,7 +28,6 @@ async fn account_recovery_empty() -> Result<()> {
 }
 
 #[ignore]
-#[cfg(feature = "storage")]
 #[tokio::test]
 async fn account_recovery_existing_accounts() -> Result<()> {
     let storage_path = "test-storage/account_recovery_existing_accounts";
@@ -56,7 +51,6 @@ async fn account_recovery_existing_accounts() -> Result<()> {
 }
 
 #[ignore]
-#[cfg(feature = "storage")]
 #[tokio::test]
 async fn account_recovery_with_balance_and_empty_addresses() -> Result<()> {
     let storage_path = "test-storage/account_recovery_with_balance_and_empty_addresses";

--- a/tests/balance.rs
+++ b/tests/balance.rs
@@ -81,5 +81,16 @@ async fn balance_expiration() -> Result<()> {
     assert_eq!(balance.base_coin.total, 1_000_000);
     assert_eq!(balance.base_coin.available, 1_000_000);
 
+    // It's possible to send the expired output
+    let outputs = vec![
+        BasicOutputBuilder::new_with_amount(1_000_000)?
+            // Send to account 1 with expiration to account 2, both have no amount yet
+            .with_unlock_conditions(vec![UnlockCondition::Address(AddressUnlockCondition::new(
+                *account_1.addresses().await?[0].address().as_ref(),
+            ))])
+            .finish_output(token_supply)?,
+    ];
+    let _tx = account_2.send(outputs, None).await?;
+
     common::tear_down(storage_path)
 }

--- a/tests/balance.rs
+++ b/tests/balance.rs
@@ -1,0 +1,81 @@
+// Copyright 2023 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+mod common;
+
+use iota_client::block::output::{
+    unlock_condition::{AddressUnlockCondition, ExpirationUnlockCondition},
+    BasicOutputBuilder, UnlockCondition,
+};
+use iota_wallet::Result;
+
+#[ignore]
+#[tokio::test]
+async fn balance_expiration() -> Result<()> {
+    let storage_path = "test-storage/balance_expiration";
+    common::setup(storage_path)?;
+
+    let manager = common::make_manager(storage_path, None, None).await?;
+
+    let account_0 = &common::create_accounts_with_funds(&manager, 1).await?[0];
+    let account_1 = manager.create_account().finish().await?;
+    let account_2 = manager.create_account().finish().await?;
+
+    let seconds_until_expired = 20;
+    let token_supply = account_0.client().get_token_supply().await?;
+    let outputs = vec![
+        BasicOutputBuilder::new_with_amount(1_000_000)?
+            // Send to account 1 with expiration to account 2, both have no amount yet
+            .with_unlock_conditions(vec![
+                UnlockCondition::Address(AddressUnlockCondition::new(
+                    *account_1.addresses().await?[0].address().as_ref(),
+                )),
+                UnlockCondition::Expiration(ExpirationUnlockCondition::new(
+                    *account_2.addresses().await?[0].address().as_ref(),
+                    // Current time + 20s
+                    account_0.client().get_time_checked().await? + seconds_until_expired,
+                )?),
+            ])
+            .finish_output(token_supply)?,
+    ];
+
+    let balance_before_tx = account_0.balance().await?;
+    let tx = account_0.send(outputs, None).await?;
+    let balance_after_tx = account_0.balance().await?;
+    // Total doesn't change before syncing after tx got confirmed
+    assert_eq!(balance_before_tx.base_coin.total, balance_after_tx.base_coin.total);
+    assert_eq!(balance_after_tx.base_coin.available, 0);
+
+    account_0
+        .retry_transaction_until_included(&tx.transaction_id, None, None)
+        .await?;
+
+    // Account 1 balance before expiration
+    let balance = account_1.sync(None).await?;
+    assert_eq!(balance.potentially_locked_outputs.len(), 1);
+    assert_eq!(balance.base_coin.total, 0);
+    assert_eq!(balance.base_coin.available, 0);
+
+    // Account 2 balance before expiration
+    let balance = account_2.sync(None).await?;
+    assert_eq!(balance.potentially_locked_outputs.len(), 1);
+    assert_eq!(balance.base_coin.total, 0);
+    assert_eq!(balance.base_coin.available, 0);
+
+    // Wait until expired
+    tokio::time::sleep(std::time::Duration::from_secs(seconds_until_expired.into())).await;
+
+    // Account 1 balance after expiration
+    let balance = account_1.sync(None).await?;
+    assert_eq!(balance.potentially_locked_outputs.len(), 0);
+    assert_eq!(balance.base_coin.total, 0);
+    assert_eq!(balance.base_coin.available, 0);
+
+    // Account 2 balance after expiration
+    let balance = account_2.sync(None).await?;
+    assert_eq!(balance.potentially_locked_outputs.len(), 0);
+    assert_eq!(balance.base_coin.total, 1_000_000);
+    assert_eq!(balance.base_coin.available, 1_000_000);
+
+    common::tear_down(storage_path)
+}

--- a/tests/balance.rs
+++ b/tests/balance.rs
@@ -4,8 +4,9 @@
 mod common;
 
 use iota_client::block::output::{
+    feature::SenderFeature,
     unlock_condition::{AddressUnlockCondition, ExpirationUnlockCondition},
-    BasicOutputBuilder, UnlockCondition,
+    BasicOutputBuilder, Feature, UnlockCondition,
 };
 use iota_wallet::Result;
 
@@ -36,6 +37,9 @@ async fn balance_expiration() -> Result<()> {
                     account_0.client().get_time_checked().await? + seconds_until_expired,
                 )?),
             ])
+            .with_features(vec![Feature::Sender(SenderFeature::new(
+                *account_0.addresses().await?[0].address().as_ref(),
+            ))])
             .finish_output(token_supply)?,
     ];
 

--- a/tests/burn_outputs.rs
+++ b/tests/burn_outputs.rs
@@ -3,13 +3,10 @@
 
 mod common;
 
-#[cfg(feature = "storage")]
 use iota_client::block::output::{NftId, OutputId};
-#[cfg(feature = "storage")]
 use iota_wallet::{account::AccountHandle, NativeTokenOptions, NftOptions, Result, U256};
 
 #[ignore]
-#[cfg(feature = "storage")]
 #[tokio::test]
 async fn mint_and_burn_nft() -> Result<()> {
     let storage_path = "test-storage/mint_and_burn_outputs";
@@ -53,7 +50,6 @@ async fn mint_and_burn_nft() -> Result<()> {
 }
 
 #[ignore]
-#[cfg(feature = "storage")]
 #[tokio::test]
 async fn mint_and_decrease_native_token_supply() -> Result<()> {
     let storage_path = "test-storage/mint_and_decrease_native_token_supply";
@@ -137,7 +133,6 @@ async fn mint_and_decrease_native_token_supply() -> Result<()> {
     common::tear_down(storage_path)
 }
 
-#[cfg(feature = "storage")]
 async fn destroy_foundry(account: &AccountHandle) -> Result<()> {
     let balance = account.sync(None).await?;
     println!("account balance -> {}", serde_json::to_string(&balance).unwrap());
@@ -161,7 +156,6 @@ async fn destroy_foundry(account: &AccountHandle) -> Result<()> {
     Ok(())
 }
 
-#[cfg(feature = "storage")]
 async fn destroy_alias(account: &AccountHandle) -> Result<()> {
     let balance = account.sync(None).await.unwrap();
     println!("account balance -> {}", serde_json::to_string(&balance).unwrap());
@@ -185,7 +179,6 @@ async fn destroy_alias(account: &AccountHandle) -> Result<()> {
 }
 
 #[ignore]
-#[cfg(feature = "storage")]
 #[tokio::test]
 async fn mint_and_burn_native_tokens() -> Result<()> {
     let storage_path = "test-storage/mint_and_burn_native_tokens";

--- a/tests/claim_outputs.rs
+++ b/tests/claim_outputs.rs
@@ -3,18 +3,15 @@
 
 mod common;
 
-#[cfg(feature = "storage")]
 use iota_client::block::output::{
     unlock_condition::{AddressUnlockCondition, ExpirationUnlockCondition},
     NftId, NftOutputBuilder, UnlockCondition,
 };
-#[cfg(feature = "storage")]
 use iota_wallet::{
     account::OutputsToClaim, AddressNativeTokens, AddressWithMicroAmount, NativeTokenOptions, Result, U256,
 };
 
 #[ignore]
-#[cfg(feature = "storage")]
 #[tokio::test]
 async fn claim_2_basic_outputs() -> Result<()> {
     let storage_path = "test-storage/claim_2_basic_outputs";
@@ -76,7 +73,6 @@ async fn claim_2_basic_outputs() -> Result<()> {
 }
 
 #[ignore]
-#[cfg(feature = "storage")]
 #[tokio::test]
 async fn claim_2_native_tokens() -> Result<()> {
     let storage_path = "test-storage/claim_2_native_tokens";
@@ -184,7 +180,6 @@ async fn claim_2_native_tokens() -> Result<()> {
 }
 
 #[ignore]
-#[cfg(feature = "storage")]
 #[tokio::test]
 async fn claim_2_nft_outputs() -> Result<()> {
     let storage_path = "test-storage/claim_2_nft_outputs";

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -36,16 +36,16 @@ pub(crate) async fn make_manager(
         MnemonicSecretManager::try_from_mnemonic(mnemonic.unwrap_or(&Client::generate_mnemonic().unwrap()))?;
 
     #[allow(unused_mut)]
-    let mut manager_builder = AccountManager::builder()
+    let mut account_manager_builder = AccountManager::builder()
         .with_secret_manager(SecretManager::Mnemonic(secret_manager))
         .with_client_options(client_options)
         .with_coin_type(SHIMMER_COIN_TYPE);
     #[cfg(feature = "storage")]
     {
-        manager_builder = manager_builder.with_storage_path(storage_path);
+        account_manager_builder = account_manager_builder.with_storage_path(storage_path);
     }
 
-    manager_builder.finish().await
+    account_manager_builder.finish().await
 }
 
 /// Create `amount` new accounts, request funds from the faucet and sync the accounts afterwards until the faucet output

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -3,14 +3,12 @@
 
 mod constants;
 
-use iota_client::request_funds_from_faucet;
-#[cfg(feature = "storage")]
-use iota_client::{constants::SHIMMER_COIN_TYPE, Client};
-use iota_wallet::{account::AccountHandle, account_manager::AccountManager, Result};
-#[cfg(feature = "storage")]
+use iota_client::{constants::SHIMMER_COIN_TYPE, request_funds_from_faucet, Client};
 use iota_wallet::{
+    account::AccountHandle,
+    account_manager::AccountManager,
     secret::{mnemonic::MnemonicSecretManager, SecretManager},
-    ClientOptions,
+    ClientOptions, Result,
 };
 
 pub use self::constants::*;
@@ -27,8 +25,7 @@ pub use self::constants::*;
 /// Returns:
 ///
 /// An AccountManager
-#[cfg(feature = "storage")]
-#[allow(dead_code)]
+#[allow(dead_code, unused_variables)]
 pub(crate) async fn make_manager(
     storage_path: &str,
     mnemonic: Option<&str>,
@@ -38,13 +35,17 @@ pub(crate) async fn make_manager(
     let secret_manager =
         MnemonicSecretManager::try_from_mnemonic(mnemonic.unwrap_or(&Client::generate_mnemonic().unwrap()))?;
 
-    AccountManager::builder()
+    #[allow(unused_mut)]
+    let mut manager_builder = AccountManager::builder()
         .with_secret_manager(SecretManager::Mnemonic(secret_manager))
         .with_client_options(client_options)
-        .with_coin_type(SHIMMER_COIN_TYPE)
-        .with_storage_path(storage_path)
-        .finish()
-        .await
+        .with_coin_type(SHIMMER_COIN_TYPE);
+    #[cfg(feature = "storage")]
+    {
+        manager_builder = manager_builder.with_storage_path(storage_path);
+    }
+
+    manager_builder.finish().await
 }
 
 /// Create `amount` new accounts, request funds from the faucet and sync the accounts afterwards until the faucet output

--- a/tests/consolidation.rs
+++ b/tests/consolidation.rs
@@ -3,11 +3,9 @@
 
 mod common;
 
-#[cfg(feature = "storage")]
 use iota_wallet::{AddressWithAmount, Result};
 
 #[ignore]
-#[cfg(feature = "storage")]
 #[tokio::test]
 async fn consolidation() -> Result<()> {
     let storage_path = "test-storage/consolidation";

--- a/tests/native_tokens.rs
+++ b/tests/native_tokens.rs
@@ -3,11 +3,9 @@
 
 mod common;
 
-#[cfg(feature = "storage")]
 use iota_wallet::{account::SyncOptions, NativeTokenOptions, Result, U256};
 
 #[ignore]
-#[cfg(feature = "storage")]
 #[tokio::test]
 async fn mint_and_increase_native_token_supply() -> Result<()> {
     let storage_path = "test-storage/mint_and_increase_native_token_supply";
@@ -71,7 +69,6 @@ async fn mint_and_increase_native_token_supply() -> Result<()> {
 }
 
 #[ignore]
-#[cfg(feature = "storage")]
 #[tokio::test]
 async fn native_token_foundry_metadata() -> Result<()> {
     let storage_path = "test-storage/native_token_foundry_metadata";

--- a/tests/output_preparation.rs
+++ b/tests/output_preparation.rs
@@ -3,19 +3,15 @@
 
 mod common;
 
-#[cfg(feature = "storage")]
 use std::str::FromStr;
 
-#[cfg(feature = "storage")]
 use iota_client::block::address::Address;
-#[cfg(feature = "storage")]
 use iota_wallet::{
     account::{Assets, Features, OutputOptions, Unlocks},
     iota_client::block::output::{NativeToken, NftId, TokenId},
     Result, U256,
 };
 
-#[cfg(feature = "storage")]
 #[tokio::test]
 async fn output_preparation() -> Result<()> {
     let storage_path = "test-storage/output_preparation";

--- a/tests/syncing.rs
+++ b/tests/syncing.rs
@@ -1,0 +1,121 @@
+// Copyright 2023 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+mod common;
+
+use iota_client::block::output::{
+    unlock_condition::{
+        AddressUnlockCondition, ExpirationUnlockCondition, GovernorAddressUnlockCondition,
+        StateControllerAddressUnlockCondition, StorageDepositReturnUnlockCondition,
+    },
+    AliasId, AliasOutputBuilder, BasicOutputBuilder, NftId, NftOutputBuilder, UnlockCondition,
+};
+use iota_wallet::{account::SyncOptions, Result};
+
+#[ignore]
+#[tokio::test]
+async fn sync_only_most_basic_outputs() -> Result<()> {
+    let storage_path = "test-storage/sync_only_most_basic_outputs";
+    common::setup(storage_path)?;
+
+    let manager = common::make_manager(storage_path, None, None).await?;
+
+    let account_0 = &common::create_accounts_with_funds(&manager, 1).await?[0];
+    let account_1 = manager.create_account().finish().await?;
+
+    let account_1_address = *account_1.addresses().await?[0].address().as_ref();
+
+    let token_supply = account_0.client().get_token_supply().await?;
+    // Only one basic output without further unlock conditions
+    let outputs = vec![
+        BasicOutputBuilder::new_with_amount(1_000_000)?
+            .with_unlock_conditions(vec![UnlockCondition::Address(AddressUnlockCondition::new(
+                account_1_address,
+            ))])
+            .finish_output(token_supply)?,
+        BasicOutputBuilder::new_with_amount(1_000_000)?
+            .with_unlock_conditions(vec![
+                UnlockCondition::Address(AddressUnlockCondition::new(account_1_address)),
+                UnlockCondition::Expiration(ExpirationUnlockCondition::new(
+                    account_1_address,
+                    // Already expired
+                    account_0.client().get_time_checked().await? - 5000,
+                )?),
+            ])
+            .finish_output(token_supply)?,
+        BasicOutputBuilder::new_with_amount(1_000_000)?
+            .with_unlock_conditions(vec![
+                UnlockCondition::Address(AddressUnlockCondition::new(account_1_address)),
+                UnlockCondition::Expiration(ExpirationUnlockCondition::new(
+                    account_1_address,
+                    // Not expired
+                    account_0.client().get_time_checked().await? + 5000,
+                )?),
+            ])
+            .finish_output(token_supply)?,
+        BasicOutputBuilder::new_with_amount(1_000_000)?
+            .with_unlock_conditions(vec![
+                UnlockCondition::Address(AddressUnlockCondition::new(account_1_address)),
+                UnlockCondition::StorageDepositReturn(StorageDepositReturnUnlockCondition::new(
+                    account_1_address,
+                    1_000_000,
+                    token_supply,
+                )?),
+            ])
+            .finish_output(token_supply)?,
+        NftOutputBuilder::new_with_amount(1_000_000, NftId::null())?
+            .with_unlock_conditions(vec![UnlockCondition::Address(AddressUnlockCondition::new(
+                account_1_address,
+            ))])
+            .finish_output(token_supply)?,
+        NftOutputBuilder::new_with_amount(1_000_000, NftId::null())?
+            .with_unlock_conditions(vec![
+                UnlockCondition::Address(AddressUnlockCondition::new(account_1_address)),
+                UnlockCondition::Expiration(ExpirationUnlockCondition::new(
+                    account_1_address,
+                    account_0.client().get_time_checked().await? + 5000,
+                )?),
+            ])
+            .finish_output(token_supply)?,
+        AliasOutputBuilder::new_with_amount(1_000_000, AliasId::null())?
+            .with_unlock_conditions(vec![
+                UnlockCondition::StateControllerAddress(StateControllerAddressUnlockCondition::new(account_1_address)),
+                UnlockCondition::GovernorAddress(GovernorAddressUnlockCondition::new(account_1_address)),
+            ])
+            .finish_output(token_supply)?,
+    ];
+
+    let tx = account_0.send(outputs, None).await?;
+    account_0
+        .retry_transaction_until_included(&tx.transaction_id, None, None)
+        .await?;
+
+    // Sync with sync_only_most_basic_outputs: true, only the first output should be synced
+    let balance = account_1
+        .sync(Some(SyncOptions {
+            sync_only_most_basic_outputs: true,
+            ..Default::default()
+        }))
+        .await?;
+    assert_eq!(balance.potentially_locked_outputs.len(), 0);
+    assert_eq!(balance.nfts.len(), 0);
+    assert_eq!(balance.aliases.len(), 0);
+    let unspent_outputs = account_1.unspent_outputs(None).await?;
+    assert_eq!(unspent_outputs.len(), 1);
+    unspent_outputs.into_iter().for_each(|output_data| {
+        assert!(output_data.output.is_basic());
+        assert_eq!(output_data.output.unlock_conditions().unwrap().len(), 1);
+        assert_eq!(
+            *output_data
+                .output
+                .unlock_conditions()
+                .unwrap()
+                .address()
+                .unwrap()
+                .address(),
+            account_1_address
+        );
+    });
+
+    common::tear_down(storage_path)
+}

--- a/tests/transactions.rs
+++ b/tests/transactions.rs
@@ -3,11 +3,9 @@
 
 mod common;
 
-#[cfg(feature = "storage")]
 use iota_wallet::{account::TransactionOptions, AddressAndNftId, AddressWithAmount, NftOptions, Result};
 
 #[ignore]
-#[cfg(feature = "storage")]
 #[tokio::test]
 async fn send_amount() -> Result<()> {
     let storage_path = "test-storage/send_amount";
@@ -40,7 +38,6 @@ async fn send_amount() -> Result<()> {
 }
 
 #[ignore]
-#[cfg(feature = "storage")]
 #[tokio::test]
 async fn send_amount_127_outputs() -> Result<()> {
     let storage_path = "test-storage/send_amount_127_outputs";
@@ -77,7 +74,6 @@ async fn send_amount_127_outputs() -> Result<()> {
 }
 
 #[ignore]
-#[cfg(feature = "storage")]
 #[tokio::test]
 async fn send_amount_custom_input() -> Result<()> {
     let storage_path = "test-storage/send_amount_custom_input";
@@ -132,7 +128,6 @@ async fn send_amount_custom_input() -> Result<()> {
 }
 
 #[ignore]
-#[cfg(feature = "storage")]
 #[tokio::test]
 async fn send_nft() -> Result<()> {
     let storage_path = "test-storage/send_nft";


### PR DESCRIPTION
# Description of change

Add balance_expiration and sync_only_most_basic_outputs test and make the storage not required

Tests the case described in https://github.com/iotaledger/wallet.rs/issues/1809 and it's working, so the reported bug is about something different

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Running the test

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
