### PR TITLE
Docs - Update testnet networkId in expected outputs

### DIFF
--- a/documentation/docs/libraries/java/how_to/NFT/_01_mint_nft/_expected_output.md
+++ b/documentation/docs/libraries/java/how_to/NFT/_01_mint_nft/_expected_output.md
@@ -4,7 +4,7 @@
       "type":6,
       "essence":{
          "type":1,
-         "networkId":"8342982141227064571",
+         "networkId":"1856588631910923207",
          "inputs":[
             {
                "type":0,
@@ -82,7 +82,7 @@
    "inclusionState":"Pending",
    "timestamp":"1664306373802",
    "transactionId":"0x87f0eeca7a4fd8706a4f57c5b440c2a1d190254a967e1e678d3e132c9dd44e14",
-   "networkId":"8342982141227064571",
+   "networkId":"1856588631910923207",
    "incoming":false
 }
 ```

--- a/documentation/docs/libraries/java/how_to/NFT/_02_send_nft/_expected_output.md
+++ b/documentation/docs/libraries/java/how_to/NFT/_02_send_nft/_expected_output.md
@@ -4,7 +4,7 @@
     "type":6,
     "essence":{
       "type":1,
-      "networkId":"8342982141227064571",
+      "networkId":"1856588631910923207",
       "inputs":[
         {
           "type":0,
@@ -51,7 +51,7 @@
   "inclusionState":"Pending",
   "timestamp":"1664876443672",
   "transactionId":"0xb423ef2155828a4b301795a77357c70bdac76c47f6ee1a20af6a298540fd9b86",
-  "networkId":"8342982141227064571",
+  "networkId":"1856588631910923207",
   "incoming":false
 }
 ```

--- a/documentation/docs/libraries/java/how_to/NFT/_03_burn_nft/_expected_output.md
+++ b/documentation/docs/libraries/java/how_to/NFT/_03_burn_nft/_expected_output.md
@@ -4,7 +4,7 @@
     "type":6,
     "essence":{
       "type":1,
-      "networkId":"8342982141227064571",
+      "networkId":"1856588631910923207",
       "inputs":[
         {
           "type":0,
@@ -44,7 +44,7 @@
   "inclusionState":"Pending",
   "timestamp":"1664876190299",
   "transactionId":"0x9c26110d611ea78fc0542dca45834abb35497c5ec6045448713f5a588e7f4292",
-  "networkId":"8342982141227064571",
+  "networkId":"1856588631910923207",
   "incoming":false
 }
 ```

--- a/documentation/docs/libraries/java/how_to/native_tokens/_01_mint_native_token/_expected_output.md
+++ b/documentation/docs/libraries/java/how_to/native_tokens/_01_mint_native_token/_expected_output.md
@@ -6,7 +6,7 @@
       "type":6,
       "essence":{
         "type":1,
-        "networkId":"8342982141227064571",
+        "networkId":"1856588631910923207",
         "inputs":[
           {
             "type":0,
@@ -125,7 +125,7 @@
     "inclusionState":"Pending",
     "timestamp":"1664896472744",
     "transactionId":"0xf323167737a556fcfcfa9da0248fc39aa344c275484a6f224769d2379ca49352",
-    "networkId":"8342982141227064571",
+    "networkId":"1856588631910923207",
     "incoming":false
   }
 }

--- a/documentation/docs/libraries/java/how_to/native_tokens/_02_send_native_token/_expected_output.md
+++ b/documentation/docs/libraries/java/how_to/native_tokens/_02_send_native_token/_expected_output.md
@@ -4,7 +4,7 @@
     "type":6,
     "essence":{
       "type":1,
-      "networkId":"8342982141227064571",
+      "networkId":"1856588631910923207",
       "inputs":[
         {
           "type":0,
@@ -93,7 +93,7 @@
   "inclusionState":"Pending",
   "timestamp":"1664884309679",
   "transactionId":"0x68454a9dbf31790aa072910a1caa0d3b32cc9ab89c476219a7d184a6dffbcc5c",
-  "networkId":"8342982141227064571",
+  "networkId":"1856588631910923207",
   "incoming":false
 }
 ```

--- a/documentation/docs/libraries/java/how_to/native_tokens/_03_melt_native_token/_expected_output.md
+++ b/documentation/docs/libraries/java/how_to/native_tokens/_03_melt_native_token/_expected_output.md
@@ -4,7 +4,7 @@
     "type":6,
     "essence":{
       "type":1,
-      "networkId":"8342982141227064571",
+      "networkId":"1856588631910923207",
       "inputs":[
         {
           "type":0,
@@ -112,7 +112,7 @@
   "inclusionState":"Pending",
   "timestamp":"1664885556280",
   "transactionId":"0xcbcfbbd9b36bd9a3d6830311ed428036d13fc37050bcd1cf82fb4e4b695570fd",
-  "networkId":"8342982141227064571",
+  "networkId":"1856588631910923207",
   "incoming":false
 }
 ```

--- a/documentation/docs/libraries/java/how_to/native_tokens/_04_burn_native_token/_expected_output.md
+++ b/documentation/docs/libraries/java/how_to/native_tokens/_04_burn_native_token/_expected_output.md
@@ -4,7 +4,7 @@
     "type":6,
     "essence":{
       "type":1,
-      "networkId":"8342982141227064571",
+      "networkId":"1856588631910923207",
       "inputs":[
         {
           "type":0,
@@ -50,7 +50,7 @@
   "inclusionState":"Pending",
   "timestamp":"1664885731096",
   "transactionId":"0xbb7f884e81ed32dbfe4f9c880b0f6577c9c90744b7ab33d84950706d2924c18c",
-  "networkId":"8342982141227064571",
+  "networkId":"1856588631910923207",
   "incoming":false
 }
 ```

--- a/documentation/docs/libraries/java/how_to/native_tokens/_05_destroy_foundry/_expected_output.md
+++ b/documentation/docs/libraries/java/how_to/native_tokens/_05_destroy_foundry/_expected_output.md
@@ -4,7 +4,7 @@
     "type":6,
     "essence":{
       "type":1,
-      "networkId":"8342982141227064571",
+      "networkId":"1856588631910923207",
       "inputs":[
         {
           "type":0,
@@ -64,7 +64,7 @@
   "inclusionState":"Pending",
   "timestamp":"1664886716685",
   "transactionId":"0xce5504e02bf0796e48143d5daa1753500e798dbab673e14bb671512750f7d03a",
-  "networkId":"8342982141227064571",
+  "networkId":"1856588631910923207",
   "incoming":false
 }
 ```

--- a/documentation/docs/libraries/java/how_to/outputs_and_transactions/_01_send_transaction/_expected_output.md
+++ b/documentation/docs/libraries/java/how_to/outputs_and_transactions/_01_send_transaction/_expected_output.md
@@ -4,7 +4,7 @@
     "type": 6,
     "essence": {
       "type": 1,
-      "networkId": "8342982141227064571",
+      "networkId": "1856588631910923207",
       "inputs": [
         {
           "type": 0,
@@ -71,7 +71,7 @@
   "inclusionState": "Pending",
   "timestamp": "1664304732407",
   "transactionId": "0x57aba1c7060c577f4404692e673910fa05dadf30e09a1cbc6aad2439628011e1",
-  "networkId": "8342982141227064571",
+  "networkId": "1856588631910923207",
   "incoming": false
 }
 ```

--- a/documentation/docs/libraries/java/how_to/outputs_and_transactions/_02_send_micro_transaction/_expected_output.md
+++ b/documentation/docs/libraries/java/how_to/outputs_and_transactions/_02_send_micro_transaction/_expected_output.md
@@ -4,7 +4,7 @@
     "type":6,
     "essence":{
       "type":1,
-      "networkId":"8342982141227064571",
+      "networkId":"1856588631910923207",
       "inputs":[
         {
           "type":0,
@@ -120,7 +120,7 @@
   "inclusionState":"Pending",
   "timestamp":"1664887369004",
   "transactionId":"0xaccae1f4e78ee169d0fc1d99843e6cd417290da91aa62c696fa507d21fd245cc",
-  "networkId":"8342982141227064571",
+  "networkId":"1856588631910923207",
   "incoming":false
 }
 ```

--- a/documentation/docs/libraries/java/how_to/outputs_and_transactions/_03_list_outputs/_expected_output.md
+++ b/documentation/docs/libraries/java/how_to/outputs_and_transactions/_03_list_outputs/_expected_output.md
@@ -44,7 +44,7 @@
     "type":0,
     "pubKeyHash":"0x4cfde0600797ae07d19d67d78910e70950bfdaf716f0035e9a30b97828aaf6a2"
   },
-  "networkId":"8342982141227064571",
+  "networkId":"1856588631910923207",
   "remainder":false,
   "chain":[
     {
@@ -139,7 +139,7 @@
     "type":0,
     "pubKeyHash":"0x4cfde0600797ae07d19d67d78910e70950bfdaf716f0035e9a30b97828aaf6a2"
   },
-  "networkId":"8342982141227064571",
+  "networkId":"1856588631910923207",
   "remainder":false,
   "chain":[
     {
@@ -232,7 +232,7 @@
       "type":0,
       "pubKeyHash":"0x4cfde0600797ae07d19d67d78910e70950bfdaf716f0035e9a30b97828aaf6a2"
    },
-   "networkId":"8342982141227064571",
+   "networkId":"1856588631910923207",
    "remainder":false,
    "chain":[
       {

--- a/documentation/docs/libraries/java/how_to/outputs_and_transactions/_04_claim_outputs/_expected_output.md
+++ b/documentation/docs/libraries/java/how_to/outputs_and_transactions/_04_claim_outputs/_expected_output.md
@@ -4,7 +4,7 @@
     "type":6,
     "essence":{
       "type":1,
-      "networkId":"8342982141227064571",
+      "networkId":"1856588631910923207",
       "inputs":[
         {
           "type":0,
@@ -44,7 +44,7 @@
   "inclusionState":"Pending",
   "timestamp":"1664900613290",
   "transactionId":"0x4893b9813145001e67fe89394c2e9464c9a2d07dea1536d36beb83258e5aa1c0",
-  "networkId":"8342982141227064571",
+  "networkId":"1856588631910923207",
   "incoming":false
 }
 ```

--- a/documentation/docs/libraries/java/how_to/outputs_and_transactions/_05_list_transactions/_expected_output.md
+++ b/documentation/docs/libraries/java/how_to/outputs_and_transactions/_05_list_transactions/_expected_output.md
@@ -35,7 +35,7 @@
       "type":0,
       "pubKeyHash":"0x4cfde0600797ae07d19d67d78910e70950bfdaf716f0035e9a30b97828aaf6a2"
    },
-   "networkId":"8342982141227064571",
+   "networkId":"1856588631910923207",
    "remainder":false,
    "chain":[
       {

--- a/documentation/docs/libraries/java/how_to/outputs_and_transactions/_06_destroy_alias_output/_expected_output.md
+++ b/documentation/docs/libraries/java/how_to/outputs_and_transactions/_06_destroy_alias_output/_expected_output.md
@@ -4,7 +4,7 @@
     "type":6,
     "essence":{
       "type":1,
-      "networkId":"8342982141227064571",
+      "networkId":"1856588631910923207",
       "inputs":[
         {
           "type":0,
@@ -44,7 +44,7 @@
   "inclusionState":"Pending",
   "timestamp":"1664966791558",
   "transactionId":"0xf4f21680774c74ae44d3244aca8cc3fd0248930561de673032afb21b18b04e8e",
-  "networkId":"8342982141227064571",
+  "networkId":"1856588631910923207",
   "incoming":false
 }
 ```

--- a/documentation/docs/libraries/nodejs/how_to/NFT/_01_mint_nft/_expected_output.md
+++ b/documentation/docs/libraries/nodejs/how_to/NFT/_01_mint_nft/_expected_output.md
@@ -4,7 +4,7 @@
     type: 6,
     essence: {
       type: 1,
-      networkId: '8342982141227064571',
+      networkId: '1856588631910923207',
       inputs: [Array],
       inputsCommitment: '0x086739a754bd6e9bd74f6242aaa354a46ee3615ad74a33caab84f0b0621e4885',
       outputs: [Array]
@@ -15,7 +15,7 @@
   inclusionState: 'Pending',
   timestamp: '1663000060038',
   transactionId: '0x2db9d3348abc98b59e8a8f68c3f6243300facc47fd2e005fd28878f295316fe9',
-  networkId: '8342982141227064571',
+  networkId: '1856588631910923207',
   incoming: false,
   note: null
 }

--- a/documentation/docs/libraries/nodejs/how_to/NFT/_02_send_nft/_expected_output.md
+++ b/documentation/docs/libraries/nodejs/how_to/NFT/_02_send_nft/_expected_output.md
@@ -4,7 +4,7 @@
     type: 6,
     essence: {
       type: 1,
-      networkId: '8342982141227064571',
+      networkId: '1856588631910923207',
       inputs: [Array],
       inputsCommitment: '0xd549b56a017e51a4ff053171b55aba62aac59e38a167067769991ccfb663ce1b',
       outputs: [Array]
@@ -15,7 +15,7 @@
   inclusionState: 'Pending',
   timestamp: '1663000240615',
   transactionId: '0x03d4fe1335d0880db4163e7cb19735e016c803b015c9e65123e07de579ed41d2',
-  networkId: '8342982141227064571',
+  networkId: '1856588631910923207',
   incoming: false,
   note: null
 }

--- a/documentation/docs/libraries/nodejs/how_to/NFT/_03_burn_nft/_expected_output.md
+++ b/documentation/docs/libraries/nodejs/how_to/NFT/_03_burn_nft/_expected_output.md
@@ -4,7 +4,7 @@
     type: 6,
     essence: {
       type: 1,
-      networkId: '8342982141227064571',
+      networkId: '1856588631910923207',
       inputs: [Array],
       inputsCommitment: '0x8ed6de2d3570269b4cfe2eb7ad29ee324c1b6ff78ad1f608db2b4e40c03db366',
       outputs: [Array]
@@ -15,7 +15,7 @@
   inclusionState: 'Pending',
   timestamp: '1663000414059',
   transactionId: '0x8e178dddc6c65be31ebe9fc980add3a62573d972a15deee03ac2434fc91812c5',
-  networkId: '8342982141227064571',
+  networkId: '1856588631910923207',
   incoming: false,
   note: null
 }

--- a/documentation/docs/libraries/nodejs/how_to/native_tokens/_02_send_native_token/_expected_output.md
+++ b/documentation/docs/libraries/nodejs/how_to/native_tokens/_02_send_native_token/_expected_output.md
@@ -4,7 +4,7 @@
     type: 6,
     essence: {
       type: 1,
-      networkId: '8342982141227064571',
+      networkId: '1856588631910923207',
       inputs: [Array],
       inputsCommitment: '0xaf866f45f6418098b2bb3b8359f39ca55ecb57c666c65c40c4f982af365f37d6',
       outputs: [Array]
@@ -15,7 +15,7 @@
   inclusionState: 'Pending',
   timestamp: '1662659637387',
   transactionId: '0xd4a81db105132dfa0c51a29eaecff1d796bf66d4be91be15a9864c88ee8f2c67',
-  networkId: '8342982141227064571',
+  networkId: '1856588631910923207',
   incoming: false,
   note: null
 }

--- a/documentation/docs/libraries/nodejs/how_to/native_tokens/_03_melt_native_token/_expected_output.md
+++ b/documentation/docs/libraries/nodejs/how_to/native_tokens/_03_melt_native_token/_expected_output.md
@@ -4,7 +4,7 @@
     type: 6,
     essence: {
       type: 1,
-      networkId: '8342982141227064571',
+      networkId: '1856588631910923207',
       inputs: [Array],
       inputsCommitment: '0x2d6b40731bd6222d0f7670ea5a1b143e499703cf71fd51a821d32d91a77a5041',
       outputs: [Array]
@@ -15,7 +15,7 @@
   inclusionState: 'Pending',
   timestamp: '1671182041013',
   transactionId: '0xd7b94f8487a817bc70febb80d83f0df93f1d7035851affaf7114cd7348cb610d',
-  networkId: '8342982141227064571',
+  networkId: '1856588631910923207',
   incoming: false,
   note: null
 }

--- a/documentation/docs/libraries/nodejs/how_to/native_tokens/_04_burn_native_token/_expected_output.md
+++ b/documentation/docs/libraries/nodejs/how_to/native_tokens/_04_burn_native_token/_expected_output.md
@@ -4,7 +4,7 @@
     type: 6,
     essence: {
       type: 1,
-      networkId: '8342982141227064571',
+      networkId: '1856588631910923207',
       inputs: [Array],
       inputsCommitment: '0xbbeedfa08b1136421e6c0ad599ada29ccadd326535262de9edadbfe9475b29cf',
       outputs: [Array]
@@ -15,7 +15,7 @@
   inclusionState: 'Pending',
   timestamp: '1671182074342',
   transactionId: '0x13df212d5f8ae281226543d7888491f866fbe669b160a9d2893674ff1a00a81a',
-  networkId: '8342982141227064571',
+  networkId: '1856588631910923207',
   incoming: false,
   note: null
 }

--- a/documentation/docs/libraries/nodejs/how_to/native_tokens/_05_destroy_foundry/_expected_output.md
+++ b/documentation/docs/libraries/nodejs/how_to/native_tokens/_05_destroy_foundry/_expected_output.md
@@ -4,7 +4,7 @@
     type: 6,
     essence: {
       type: 1,
-      networkId: '8342982141227064571',
+      networkId: '1856588631910923207',
       inputs: [Array],
       inputsCommitment: '0x3179afe33825e2c9557079291324968a159b6f8b89d0c7478ae3ec38b3b00548',
       outputs: [Array]
@@ -15,7 +15,7 @@
   inclusionState: 'Pending',
   timestamp: '1671182397354',
   transactionId: '0x6de7c4366f0419a6cbc2a39f8d67f0b6e5737b8caa8c029f59cee486b36ab8e9',
-  networkId: '8342982141227064571',
+  networkId: '1856588631910923207',
   incoming: false,
   note: null
 }

--- a/documentation/docs/libraries/nodejs/how_to/outputs_and_transactions/_05_send_transaction/_expected_output.md
+++ b/documentation/docs/libraries/nodejs/how_to/outputs_and_transactions/_05_send_transaction/_expected_output.md
@@ -49,7 +49,7 @@ Account: Account {
     type: 6,
     essence: {
       type: 1,
-      networkId: '8342982141227064571',
+      networkId: '1856588631910923207',
       inputs: [Array],
       inputsCommitment: '0x4a56ceb8ee05b747b73e97bdb093be9f885b6ba27562c91a1d8745d9ccfd57e1',
       outputs: [Array]
@@ -60,7 +60,7 @@ Account: Account {
   inclusionState: 'Pending',
   timestamp: '1662654717453',
   transactionId: '0x17670e2cda90f199c3e07188068c38ad856274e98d4913b80da8e3830db7afc4',
-  networkId: '8342982141227064571',
+  networkId: '1856588631910923207',
   incoming: false,
   note: null
 }

--- a/documentation/docs/libraries/nodejs/how_to/outputs_and_transactions/_06_send_micro_transaction/_expected_output.md
+++ b/documentation/docs/libraries/nodejs/how_to/outputs_and_transactions/_06_send_micro_transaction/_expected_output.md
@@ -4,7 +4,7 @@
     type: 6,
     essence: {
       type: 1,
-      networkId: '8342982141227064571',
+      networkId: '1856588631910923207',
       inputs: [Array],
       inputsCommitment: '0xad0e11ab7795212f3ff497e06c22218a18b297280e26e1d6392d217244879348',
       outputs: [Array]
@@ -15,7 +15,7 @@
   inclusionState: 'Pending',
   timestamp: '1662654628971',
   transactionId: '0x91a469ff1008ed3dc21d02aa6c20d8c2c048c5f096d7c9af797d3215f824e369',
-  networkId: '8342982141227064571',
+  networkId: '1856588631910923207',
   incoming: false,
   note: null
 }

--- a/documentation/docs/libraries/nodejs/how_to/outputs_and_transactions/_12a_list_outputs/_expected_output.md
+++ b/documentation/docs/libraries/nodejs/how_to/outputs_and_transactions/_12a_list_outputs/_expected_output.md
@@ -24,7 +24,7 @@ Listing Outputs: [
       type: 0,
       pubKeyHash: '0xeed1e4e3e9e7555e2f1592594bf916523e7fef3a9a8c0d630a4934440b822647'
     },
-    networkId: '8342982141227064571',
+    networkId: '1856588631910923207',
     remainder: false,
     chain: [ [Object], [Object], [Object], [Object], [Object] ]
   },

--- a/documentation/docs/libraries/nodejs/how_to/outputs_and_transactions/_12c_list_transactions/_expected_output.md
+++ b/documentation/docs/libraries/nodejs/how_to/outputs_and_transactions/_12c_list_transactions/_expected_output.md
@@ -6,7 +6,7 @@ Listing Transactions: [
     inclusionState: 'Confirmed',
     timestamp: '1663005355019',
     transactionId: '0xc4cd87bb0f33f2be15fab5454628ca21dc7f516120e7ddae8f87f4308b123412',
-    networkId: '8342982141227064571',
+    networkId: '1856588631910923207',
     incoming: false,
     note: null
   }

--- a/documentation/docs/libraries/nodejs/how_to/outputs_and_transactions/_21_claim_outputs/_expected_output.md
+++ b/documentation/docs/libraries/nodejs/how_to/outputs_and_transactions/_21_claim_outputs/_expected_output.md
@@ -4,7 +4,7 @@ Transaction is sent {
     type: 6,
     essence: {
       type: 1,
-      networkId: '8342982141227064571',
+      networkId: '1856588631910923207',
       inputs: [Array],
       inputsCommitment: '0xe564a6ec7749b3c09e06b05c76c95b37a34d0fd026dfb4082b8e4ff900f9dc81',
       outputs: [Array]
@@ -15,12 +15,12 @@ Transaction is sent {
   inclusionState: 'Pending',
   timestamp: '1663005430349',
   transactionId: '0xad3f8e00af9d56d22eff5ec730e01918e52d80c87e94859e00907099091aa95a',
-  networkId: '8342982141227064571',
+  networkId: '1856588631910923207',
   incoming: false,
   note: null
 }
-Output received: {"accountIndex":0,"event":{"NewOutput":{"output":{"outputId":"0xad3f8e00af9d56d22eff5ec730e01918e52d80c87e94859e00907099091aa95a0100","metadata":{"blockId":"0x8ce286630d376d3f6f2c74c1f758e38a0b88d776887aa6e4c7af0c125b533c7f","transactionId":"0xad3f8e00af9d56d22eff5ec730e01918e52d80c87e94859e00907099091aa95a","outputIndex":1,"isSpent":false,"milestoneIndexBooked":974130,"milestoneTimestampBooked":1663005433,"ledgerIndex":974130},"output":{"type":3,"amount":"998837200","unlockConditions":[{"type":0,"address":{"type":0,"pubKeyHash":"0xeed1e4e3e9e7555e2f1592594bf916523e7fef3a9a8c0d630a4934440b822647"}}]},"isSpent":false,"address":{"type":0,"pubKeyHash":"0xeed1e4e3e9e7555e2f1592594bf916523e7fef3a9a8c0d630a4934440b822647"},"networkId":"8342982141227064571","remainder":true,"chain":[{"hardened":true,"bs":[128,0,0,44]},{"hardened":true,"bs":[128,0,16,123]},{"hardened":true,"bs":[128,0,0,0]},{"hardened":true,"bs":[128,0,0,0]},{"hardened":true,"bs":[128,0,0,0]}]},"transaction":null,"transactionInputs":null}}}
-Output received: {"accountIndex":1,"event":{"NewOutput":{"output":{"outputId":"0xad3f8e00af9d56d22eff5ec730e01918e52d80c87e94859e00907099091aa95a0000","metadata":{"blockId":"0x8ce286630d376d3f6f2c74c1f758e38a0b88d776887aa6e4c7af0c125b533c7f","transactionId":"0xad3f8e00af9d56d22eff5ec730e01918e52d80c87e94859e00907099091aa95a","outputIndex":0,"isSpent":false,"milestoneIndexBooked":974130,"milestoneTimestampBooked":1663005433,"ledgerIndex":974131},"output":{"type":3,"amount":"1000000","unlockConditions":[{"type":0,"address":{"type":0,"pubKeyHash":"0x085748b21812b9fd706d58983a7b16dabe8a068bd8473ee1cd322fc9e02d8703"}}]},"isSpent":false,"address":{"type":0,"pubKeyHash":"0x085748b21812b9fd706d58983a7b16dabe8a068bd8473ee1cd322fc9e02d8703"},"networkId":"8342982141227064571","remainder":false,"chain":[{"hardened":true,"bs":[128,0,0,44]},{"hardened":true,"bs":[128,0,16,123]},{"hardened":true,"bs":[128,0,0,1]},{"hardened":true,"bs":[128,0,0,0]},{"hardened":true,"bs":[128,0,0,0]}]},"transaction":null,"transactionInputs":null}}}
+Output received: {"accountIndex":0,"event":{"NewOutput":{"output":{"outputId":"0xad3f8e00af9d56d22eff5ec730e01918e52d80c87e94859e00907099091aa95a0100","metadata":{"blockId":"0x8ce286630d376d3f6f2c74c1f758e38a0b88d776887aa6e4c7af0c125b533c7f","transactionId":"0xad3f8e00af9d56d22eff5ec730e01918e52d80c87e94859e00907099091aa95a","outputIndex":1,"isSpent":false,"milestoneIndexBooked":974130,"milestoneTimestampBooked":1663005433,"ledgerIndex":974130},"output":{"type":3,"amount":"998837200","unlockConditions":[{"type":0,"address":{"type":0,"pubKeyHash":"0xeed1e4e3e9e7555e2f1592594bf916523e7fef3a9a8c0d630a4934440b822647"}}]},"isSpent":false,"address":{"type":0,"pubKeyHash":"0xeed1e4e3e9e7555e2f1592594bf916523e7fef3a9a8c0d630a4934440b822647"},"networkId":"1856588631910923207","remainder":true,"chain":[{"hardened":true,"bs":[128,0,0,44]},{"hardened":true,"bs":[128,0,16,123]},{"hardened":true,"bs":[128,0,0,0]},{"hardened":true,"bs":[128,0,0,0]},{"hardened":true,"bs":[128,0,0,0]}]},"transaction":null,"transactionInputs":null}}}
+Output received: {"accountIndex":1,"event":{"NewOutput":{"output":{"outputId":"0xad3f8e00af9d56d22eff5ec730e01918e52d80c87e94859e00907099091aa95a0000","metadata":{"blockId":"0x8ce286630d376d3f6f2c74c1f758e38a0b88d776887aa6e4c7af0c125b533c7f","transactionId":"0xad3f8e00af9d56d22eff5ec730e01918e52d80c87e94859e00907099091aa95a","outputIndex":0,"isSpent":false,"milestoneIndexBooked":974130,"milestoneTimestampBooked":1663005433,"ledgerIndex":974131},"output":{"type":3,"amount":"1000000","unlockConditions":[{"type":0,"address":{"type":0,"pubKeyHash":"0x085748b21812b9fd706d58983a7b16dabe8a068bd8473ee1cd322fc9e02d8703"}}]},"isSpent":false,"address":{"type":0,"pubKeyHash":"0x085748b21812b9fd706d58983a7b16dabe8a068bd8473ee1cd322fc9e02d8703"},"networkId":"1856588631910923207","remainder":false,"chain":[{"hardened":true,"bs":[128,0,0,44]},{"hardened":true,"bs":[128,0,16,123]},{"hardened":true,"bs":[128,0,0,1]},{"hardened":true,"bs":[128,0,0,0]},{"hardened":true,"bs":[128,0,0,0]}]},"transaction":null,"transactionInputs":null}}}
 Output has been claimed in the following transaction: [
   {
     payload: { type: 6, essence: [Object], unlocks: [Array] },
@@ -28,7 +28,7 @@ Output has been claimed in the following transaction: [
     inclusionState: 'Pending',
     timestamp: '1663005447689',
     transactionId: '0x046a1112ba53beeee146dd4b0a28c59565fda3f62628b53655b5719b326e25d0',
-    networkId: '8342982141227064571',
+    networkId: '1856588631910923207',
     incoming: false,
     note: null
   }

--- a/documentation/docs/libraries/python/how_to/NFT/_01_mint_nft/_expected_output.md
+++ b/documentation/docs/libraries/python/how_to/NFT/_01_mint_nft/_expected_output.md
@@ -44,7 +44,7 @@ Sent transaction:{
 		'type':6,
 		'essence':{
 			'type':1,
-			'networkId':'8342982141227064571',
+			'networkId':'1856588631910923207',
 			'inputs':[
 				{
 					'type':0,
@@ -113,7 +113,7 @@ Sent transaction:{
 	'inclusionState':'Pending',
 	'timestamp':'1665918633606',
 	'transactionId':'0x25ddb61de4422f1df52286647517e5e1db8b1a7925ce3323bbf4533bbd3a7487',
-	'networkId':'8342982141227064571',
+	'networkId':'1856588631910923207',
 	'incoming':False,
 	'note':None
 }

--- a/documentation/docs/libraries/python/how_to/NFT/_02_send_nft/_expected_output.md
+++ b/documentation/docs/libraries/python/how_to/NFT/_02_send_nft/_expected_output.md
@@ -45,7 +45,7 @@ Sent transaction:{
 		'type':6,
 		'essence':{
 			'type':1,
-			'networkId':'8342982141227064571',
+			'networkId':'1856588631910923207',
 			'inputs':[
 				{
 					'type':0,
@@ -98,7 +98,7 @@ Sent transaction:{
 	'inclusionState':'Pending',
 	'timestamp':'1665918220888',
 	'transactionId':'0x3158626d7f404bded6af815f104e4001009a3f82fab7f9eb267cc691d039eed5',
-	'networkId':'8342982141227064571',
+	'networkId':'1856588631910923207',
 	'incoming':False,
 	'note':None
 }

--- a/documentation/docs/libraries/python/how_to/NFT/_03_burn_nft/_expected_output.md
+++ b/documentation/docs/libraries/python/how_to/NFT/_03_burn_nft/_expected_output.md
@@ -4,7 +4,7 @@
     "type":6,
     "essence":{
       "type":1,
-      "networkId":"8342982141227064571",
+      "networkId":"1856588631910923207",
       "inputs":[
         {
           "type":0,
@@ -44,7 +44,7 @@
   "inclusionState":"Pending",
   "timestamp":"1664876190299",
   "transactionId":"0x9c26110d611ea78fc0542dca45834abb35497c5ec6045448713f5a588e7f4292",
-  "networkId":"8342982141227064571",
+  "networkId":"1856588631910923207",
   "incoming":false
 }
 ```

--- a/documentation/docs/libraries/python/how_to/native_tokens/_01_mint_native_tokens/_expected_output.md
+++ b/documentation/docs/libraries/python/how_to/native_tokens/_01_mint_native_tokens/_expected_output.md
@@ -40,7 +40,7 @@ Sent transaction:{
 			'type':6,
 			'essence':{
 				'type':1,
-				'networkId':'8342982141227064571',
+				'networkId':'1856588631910923207',
 				'inputs':[
 					{
 						'type':0,
@@ -163,7 +163,7 @@ Sent transaction:{
 		'inclusionState':'Pending',
 		'timestamp':'1665917714656',
 		'transactionId':'0x9d1e61384fc78777c8db475a3d6eaec6465c136dc3ce586ee46a9453aa3dfdc4',
-		'networkId':'8342982141227064571',
+		'networkId':'1856588631910923207',
 		'incoming':False,
 		'note':None
 	}

--- a/documentation/docs/libraries/python/how_to/native_tokens/_02_send_native_tokens/_expected_output.md
+++ b/documentation/docs/libraries/python/how_to/native_tokens/_02_send_native_tokens/_expected_output.md
@@ -44,7 +44,7 @@ Sent transaction:{
 		'type':6,
 		'essence':{
 			'type':1,
-			'networkId':'8342982141227064571',
+			'networkId':'1856588631910923207',
 			'inputs':[
 				{
 					'type':0,
@@ -134,7 +134,7 @@ Sent transaction:{
 	'inclusionState':'Pending',
 	'timestamp':'1665918129925',
 	'transactionId':'0x9a5869b61b29f17326e04b6161d9cd169687e79476c556bd0c3cbbc3648d4ff6',
-	'networkId':'8342982141227064571',
+	'networkId':'1856588631910923207',
 	'incoming':False,
 	'note':None
 }

--- a/documentation/docs/libraries/python/how_to/native_tokens/_03_melt_native_token/_expected_output.md
+++ b/documentation/docs/libraries/python/how_to/native_tokens/_03_melt_native_token/_expected_output.md
@@ -4,7 +4,7 @@
     "type":6,
     "essence":{
       "type":1,
-      "networkId":"8342982141227064571",
+      "networkId":"1856588631910923207",
       "inputs":[
         {
           "type":0,
@@ -112,7 +112,7 @@
   "inclusionState":"Pending",
   "timestamp":"1664885556280",
   "transactionId":"0xcbcfbbd9b36bd9a3d6830311ed428036d13fc37050bcd1cf82fb4e4b695570fd",
-  "networkId":"8342982141227064571",
+  "networkId":"1856588631910923207",
   "incoming":false
 }
 ```

--- a/documentation/docs/libraries/python/how_to/native_tokens/_04_burn_native_token/_expected_output.md
+++ b/documentation/docs/libraries/python/how_to/native_tokens/_04_burn_native_token/_expected_output.md
@@ -4,7 +4,7 @@
     "type":6,
     "essence":{
       "type":1,
-      "networkId":"8342982141227064571",
+      "networkId":"1856588631910923207",
       "inputs":[
         {
           "type":0,
@@ -50,7 +50,7 @@
   "inclusionState":"Pending",
   "timestamp":"1664885731096",
   "transactionId":"0xbb7f884e81ed32dbfe4f9c880b0f6577c9c90744b7ab33d84950706d2924c18c",
-  "networkId":"8342982141227064571",
+  "networkId":"1856588631910923207",
   "incoming":false
 }
 ```

--- a/documentation/docs/libraries/python/how_to/native_tokens/_05_destroy_foundry/_expected_output.md
+++ b/documentation/docs/libraries/python/how_to/native_tokens/_05_destroy_foundry/_expected_output.md
@@ -4,7 +4,7 @@
     "type":6,
     "essence":{
       "type":1,
-      "networkId":"8342982141227064571",
+      "networkId":"1856588631910923207",
       "inputs":[
         {
           "type":0,
@@ -64,7 +64,7 @@
   "inclusionState":"Pending",
   "timestamp":"1664886716685",
   "transactionId":"0xce5504e02bf0796e48143d5daa1753500e798dbab673e14bb671512750f7d03a",
-  "networkId":"8342982141227064571",
+  "networkId":"1856588631910923207",
   "incoming":false
 }
 ```

--- a/documentation/docs/libraries/python/how_to/outputs_and_transactions/_01_send_transaction/_expected_output.md
+++ b/documentation/docs/libraries/python/how_to/outputs_and_transactions/_01_send_transaction/_expected_output.md
@@ -39,7 +39,7 @@ Senttransaction: {
     'type': 6,
     'essence': {
       'type': 1,
-      'networkId': '8342982141227064571',
+      'networkId': '1856588631910923207',
       'inputs': [
         {
           'type': 0,
@@ -92,7 +92,7 @@ Senttransaction: {
   'inclusionState': 'Pending',
   'timestamp': '1662654181658',
   'transactionId': '0xb40d2a02805712bd88c5d3663eee228379a4acdd365fbc301d9cf79c46540c72',
-  'networkId': '8342982141227064571',
+  'networkId': '1856588631910923207',
   'incoming': False,
   'note': None
 }

--- a/documentation/docs/libraries/python/how_to/outputs_and_transactions/_02_send_micro_transaction/_expected_output.md
+++ b/documentation/docs/libraries/python/how_to/outputs_and_transactions/_02_send_micro_transaction/_expected_output.md
@@ -36,7 +36,7 @@ Sent transaction:{
 		'type':6,
 		'essence':{
 			'type':1,
-			'networkId':'8342982141227064571',
+			'networkId':'1856588631910923207',
 			'inputs':[
 				{
 					'type':0,
@@ -114,7 +114,7 @@ Sent transaction:{
 	'inclusionState':'Pending',
 	'timestamp':'1665916700678',
 	'transactionId':'0x850c1e43dff1a28a42d71edc6d4ad0b9f251c03993f9b0684a34f645514ffe27',
-	'networkId':'8342982141227064571',
+	'networkId':'1856588631910923207',
 	'incoming':False,
 	'note':None
 }

--- a/documentation/docs/libraries/python/how_to/outputs_and_transactions/_03_list_outputs/_expected_output.md
+++ b/documentation/docs/libraries/python/how_to/outputs_and_transactions/_03_list_outputs/_expected_output.md
@@ -29,7 +29,7 @@ Outputs:[
 			'type':0,
 			'pubKeyHash':'0xf4d94c9f4e63d553c81e644225fa3bbc412f820c4eafd495aeb0bb05a29922b2'
 		},
-		'networkId':'8342982141227064571',
+		'networkId':'1856588631910923207',
 		'remainder':False,
 		'chain':[
 			{
@@ -110,7 +110,7 @@ Unspent outputs:[
 			'type':0,
 			'pubKeyHash':'0xf4d94c9f4e63d553c81e644225fa3bbc412f820c4eafd495aeb0bb05a29922b2'
 		},
-		'networkId':'8342982141227064571',
+		'networkId':'1856588631910923207',
 		'remainder':False,
 		'chain':[
 			{

--- a/documentation/docs/libraries/python/how_to/outputs_and_transactions/_04_claim_outputs/_expected_output.md
+++ b/documentation/docs/libraries/python/how_to/outputs_and_transactions/_04_claim_outputs/_expected_output.md
@@ -7,7 +7,7 @@ Sent transaction:{
 		'type':6,
 		'essence':{
 			'type':1,
-			'networkId':'8342982141227064571',
+			'networkId':'1856588631910923207',
 			'inputs':[
 				{
 					'type':0,
@@ -69,7 +69,7 @@ Sent transaction:{
 	'inclusionState':'Pending',
 	'timestamp':'1665992931904',
 	'transactionId':'0xeed7357bf0c0bbdca809e5e537af5a10872e488b26a157af78c68e104420ad75',
-	'networkId':'8342982141227064571',
+	'networkId':'1856588631910923207',
 	'incoming':False,
 	'note':None
 }

--- a/documentation/docs/libraries/python/how_to/outputs_and_transactions/_05_list_transactions/_expected_output.md
+++ b/documentation/docs/libraries/python/how_to/outputs_and_transactions/_05_list_transactions/_expected_output.md
@@ -5,7 +5,7 @@ Transactions:[
 			'type':6,
 			'essence':{
 				'type':1,
-				'networkId':'8342982141227064571',
+				'networkId':'1856588631910923207',
 				'inputs':[
 					{
 						'type':0,
@@ -67,7 +67,7 @@ Transactions:[
 		'inclusionState':'Pending',
 		'timestamp':'1665992931904',
 		'transactionId':'0xeed7357bf0c0bbdca809e5e537af5a10872e488b26a157af78c68e104420ad75',
-		'networkId':'8342982141227064571',
+		'networkId':'1856588631910923207',
 		'incoming':False,
 		'note':None
 	}
@@ -78,7 +78,7 @@ Pending transactions:[
 			'type':6,
 			'essence':{
 				'type':1,
-				'networkId':'8342982141227064571',
+				'networkId':'1856588631910923207',
 				'inputs':[
 					{
 						'type':0,
@@ -140,7 +140,7 @@ Pending transactions:[
 		'inclusionState':'Pending',
 		'timestamp':'1665992931904',
 		'transactionId':'0xeed7357bf0c0bbdca809e5e537af5a10872e488b26a157af78c68e104420ad75',
-		'networkId':'8342982141227064571',
+		'networkId':'1856588631910923207',
 		'incoming':False,
 		'note':None
 	}


### PR DESCRIPTION
# Description of change

Updated testnet  `networkId` to  `1856588631910923207` in expected outputs.

## Type of change

- Documentation Fix

## Related Issues

partially addresses https://github.com/iotaledger/guild-devx/issues/8

## How the change has been tested

Wiki was built locally.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have made corresponding changes to the documentation
