### PR TITLE
Fix address in burn_nft()

### DIFF
--- a/.changes/expiredNftBurn.md
+++ b/.changes/expiredNftBurn.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": patch
+---
+
+Fix address for the amount of expired NFTs that get burned with `Account::burnNft()`;

--- a/wallet/CHANGELOG.md
+++ b/wallet/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `prepare_nft_output` uses newly provided tag/metadata instead of previous ones from unspent output;
 - `Account::claim_outputs()` when the account has no basic outputs available;
 - SDR amount in `Account::prepare_output()`;
+- Address for the amount of expired NFTs that get burned with `Account::burn_nft()`;
 
 ## 1.0.0-rc.5 - 2023-02-09
 


### PR DESCRIPTION
# Description of change

Fix address for the amount of expired NFTs that get burned with `Account::burn_nft()`

## Links to any relevant issues

Fixes https://github.com/iotaledger/wallet.rs/issues/1915

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Added test

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
