### PR TITLE
Resync outputs if a transaction got confirmed

### DIFF
--- a/.changes/sync.md
+++ b/.changes/sync.md
@@ -1,0 +1,5 @@
+---
+"nodejs-binding": patch
+---
+
+Resync outputs if a transaction got confirmed between syncing outputs and pending transactions to prevent not having unspent outputs afterwards.

--- a/wallet/CHANGELOG.md
+++ b/wallet/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+## 1.0.0-rc.7 - 2023-XX-XX
+
+### Changed
+
+- Resync outputs if a transaction got confirmed between syncing outputs and pending transactions to prevent not having unspent outputs afterwards;
+
 ## 1.0.0-rc.6 - 2023-03-09
 
 ### Added
@@ -42,7 +48,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Custom `Serialize` implementation for `Error`;
 - Reduced `MIN_SYNC_INTERVAL`;
 - Made `TransactionOptionsDto`, `ReturnStrategy` and `MintTokenTransactionDto` pub reachable;
-- Resync outputs if a transaction got confirmed between syncing outputs and pending transactions to prevent not having unspent outputs afterwards;
 
 ### Removed
 

--- a/wallet/CHANGELOG.md
+++ b/wallet/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Custom `Serialize` implementation for `Error`;
 - Reduced `MIN_SYNC_INTERVAL`;
 - Made `TransactionOptionsDto`, `ReturnStrategy` and `MintTokenTransactionDto` pub reachable;
+- Resync outputs if a transaction got confirmed between syncing outputs and pending transactions to prevent not having unspent outputs afterwards;
 
 ### Removed
 

--- a/wallet/src/account/operations/syncing/mod.rs
+++ b/wallet/src/account/operations/syncing/mod.rs
@@ -48,82 +48,18 @@ impl AccountHandle {
             return self.balance().await;
         }
 
