### PR TITLE
Fix issue linking problem in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@ Please write a summary of your changes and why you made them.
 
 ## Links to any relevant issues
 
-Be sure to reference any related issues by adding `fixes issue #`.
+Be sure to reference any related issues by adding `fixes #issue_number`.
 
 ## Type of change
 


### PR DESCRIPTION
# Description of change

For Github to recognise the linked issue it needs to follow a strict syntax. So by having `issue` before the issue link this does't correctly work currently