### PR TITLE
Add && tsc to install script

### DIFF
--- a/wallet/bindings/nodejs/package.json
+++ b/wallet/bindings/nodejs/package.json
@@ -1,64 +1,64 @@
 {
-  "name": "@iota/wallet",
-  "version": "2.0.3-rc.23",
-  "description": "Node.js binding to the wallet library",
-  "main": "out/lib/index.js",
-  "types": "out/lib/index.d.ts",
-  "scripts": {
-    "lint": "eslint --ignore-path .eslintignore --ext .js,.ts .",
-    "format": "prettier --ignore-path .eslintignore -w {,*/**/}*.{ts,js,json}",
-    "format-check": "prettier --ignore-path .eslintignore -c {,*/**/}*.{ts,js,json}",
-    "build": "node scripts/neon-build && tsc",
-    "build:neon": "cargo-cp-artifact -nc ./index.node -- cargo build --release --message-format=json-render-diagnostics",
-    "docs-wiki-build": "typedoc --githubPages false --disableSources --excludePrivate --excludeInternal --excludeNotDocumented --plugin typedoc-plugin-markdown --theme markdown --hideBreadcrumbs --entryDocument api_ref.md --readme none --hideGenerator --sort source-order --exclude ./**/src/index.ts --out ../../../documentation/docs/references/nodejs ./lib/index.ts ",
-    "prebuild": "prebuild --runtime napi --target 6 --prepack scripts/neon-build.js --strip",
-    "rebuild": "node scripts/neon-build && tsc && node scripts/strip.js",
-    "install": "prebuild-install --runtime napi --tag-prefix='nodejs-binding-v' || npm run rebuild",
-    "test": "jest --forceExit"
-  },
-  "author": "IOTA Foundation <contact@iota.org>",
-  "license": "Apache-2.0",
-  "dependencies": {
-    "@iota/types": "^1.0.0-beta.15",
-    "cargo-cp-artifact": "^0.1.6",
-    "prebuild-install": "^7.1.1",
-    "typescript": "^4.9.4"
-  },
-  "devDependencies": {
-    "@types/jest": "^29.4.0",
-    "@typescript-eslint/eslint-plugin": "^5.30.7",
-    "@typescript-eslint/parser": "^5.30.7",
-    "dotenv": "^16.0.1",
-    "electron-build-env": "^0.2.0",
-    "eslint": "^8.20.0",
-    "eslint-config-prettier": "^8.5.0",
-    "jest": "^29.4.2",
-    "prebuild": "^11.0.4",
-    "prettier": "^2.8.3",
-    "ts-jest": "^29.0.5",
-    "typedoc": "^0.23.24",
-    "typedoc-plugin-markdown": "^3.14.0"
-  },
-  "overrides": {
-    "tar@<=4.4.17": "^4.4.19",
-    "tar@2.0.0": "^4.4.19",
-    "simple-get@1.4.2": "^2.8.2"
-  },
-  "resolutions": {
-    "tar": "^4.4.19",
-    "simple-get": "^2.8.2"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/iotaledger/wallet.rs.git"
-  },
-  "binary": {
-    "napi_versions": [
-      6
-    ]
-  },
-  "bugs": {
-    "url": "https://github.com/iotaledger/wallet.rs/issues"
-  },
-  "homepage": "https://github.com/iotaledger/wallet.rs#readme"
+    "name": "@iota/wallet",
+    "version": "2.0.3-rc.23",
+    "description": "Node.js binding to the wallet library",
+    "main": "out/lib/index.js",
+    "types": "out/lib/index.d.ts",
+    "scripts": {
+        "lint": "eslint --ignore-path .eslintignore --ext .js,.ts .",
+        "format": "prettier --ignore-path .eslintignore -w {,*/**/}*.{ts,js,json}",
+        "format-check": "prettier --ignore-path .eslintignore -c {,*/**/}*.{ts,js,json}",
+        "build": "node scripts/neon-build && tsc",
+        "build:neon": "cargo-cp-artifact -nc ./index.node -- cargo build --release --message-format=json-render-diagnostics",
+        "docs-wiki-build": "typedoc --githubPages false --disableSources --excludePrivate --excludeInternal --excludeNotDocumented --plugin typedoc-plugin-markdown --theme markdown --hideBreadcrumbs --entryDocument api_ref.md --readme none --hideGenerator --sort source-order --exclude ./**/src/index.ts --out ../../../documentation/docs/references/nodejs ./lib/index.ts ",
+        "prebuild": "prebuild --runtime napi --target 6 --prepack scripts/neon-build.js --strip",
+        "rebuild": "node scripts/neon-build && tsc && node scripts/strip.js",
+        "install": "prebuild-install --runtime napi --tag-prefix='nodejs-binding-v' && tsc || npm run rebuild",
+        "test": "jest --forceExit"
+    },
+    "author": "IOTA Foundation <contact@iota.org>",
+    "license": "Apache-2.0",
+    "dependencies": {
+        "@iota/types": "^1.0.0-beta.15",
+        "cargo-cp-artifact": "^0.1.6",
+        "prebuild-install": "^7.1.1",
+        "typescript": "^4.9.4"
+    },
+    "devDependencies": {
+        "@types/jest": "^29.4.0",
+        "@typescript-eslint/eslint-plugin": "^5.30.7",
+        "@typescript-eslint/parser": "^5.30.7",
+        "dotenv": "^16.0.1",
+        "electron-build-env": "^0.2.0",
+        "eslint": "^8.20.0",
+        "eslint-config-prettier": "^8.5.0",
+        "jest": "^29.4.2",
+        "prebuild": "^11.0.4",
+        "prettier": "^2.8.3",
+        "ts-jest": "^29.0.5",
+        "typedoc": "^0.23.24",
+        "typedoc-plugin-markdown": "^3.14.0"
+    },
+    "overrides": {
+        "tar@<=4.4.17": "^4.4.19",
+        "tar@2.0.0": "^4.4.19",
+        "simple-get@1.4.2": "^2.8.2"
+    },
+    "resolutions": {
+        "tar": "^4.4.19",
+        "simple-get": "^2.8.2"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/iotaledger/wallet.rs.git"
+    },
+    "binary": {
+        "napi_versions": [
+            6
+        ]
+    },
+    "bugs": {
+        "url": "https://github.com/iotaledger/wallet.rs/issues"
+    },
+    "homepage": "https://github.com/iotaledger/wallet.rs#readme"
 }


### PR DESCRIPTION
# Description of change

Add && tsc to install script, so everything gets build also if there is a prebuilt binary available

## Links to any relevant issues

Fixes https://github.com/iotaledger/wallet.rs/issues/1865

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

npm run install

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
