### PR TITLE
Add ignore_if_coin_type_mismatch to restore_backup()

### DIFF
--- a/.changes/restoreBackupOptions.md
+++ b/.changes/restoreBackupOptions.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": patch
+---
+
+Add optional ignoreIfCoinTypeMismatch to `AccountManager::restoreBackup()`;

--- a/cli/src/command/account_manager.rs
+++ b/cli/src/command/account_manager.rs
@@ -160,7 +160,9 @@ pub async fn restore_command(
         .finish()
         .await?;
 
-    account_manager.restore_backup(backup_path.into(), password).await?;
+    account_manager
+        .restore_backup(backup_path.into(), password, None)
+        .await?;
 
     Ok(account_manager)
 }

--- a/wallet/bindings/nodejs/lib/AccountManager.ts
+++ b/wallet/bindings/nodejs/lib/AccountManager.ts
@@ -291,13 +291,17 @@ export class AccountManager {
      * if ignore_if_coin_type_mismatch is provided client options will not be restored
      * if ignore_if_coin_type_mismatch == true, client options coin type and accounts will not be restored if the cointype doesn't match
      */
-    async restoreBackup(source: string, password: string, ignoreIfCoinTypeMismatch?: boolean): Promise<void> {
+    async restoreBackup(
+        source: string,
+        password: string,
+        ignoreIfCoinTypeMismatch?: boolean,
+    ): Promise<void> {
         await this.messageHandler.sendMessage({
             cmd: 'restoreBackup',
             payload: {
                 source,
                 password,
-                ignoreIfCoinTypeMismatch
+                ignoreIfCoinTypeMismatch,
             },
         });
     }

--- a/wallet/bindings/nodejs/lib/AccountManager.ts
+++ b/wallet/bindings/nodejs/lib/AccountManager.ts
@@ -288,13 +288,16 @@ export class AccountManager {
      * Replaces client_options, coin_type, secret_manager and accounts. Returns an error if accounts were already created
      * If Stronghold is used as secret_manager, the existing Stronghold file will be overwritten. If a mnemonic was
      * stored, it will be gone.
+     * if ignore_if_coin_type_mismatch is provided client options will not be restored
+     * if ignore_if_coin_type_mismatch == true, client options coin type and accounts will not be restored if the cointype doesn't match
      */
-    async restoreBackup(source: string, password: string): Promise<void> {
+    async restoreBackup(source: string, password: string, ignoreIfCoinTypeMismatch?: boolean): Promise<void> {
         await this.messageHandler.sendMessage({
             cmd: 'restoreBackup',
             payload: {
                 source,
                 password,
+                ignoreIfCoinTypeMismatch
             },
         });
     }

--- a/wallet/bindings/nodejs/types/bridge/accountManager.ts
+++ b/wallet/bindings/nodejs/types/bridge/accountManager.ts
@@ -124,6 +124,7 @@ export type __RestoreBackupMessage__ = {
     payload: {
         source: string;
         password: string;
+        ignoreIfCoinTypeMismatch?: boolean;
     };
 };
 

--- a/wallet/src/account_manager/operations/stronghold_backup/mod.rs
+++ b/wallet/src/account_manager/operations/stronghold_backup/mod.rs
@@ -55,7 +55,7 @@ impl AccountManager {
     /// Replaces client_options, coin_type, secret_manager and accounts. Returns an error if accounts were already
     /// created If Stronghold is used as secret_manager, the existing Stronghold file will be overwritten. If a
     /// mnemonic was stored, it will be gone.
-    /// if ignore_if_coin_type_mismatch.is_some(). client options will not be restored
+    /// if ignore_if_coin_type_mismatch.is_some(), client options will not be restored
     /// if ignore_if_coin_type_mismatch == Some(true), client options coin type and accounts will not be restored if the
     /// cointype doesn't match
     pub async fn restore_backup(

--- a/wallet/src/message_interface/message.rs
+++ b/wallet/src/message_interface/message.rs
@@ -104,7 +104,9 @@ pub enum Message {
     /// Replaces client_options, coin_type, secret_manager and accounts. Returns an error if accounts were already
     /// created If Stronghold is used as secret_manager, the existing Stronghold file will be overwritten. If a
     /// mnemonic was stored, it will be gone.
-    /// Expected response: [`Ok`](crate::message_interface::Response::Ok)
+    /// if ignore_if_coin_type_mismatch.is_some(). client options will not be restored
+    /// if ignore_if_coin_type_mismatch == Some(true), client options coin type and accounts will not be restored if
+    /// the cointype doesn't match Expected response: [`Ok`](crate::message_interface::Response::Ok)
     #[cfg(feature = "stronghold")]
     #[cfg_attr(docsrs, doc(cfg(feature = "stronghold")))]
     RestoreBackup {
@@ -112,6 +114,8 @@ pub enum Message {
         source: PathBuf,
         /// Stronghold file password.
         password: String,
+        #[serde(rename = "ignoreIfCoinTypeMismatch")]
+        ignore_if_coin_type_mismatch: Option<bool>,
     },
     /// Removes the latest account (account with the largest account index).
     /// Expected response: [`Ok`](crate::message_interface::Response::Ok)
@@ -268,7 +272,14 @@ impl Debug for Message {
             ),
             Self::RemoveLatestAccount => write!(f, "RemoveLatestAccount"),
             #[cfg(feature = "stronghold")]
-            Self::RestoreBackup { source, password: _ } => write!(f, "RestoreBackup{{ source: {source:?} }}"),
+            Self::RestoreBackup {
+                source,
+                password: _,
+                ignore_if_coin_type_mismatch,
+            } => write!(
+                f,
+                "RestoreBackup{{ source: {source:?}, password: <ommited>, ignore_if_coin_type_mismatch: {ignore_if_coin_type_mismatch:?} }}"
+            ),
             Self::GenerateMnemonic => write!(f, "GenerateMnemonic"),
             Self::VerifyMnemonic { mnemonic: _ } => write!(f, "VerifyMnemonic{{ mnemonic: <omitted> }}"),
             Self::SetClientOptions { client_options } => {

--- a/wallet/src/message_interface/message.rs
+++ b/wallet/src/message_interface/message.rs
@@ -104,7 +104,7 @@ pub enum Message {
     /// Replaces client_options, coin_type, secret_manager and accounts. Returns an error if accounts were already
     /// created If Stronghold is used as secret_manager, the existing Stronghold file will be overwritten. If a
     /// mnemonic was stored, it will be gone.
-    /// if ignore_if_coin_type_mismatch.is_some(). client options will not be restored
+    /// if ignore_if_coin_type_mismatch.is_some(), client options will not be restored
     /// if ignore_if_coin_type_mismatch == Some(true), client options coin type and accounts will not be restored if
     /// the cointype doesn't match Expected response: [`Ok`](crate::message_interface::Response::Ok)
     #[cfg(feature = "stronghold")]

--- a/wallet/src/message_interface/message_handler.rs
+++ b/wallet/src/message_interface/message_handler.rs
@@ -212,8 +212,16 @@ impl WalletMessageHandler {
                 .await
             }
             #[cfg(feature = "stronghold")]
-            Message::RestoreBackup { source, password } => {
-                convert_async_panics(|| async { self.restore_backup(source.to_path_buf(), password).await }).await
+            Message::RestoreBackup {
+                source,
+                password,
+                ignore_if_coin_type_mismatch,
+            } => {
+                convert_async_panics(|| async {
+                    self.restore_backup(source.to_path_buf(), password, ignore_if_coin_type_mismatch)
+                        .await
+                })
+                .await
             }
             Message::GenerateMnemonic => convert_panics(|| {
                 self.account_manager
@@ -381,9 +389,14 @@ impl WalletMessageHandler {
     }
 
     #[cfg(feature = "stronghold")]
-    async fn restore_backup(&self, backup_path: PathBuf, stronghold_password: String) -> Result<Response> {
+    async fn restore_backup(
+        &self,
+        backup_path: PathBuf,
+        stronghold_password: String,
+        ignore_if_coin_type_mismatch: Option<bool>,
+    ) -> Result<Response> {
         self.account_manager
-            .restore_backup(backup_path, stronghold_password)
+            .restore_backup(backup_path, stronghold_password, ignore_if_coin_type_mismatch)
             .await?;
         Ok(Response::Ok(()))
     }


### PR DESCRIPTION
# Description of change

Add ignore_if_coin_type_mismatch to restore_backup()

## Links to any relevant issues

Fixes https://github.com/iotaledger/wallet.rs/issues/1914

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Added test

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
