### PR TITLE
Docs - Improve Shimmer Getting Started Section

### DIFF
--- a/documentation/docs/getting_started/getting_started.md
+++ b/documentation/docs/getting_started/getting_started.md
@@ -10,22 +10,23 @@ keywords:
 - javascript
 - wallet
 - accounts
+
 ---
 
 # Getting Started
 
-Choose your programming language:
-
-* [Rust](./rust.mdx)
-* [Node.js](./nodejs.mdx)
-* [Java](./java.mdx)
-* [Python](./python.mdx)
+You can use this section to get your wallet up and running in
+the [programming language of your choice](#available-programming-languages),
+[connect to the testnet](#connect-to-the-testnet-api), [explore the network](#explore-the-network),
+and [get test tokens](#get-test-tokens) to develop your application.
 
 ## Connect to the Testnet API
 
-We recommended that you start your interactions with Shimmer on a _testnet_ network. The _testnet_ will allow you to safely
-get acquainted with the `wallet.rs` library, without the risk of losing any funds if you make a mistake along the way.
-You can use this Shimmer Testnet API load balancer: 
+We recommended that you start your interactions with Shimmer on a _testnet_ network. The _testnet_ will allow you to
+safely get acquainted with the `wallet.rs` library, without the risk of losing any funds if you make a mistake along the
+way.
+
+You can use this public load-balanced Shimmer Testnet API:
 
 ```plaintext
 https://api.testnet.shimmer.network
@@ -33,10 +34,16 @@ https://api.testnet.shimmer.network
 
 ## Explore the Network
 
-You can use the [Shimmer Tangle Explorer](https://explorer.shimmer.network/testnet) to view transactions and data stored in
-the Tangle.
+You can use the [Shimmer Tangle Explorer](https://explorer.shimmer.network/testnet) to view transactions and data stored
+in the Tangle.
 
 ## Get Test Tokens
 
 In order to properly test value-based transactions on testnet network, you are going to need some tokens. You can get
 some testnet tokens through the [Shimmer Faucet](https://faucet.testnet.shimmer.network).
+
+## Available Programming Languages
+
+The wallet.rs library is written in [Rust](./rust.mdx), and also has convenient bindings
+in [Node.js](./nodejs.mdx), [Java](./java.mdx) and  [Python](./python.mdx). Each of these languages has specific
+instructions you will need to follow to use wallet.rs in your project. 

--- a/documentation/docs/getting_started/getting_started.md
+++ b/documentation/docs/getting_started/getting_started.md
@@ -45,5 +45,5 @@ some testnet tokens through the [Shimmer Faucet](https://faucet.testnet.shimmer.
 ## Available Programming Languages
 
 The wallet.rs library is written in [Rust](./rust.mdx), and also has convenient bindings
-in [Node.js](./nodejs.mdx), [Java](./java.mdx) and  [Python](./python.mdx). Each of these languages has specific
+in [Node.js](./nodejs.mdx), [Java](./java.mdx) and [Python](./python.mdx). Each of these languages has specific
 instructions you will need to follow to use wallet.rs in your project. 


### PR DESCRIPTION
# Description of change

- [x]  Add introduction with a brief description what the Getting Started sections will cover.
- [x]  Move the choice of getting started with a specific language down the page, so important sections like the recommendation to connect to the public testnet, how to get tokens, and how to check results on the explorer come first.

## Links to any relevant issues

fixes #1759 

## Type of change

- Documentation Fix

## How the change has been tested

Wiki was built locally

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
