### PR TITLE
Return correct error for wrong ManagerOptions

### DIFF
--- a/.changes/managerOptions.md
+++ b/.changes/managerOptions.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": patch
+---
+
+Return correct error for wrong ManagerOptions.


### PR DESCRIPTION
# Description of change

Return error for wrong ManagerOptions

## Links to any relevant issues

Fixes https://github.com/iotaledger/wallet.rs/issues/1923

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Creating an account manager with `stronghold: {},` returns now `Error: {"type":"error","payload":{"type":"json","error":"`missing field `snapshotPath` at line 1 column 157`"}}`

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