-        // Sync the first time with pending_transactions if not disabled. If a pending transaction got confirmed for
-        // which we don't have an output, we request the outputs in the second round to also have them.
-        for i in 0..2 {
-            let addresses_to_sync = self.get_addresses_to_sync(&options).await?;
-            log::debug!("[SYNC] addresses_to_sync {}", addresses_to_sync.len());
+        self.sync_internal(&options).await?;
 
-            let (spent_or_not_synced_output_ids, addresses_with_unspent_outputs, outputs_data): (
-                Vec<OutputId>,
-                Vec<AddressWithUnspentOutputs>,
-                Vec<OutputData>,
-            ) = self.request_outputs_recursively(addresses_to_sync, &options).await?;
-
-            // Request possible spent outputs
-            log::debug!("[SYNC] spent_or_not_synced_outputs: {spent_or_not_synced_output_ids:?}");
-            let spent_or_unsynced_output_metadata_responses = self
-                .client
-                .try_get_outputs_metadata(spent_or_not_synced_output_ids.clone())
-                .await?;
-
-            // Add the output response to the output ids, the output response is optional, because an output could be
-            // pruned and then we can't get the metadata
-            let mut spent_or_unsynced_output_metadata_map: HashMap<OutputId, Option<OutputMetadataDto>> =
-                spent_or_not_synced_output_ids.into_iter().map(|o| (o, None)).collect();
-            for output_metadata_response in spent_or_unsynced_output_metadata_responses {
-                let output_id = output_metadata_response.output_id()?;
-                spent_or_unsynced_output_metadata_map.insert(output_id, Some(output_metadata_response));
+        // Sync transactions after updating account with outputs, so we can use them to check the transaction
+        // status
+        if options.sync_pending_transactions {
+            let confirmed_tx_with_unknown_output = self.sync_pending_transactions().await?;
+            // Sync again if we don't know the output yet, to prevent having no unspent outputs after syncing
+            if confirmed_tx_with_unknown_output {
+                log::debug!("[SYNC] a transaction for which no output is known got confirmed, syncing outputs again");
+                self.sync_internal(&options).await?;
             }
-
-            if options.sync_incoming_transactions {
-                let transaction_ids = outputs_data
-                    .iter()
-                    .map(|output| *output.output_id.transaction_id())
-                    .collect();
-                // Request and store transaction payload for newly received unspent outputs
-                self.request_incoming_transaction_data(transaction_ids).await?;
-            }
-
-            if options.sync_native_token_foundries {
-                let native_token_foundry_ids = outputs_data
-                    .iter()
-                    .filter_map(|output| output.output.native_tokens())
-                    .flat_map(|native_tokens| {
-                        native_tokens
-                            .iter()
-                            .map(|native_token| FoundryId::from(*native_token.token_id()))
-                    })
-                    .collect::<HashSet<_>>();
-
-                // Request and store foundry outputs
-                self.request_and_store_foundry_outputs(native_token_foundry_ids).await?;
-            }
-
-            // Updates account with balances, output ids, outputs
-            self.update_account(
-                addresses_with_unspent_outputs,
-                outputs_data,
-                spent_or_unsynced_output_metadata_map,
-                &options,
-            )
-            .await?;
-
-            // Only sync transactions the first time
-            // If a transaction got confirmed, sync outputs again
-            if i == 0 {
-                // Sync transactions after updating account with outputs, so we can use them to check the transaction
-                // status
-                if options.sync_pending_transactions {
-                    let confirmed = self.sync_pending_transactions().await?;
-                    if !confirmed {
-                        break;
-                    }
-                } else {
-                    break;
-                };
-            }
-        }
+        };
 
         let account_balance = self.balance().await?;
         // Update last_synced mutex
@@ -134,6 +70,68 @@ impl AccountHandle {
         *last_synced = time_now;
         log::debug!("[SYNC] finished syncing in {:.2?}", syc_start_time.elapsed());
         Ok(account_balance)
+    }
+
+    async fn sync_internal(&self, options: &SyncOptions) -> crate::Result<()> {
+        log::debug!("[SYNC] sync_internal");
+
+        let addresses_to_sync = self.get_addresses_to_sync(options).await?;
+        log::debug!("[SYNC] addresses_to_sync {}", addresses_to_sync.len());
+
+        let (spent_or_not_synced_output_ids, addresses_with_unspent_outputs, outputs_data): (
+            Vec<OutputId>,
+            Vec<AddressWithUnspentOutputs>,
+            Vec<OutputData>,
+        ) = self.request_outputs_recursively(addresses_to_sync, options).await?;
+
+        // Request possible spent outputs
+        log::debug!("[SYNC] spent_or_not_synced_outputs: {spent_or_not_synced_output_ids:?}");
+        let spent_or_unsynced_output_metadata_responses = self
+            .client
+            .try_get_outputs_metadata(spent_or_not_synced_output_ids.clone())
+            .await?;
+
+        // Add the output response to the output ids, the output response is optional, because an output could be
+        // pruned and then we can't get the metadata
+        let mut spent_or_unsynced_output_metadata_map: HashMap<OutputId, Option<OutputMetadataDto>> =
+            spent_or_not_synced_output_ids.into_iter().map(|o| (o, None)).collect();
+        for output_metadata_response in spent_or_unsynced_output_metadata_responses {
+            let output_id = output_metadata_response.output_id()?;
+            spent_or_unsynced_output_metadata_map.insert(output_id, Some(output_metadata_response));
+        }
+
+        if options.sync_incoming_transactions {
+            let transaction_ids = outputs_data
+                .iter()
+                .map(|output| *output.output_id.transaction_id())
+                .collect();
+            // Request and store transaction payload for newly received unspent outputs
+            self.request_incoming_transaction_data(transaction_ids).await?;
+        }
+
+        if options.sync_native_token_foundries {
+            let native_token_foundry_ids = outputs_data
+                .iter()
+                .filter_map(|output| output.output.native_tokens())
+                .flat_map(|native_tokens| {
+                    native_tokens
+                        .iter()
+                        .map(|native_token| FoundryId::from(*native_token.token_id()))
+                })
+                .collect::<HashSet<_>>();
+
+            // Request and store foundry outputs
+            self.request_and_store_foundry_outputs(native_token_foundry_ids).await?;
+        }
+
+        // Updates account with balances, output ids, outputs
+        self.update_account(
+            addresses_with_unspent_outputs,
+            outputs_data,
+            spent_or_unsynced_output_metadata_map,
+            options,
+        )
+        .await
     }
 
     // First request all outputs directly related to the ed25519 addresses, then for each nft and alias output we got,


### PR DESCRIPTION
# Description of change

Currently it can happen that a transaction gets confirmed between syncing the outputs and syncing pending transactions. This can lead to having no unspent outputs in the account, while there should be one

## Links to any relevant issues

Be sure to reference any related issues by adding `fixes #issue_number`.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
