### PR TITLE
Fix claim_outputs when no basic outputs are available

### DIFF
--- a/.changes/claimoutputs.md
+++ b/.changes/claimoutputs.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": patch
+---
+
+Fix `Account::claimOutputs()` when no basic outputs are available.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Account::get_participation_overview()` with multiple events and different nodes;
 - `prepare_nft_output` uses newly provided tag/metadata instead of previous ones from unspent output;
+- `Account::claim_outputs()` when the account has no basic outputs available;
 
 ## 1.0.0-rc.5 - 2023-02-09
 

--- a/bindings/nodejs/Cargo.lock
+++ b/bindings/nodejs/Cargo.lock
@@ -1102,7 +1102,7 @@ dependencies = [
 [[package]]
 name = "iota-client"
 version = "2.0.1-rc.6"
-source = "git+https://github.com/iotaledger/iota.rs?rev=e8422a87c89d3bcc811d41668ddd4d9078d36438#e8422a87c89d3bcc811d41668ddd4d9078d36438"
+source = "git+https://github.com/iotaledger/iota.rs?rev=3a491bc344ff097f3ca6e988e7c338bda748116b#3a491bc344ff097f3ca6e988e7c338bda748116b"
 dependencies = [
  "async-trait",
  "backtrace",
@@ -1182,7 +1182,7 @@ dependencies = [
 [[package]]
 name = "iota-pow"
 version = "1.0.0-rc.3"
-source = "git+https://github.com/iotaledger/iota.rs?rev=e8422a87c89d3bcc811d41668ddd4d9078d36438#e8422a87c89d3bcc811d41668ddd4d9078d36438"
+source = "git+https://github.com/iotaledger/iota.rs?rev=3a491bc344ff097f3ca6e988e7c338bda748116b#3a491bc344ff097f3ca6e988e7c338bda748116b"
 dependencies = [
  "instant",
  "iota-crypto",
@@ -1192,7 +1192,7 @@ dependencies = [
 [[package]]
 name = "iota-types"
 version = "1.0.0-rc.6"
-source = "git+https://github.com/iotaledger/iota.rs?rev=e8422a87c89d3bcc811d41668ddd4d9078d36438#e8422a87c89d3bcc811d41668ddd4d9078d36438"
+source = "git+https://github.com/iotaledger/iota.rs?rev=3a491bc344ff097f3ca6e988e7c338bda748116b#3a491bc344ff097f3ca6e988e7c338bda748116b"
 dependencies = [
  "bech32 0.9.1",
  "bitflags",

--- a/bindings/nodejs/examples/26-send-nft.js
+++ b/bindings/nodejs/examples/26-send-nft.js
@@ -6,11 +6,11 @@ const getUnlockedManager = require('./account-manager');
 async function run() {
     try {
         const { initLogger } = require('@iota/wallet');
-    initLogger({
-        name: './wallet.log',
-        levelFilter: 'debug',
-        targetExclusions: ["h2", "hyper", "rustls"]
-    });
+        initLogger({
+            name: './wallet.log',
+            levelFilter: 'debug',
+            targetExclusions: ["h2", "hyper", "rustls"]
+        });
         const manager = await getUnlockedManager();
 
         const account = await manager.getAccount('0');
@@ -25,11 +25,28 @@ async function run() {
             nftId: '0x09aa7871e126cc41f1f3784a479a5dd5f23e4dd8b97e932a001e77a11ad42f0c',
         }]);
 
+
+
         console.log(response);
 
         console.log(
             `Check your block on ${process.env.NODE_URL}/api/core/v2/blocks/${response.blockId}`,
         );
+
+        // To send an NFT with expiration unlock condition prepareOutput() can be used like this:
+        // const output = await account.prepareOutput({
+        //     recipientAddress: 'rms1qz6aj69rumk3qu0ra5ag6p6kk8ga3j8rfjlaym3wefugs3mmxgzfwa6kw3l',
+        //     amount: "47000",
+        //     unlocks: {
+        //         expirationUnixTime: 1677065933
+        //     },
+        //     assets: {
+        //         nftId: '0x447b20b81e2311a6c16a32eaeda2f2f2472c4b43ed4ffc80a0c0f850130fc4bb',
+        //     },
+        //     storageDeposit: { returnStrategy: 'Gift' }
+        // });
+
+        // const transaction = await account.sendOutputs([output]);
     } catch (error) {
         console.log('Error: ', error);
     }

--- a/tests/claim_outputs.rs
+++ b/tests/claim_outputs.rs
@@ -5,7 +5,7 @@ mod common;
 
 use iota_client::block::output::{
     unlock_condition::{AddressUnlockCondition, ExpirationUnlockCondition},
-    NftId, NftOutputBuilder, UnlockCondition,
+    BasicOutputBuilder, NativeToken, NftId, NftOutputBuilder, UnlockCondition,
 };
 use iota_wallet::{
     account::OutputsToClaim, AddressNativeTokens, AddressWithMicroAmount, NativeTokenOptions, Result, U256,
@@ -63,6 +63,69 @@ async fn claim_2_basic_outputs() -> Result<()> {
         .await?;
 
     let balance = accounts[0].sync(None).await.unwrap();
+    assert_eq!(balance.potentially_locked_outputs.len(), 0);
+    assert_eq!(
+        balance.base_coin.available,
+        base_coin_amount_before_claiming + 2 * micro_amount
+    );
+
+    common::tear_down(storage_path)
+}
+
+#[ignore]
+#[tokio::test]
+async fn claim_2_basic_outputs_no_outputs_in_claim_account() -> Result<()> {
+    let storage_path = "test-storage/claim_2_basic_outputs_no_outputs_in_claim_account";
+    common::setup(storage_path)?;
+
+    let manager = common::make_manager(storage_path, None, None).await?;
+
+    let account_0 = &common::create_accounts_with_funds(&manager, 1).await?[0];
+    let account_1 = manager.create_account().finish().await?;
+
+    // Equal to minimum required storage deposit for a basic output
+    let micro_amount = 42600;
+    let tx = account_0
+        .send_micro_transaction(
+            vec![
+                AddressWithMicroAmount {
+                    address: account_1.addresses().await?[0].address().to_bech32(),
+                    amount: micro_amount,
+                    return_address: None,
+                    expiration: None,
+                },
+                AddressWithMicroAmount {
+                    address: account_1.addresses().await?[0].address().to_bech32(),
+                    amount: micro_amount,
+                    return_address: None,
+                    expiration: None,
+                },
+            ],
+            None,
+        )
+        .await?;
+
+    account_0
+        .retry_transaction_until_included(&tx.transaction_id, None, None)
+        .await?;
+
+    // Claim with account 1
+    let balance = account_1.sync(None).await.unwrap();
+    assert_eq!(balance.potentially_locked_outputs.len(), 2);
+    let base_coin_amount_before_claiming = balance.base_coin.available;
+
+    let tx = account_1
+        .claim_outputs(
+            account_1
+                .get_unlockable_outputs_with_additional_unlock_conditions(OutputsToClaim::MicroTransactions)
+                .await?,
+        )
+        .await?;
+    account_1
+        .retry_transaction_until_included(&tx.transaction_id, None, None)
+        .await?;
+
+    let balance = account_1.sync(None).await.unwrap();
     assert_eq!(balance.potentially_locked_outputs.len(), 0);
     assert_eq!(
         balance.base_coin.available,
@@ -181,6 +244,125 @@ async fn claim_2_native_tokens() -> Result<()> {
 
 #[ignore]
 #[tokio::test]
+async fn claim_2_native_tokens_no_outputs_in_claim_account() -> Result<()> {
+    let storage_path = "test-storage/claim_2_native_tokens_no_outputs_in_claim_account";
+    common::setup(storage_path)?;
+
+    let manager = common::make_manager(storage_path, None, None).await?;
+
+    let account_0 = &common::create_accounts_with_funds(&manager, 1).await?[0];
+    let account_1 = manager.create_account().finish().await?;
+
+    let native_token_amount = U256::from(100);
+
+    let tx = account_0.create_alias_output(None, None).await?;
+    account_0
+        .retry_transaction_until_included(&tx.transaction_id, None, None)
+        .await?;
+    account_0.sync(None).await?;
+
+    let mint_tx_0 = account_0
+        .mint_native_token(
+            NativeTokenOptions {
+                alias_id: None,
+                circulating_supply: native_token_amount,
+                maximum_supply: native_token_amount,
+                foundry_metadata: None,
+            },
+            None,
+        )
+        .await?;
+    account_0
+        .retry_transaction_until_included(&mint_tx_0.transaction.transaction_id, None, None)
+        .await?;
+    account_0.sync(None).await?;
+
+    let mint_tx_1 = account_0
+        .mint_native_token(
+            NativeTokenOptions {
+                alias_id: None,
+                circulating_supply: native_token_amount,
+                maximum_supply: native_token_amount,
+                foundry_metadata: None,
+            },
+            None,
+        )
+        .await?;
+    account_0
+        .retry_transaction_until_included(&mint_tx_1.transaction.transaction_id, None, None)
+        .await?;
+    account_0.sync(None).await?;
+
+    let rent_structure = account_0.client().get_rent_structure().await?;
+    let token_supply = account_0.client().get_token_supply().await?;
+
+    let tx = account_0
+        .send(
+            vec![
+                BasicOutputBuilder::new_with_minimum_storage_deposit(rent_structure.clone())?
+                    .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(
+                        *account_1.addresses().await?[0].address().as_ref(),
+                    )))
+                    .add_unlock_condition(UnlockCondition::Expiration(ExpirationUnlockCondition::new(
+                        *account_0.addresses().await?[0].address().as_ref(),
+                        account_0.client().get_time_checked().await? + 5000,
+                    )?))
+                    .add_native_token(NativeToken::new(mint_tx_0.token_id, native_token_amount)?)
+                    .finish_output(token_supply)?,
+                BasicOutputBuilder::new_with_minimum_storage_deposit(rent_structure.clone())?
+                    .add_unlock_condition(UnlockCondition::Address(AddressUnlockCondition::new(
+                        *account_1.addresses().await?[0].address().as_ref(),
+                    )))
+                    .add_unlock_condition(UnlockCondition::Expiration(ExpirationUnlockCondition::new(
+                        *account_0.addresses().await?[0].address().as_ref(),
+                        account_0.client().get_time_checked().await? + 5000,
+                    )?))
+                    .add_native_token(NativeToken::new(mint_tx_1.token_id, native_token_amount)?)
+                    .finish_output(token_supply)?,
+            ],
+            None,
+        )
+        .await?;
+    account_0
+        .retry_transaction_until_included(&tx.transaction_id, None, None)
+        .await?;
+
+    // Claim with account 1
+    let balance = account_1.sync(None).await.unwrap();
+    assert_eq!(balance.potentially_locked_outputs.len(), 2);
+
+    let tx = account_1
+        .claim_outputs(
+            account_1
+                .get_unlockable_outputs_with_additional_unlock_conditions(OutputsToClaim::NativeTokens)
+                .await?,
+        )
+        .await?;
+    account_1
+        .retry_transaction_until_included(&tx.transaction_id, None, None)
+        .await?;
+
+    let balance = account_1.sync(None).await.unwrap();
+    assert_eq!(balance.potentially_locked_outputs.len(), 0);
+    assert_eq!(balance.native_tokens.len(), 2);
+    let native_token_0 = balance
+        .native_tokens
+        .iter()
+        .find(|t| t.token_id == mint_tx_0.token_id)
+        .unwrap();
+    assert_eq!(native_token_0.total, native_token_amount);
+    let native_token_1 = balance
+        .native_tokens
+        .iter()
+        .find(|t| t.token_id == mint_tx_1.token_id)
+        .unwrap();
+    assert_eq!(native_token_1.total, native_token_amount);
+
+    common::tear_down(storage_path)
+}
+
+#[ignore]
+#[tokio::test]
 async fn claim_2_nft_outputs() -> Result<()> {
     let storage_path = "test-storage/claim_2_nft_outputs";
     common::setup(storage_path)?;
@@ -237,6 +419,71 @@ async fn claim_2_nft_outputs() -> Result<()> {
         .await?;
 
     let balance = accounts[0].sync(None).await.unwrap();
+    assert_eq!(balance.potentially_locked_outputs.len(), 0);
+    assert_eq!(balance.nfts.len(), 2);
+
+    common::tear_down(storage_path)
+}
+
+#[ignore]
+#[tokio::test]
+async fn claim_2_nft_outputs_no_outputs_in_claim_account() -> Result<()> {
+    let storage_path = "test-storage/claim_2_nft_outputs_no_outputs_in_claim_account";
+    common::setup(storage_path)?;
+
+    let manager = common::make_manager(storage_path, None, None).await?;
+
+    let account_0 = &common::create_accounts_with_funds(&manager, 1).await?[0];
+    let account_1 = manager.create_account().finish().await?;
+
+    let token_supply = account_0.client().get_token_supply().await?;
+    let outputs = vec![
+        // address of the owner of the NFT
+        NftOutputBuilder::new_with_amount(1_000_000, NftId::null())?
+            .with_unlock_conditions(vec![
+                UnlockCondition::Address(AddressUnlockCondition::new(
+                    *account_1.addresses().await?[0].address().as_ref(),
+                )),
+                UnlockCondition::Expiration(ExpirationUnlockCondition::new(
+                    *account_0.addresses().await?[0].address().as_ref(),
+                    account_0.client().get_time_checked().await? + 5000,
+                )?),
+            ])
+            .finish_output(token_supply)?,
+        NftOutputBuilder::new_with_amount(1_000_000, NftId::null())?
+            .with_unlock_conditions(vec![
+                UnlockCondition::Address(AddressUnlockCondition::new(
+                    *account_1.addresses().await?[0].address().as_ref(),
+                )),
+                UnlockCondition::Expiration(ExpirationUnlockCondition::new(
+                    *account_0.addresses().await?[0].address().as_ref(),
+                    account_0.client().get_time_checked().await? + 5000,
+                )?),
+            ])
+            .finish_output(token_supply)?,
+    ];
+
+    let tx = account_0.send(outputs, None).await?;
+    account_0
+        .retry_transaction_until_included(&tx.transaction_id, None, None)
+        .await?;
+
+    // Claim with account 1
+    let balance = account_1.sync(None).await.unwrap();
+    assert_eq!(balance.potentially_locked_outputs.len(), 2);
+
+    let tx = account_1
+        .claim_outputs(
+            account_1
+                .get_unlockable_outputs_with_additional_unlock_conditions(OutputsToClaim::Nfts)
+                .await?,
+        )
+        .await?;
+    account_1
+        .retry_transaction_until_included(&tx.transaction_id, None, None)
+        .await?;
+
+    let balance = account_1.sync(None).await.unwrap();
     assert_eq!(balance.potentially_locked_outputs.len(), 0);
     assert_eq!(balance.nfts.len(), 2);
 


### PR DESCRIPTION
# Description of change

Fix claim_outputs when no basic outputs are available

## Links to any relevant issues

Fixes #1875 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Added tests and nodejs example => claim tx with nft:https://explorer.shimmer.network/testnet/block/0x96357cf75e3208ec601ca57846028e40720cd04a76a01393df5d7ba2c97b9643
claim tx with basic output: https://explorer.shimmer.network/testnet/block/0xc1d95b9344e4aebcb3aae90d3a038cb69b1398e5493daced82edb5df788ae280

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
