### PR TITLE
Cache participations for spent outputs

### DIFF
--- a/wallet/CHANGELOG.md
+++ b/wallet/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Resync outputs if a transaction got confirmed between syncing outputs and pending transactions to prevent not having unspent outputs afterwards;
+- Cache participations for spent outputs;
 
 ### Fixed
 

--- a/wallet/src/account/operations/participation/mod.rs
+++ b/wallet/src/account/operations/participation/mod.rs
@@ -12,7 +12,7 @@ pub(crate) mod event;
 pub(crate) mod voting;
 pub(crate) mod voting_power;
 
-use std::collections::{hash_map::Entry, HashMap};
+use std::collections::{hash_map::Entry, HashMap, HashSet};
 
 use iota_client::{
     api_types::plugins::participation::{
@@ -58,6 +58,17 @@ impl AccountHandle {
         log::debug!("[get_participation_overview]");
         // TODO: Could use the address endpoint in the future when https://github.com/iotaledger/inx-participation/issues/50 is done.
 
+        let mut spent_cached_outputs = self
+            .storage_manager
+            .lock()
+            .await
+            .get_cached_participation_output_status(self.read().await.index)
+            .await?;
+        let restored_spent_cached_outputs_len = spent_cached_outputs.len();
+        log::debug!(
+            "[get_participation_overview] restored_spent_cached_outputs_len: {}",
+            restored_spent_cached_outputs_len
+        );
         let outputs = self.outputs(None).await?;
         let participation_outputs = outputs
             .into_iter()
@@ -65,10 +76,13 @@ impl AccountHandle {
                 is_valid_participation_output(&output_data.output)
                 // Check that the metadata exists, because otherwise we aren't participating for anything
                     && output_data.output.features().and_then(|f| f.metadata()).is_some()
+                    // Don't add spent cached outputs, we have their data already and it can't change anymore
+                    && !spent_cached_outputs.contains_key(&output_data.output_id)
             })
             .collect::<Vec<OutputData>>();
 
         let mut events = HashMap::new();
+        let mut spent_outputs = HashSet::new();
         for output_data in participation_outputs {
             // PANIC: the filter already checks that the metadata exists.
             let metadata = output_data.output.features().and_then(|f| f.metadata()).unwrap();
@@ -88,11 +102,34 @@ impl AccountHandle {
                             entry.get_mut().push(output_data.output_id);
                         }
                     }
+                    if output_data.is_spent {
+                        spent_outputs.insert(output_data.output_id);
+                    }
                 }
             };
         }
 
         let mut participations: HashMap<ParticipationEventId, HashMap<OutputId, TrackedParticipation>> = HashMap::new();
+
+        // Add cached data
+        for (output_id, output_status_response) in &spent_cached_outputs {
+            for (event_id, participation) in &output_status_response.participations {
+                // Skip events that aren't in `event_ids` if not None
+                if let Some(event_ids) = event_ids.as_ref() {
+                    if !event_ids.contains(event_id) {
+                        continue;
+                    }
+                }
+                match participations.entry(*event_id) {
+                    Entry::Vacant(entry) => {
+                        entry.insert(HashMap::from([(*output_id, participation.clone())]));
+                    }
+                    Entry::Occupied(mut entry) => {
+                        entry.get_mut().insert(*output_id, participation.clone());
+                    }
+                }
+            }
+        }
 
         for (event_id, output_ids) in events {
             log::debug!(
@@ -104,6 +141,16 @@ impl AccountHandle {
             for output_id_chunk in output_ids.chunks(100).map(|x| x.to_vec()) {
                 let mut tasks = Vec::new();
                 for output_id in output_id_chunk {
+                    // Skip if participations already contains this output id with participation for this event
+                    if let Some(p) = participations.get(&event_id) {
+                        if p.contains_key(&output_id) {
+                            log::debug!(
+                                "[get_participation_overview] skip requesting already known {output_id} for event {event_id}",
+                            );
+                            continue;
+                        }
+                    }
+
                     let event_client = event_client.clone();
                     tasks.push(async move {
                         task::spawn(async move { (event_client.output_status(&output_id).await, output_id) }).await
@@ -114,6 +161,22 @@ impl AccountHandle {
                 for (result, output_id) in results {
                     match result {
                         Ok(status) => {
+                            // Cache data for spent outputs
+                            if spent_outputs.contains(&output_id) {
+                                match spent_cached_outputs.entry(output_id) {
+                                    Entry::Vacant(entry) => {
+                                        entry.insert(status.clone());
+                                    }
+                                    Entry::Occupied(mut entry) => {
+                                        let output_status_response = entry.get_mut();
+                                        for (event_id, participation) in &status.participations {
+                                            output_status_response
+                                                .participations
+                                                .insert(*event_id, participation.clone());
+                                        }
+                                    }
+                                }
+                            }
                             for (event_id, participation) in status.participations {
                                 // Skip events that aren't in `event_ids` if not None
                                 if let Some(event_ids) = event_ids.as_ref() {
@@ -138,6 +201,19 @@ impl AccountHandle {
             }
         }
 
+        log::debug!(
+            "[get_participation_overview] new spent_cached_outputs: {}",
+            spent_cached_outputs.len()
+        );
+        // Only store updated data if new outputs got added
+        if spent_cached_outputs.len() > restored_spent_cached_outputs_len {
+            self.storage_manager
+                .lock()
+                .await
+                .set_cached_participation_output_status(self.read().await.index, spent_cached_outputs)
+                .await?;
+        }
+
         Ok(AccountParticipationOverview { participations })
     }
 
@@ -145,6 +221,7 @@ impl AccountHandle {
     ///
     /// If multiple outputs with this tag exist, the one with the largest amount will be returned.
     pub async fn get_voting_output(&self) -> Result<Option<OutputData>> {
+        log::debug!("[get_voting_output]");
         Ok(self
             .unspent_outputs(None)
             .await?
@@ -157,6 +234,7 @@ impl AccountHandle {
     /// Gets client for an event.
     /// If event isn't found, the client from the account will be returned.
     pub(crate) async fn get_client_for_event(&self, id: &ParticipationEventId) -> crate::Result<Client> {
+        log::debug!("[get_client_for_event]");
         let account_index = self.read().await.index;
         let events = self
             .storage_manager
@@ -183,6 +261,7 @@ impl AccountHandle {
         &self,
         participations: &mut Participations,
     ) -> crate::Result<()> {
+        log::debug!("[remove_ended_participation_events]");
         let latest_milestone_index = self.client().get_info().await?.node_info.status.latest_milestone.index;
 
         let account_index = self.read().await.index;

--- a/wallet/src/storage/constants.rs
+++ b/wallet/src/storage/constants.rs
@@ -27,3 +27,5 @@ pub(crate) const DATABASE_SCHEMA_VERSION_KEY: &str = "database-schema-version";
 
 #[cfg(feature = "participation")]
 pub(crate) const PARTICIPATION_EVENTS: &str = "participation-events";
+#[cfg(feature = "participation")]
+pub(crate) const PARTICIPATION_CACHED_OUTPUTS: &str = "participation-cached-outputs";


### PR DESCRIPTION
# Description of change

Cache participations for spent outputs and don't request outputs duplicated when not necessary

## Links to any relevant issues

Fixes #1866 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

cli wallet, the caching can be seen in the logs from calling `participation-overview` twice
`0x52d6cb454169a206be0acf209ad148ae35a5341b500d584567775d4f61dd98a40000` was spent, then cached and the second time not requested anymore, returned participation overview is still the same

```
2023-03-14 10:31:55 (UTC) iota_wallet::account::operations::participation DEBUG [get_participation_overview]
2023-03-14 10:31:55 (UTC) iota_wallet::storage::participation        DEBUG get_cached_participation
2023-03-14 10:31:55 (UTC) iota_wallet::account::operations::participation DEBUG [get_participation_overview] restored_spent_cached_outputs_len: 2
2023-03-14 10:31:55 (UTC) iota_wallet::account::operations::participation DEBUG [get_participation_overview] requesting 2 outputs for event 0xfb52886a80b081f3a1d4ea948870d54de406a5084603a159a93510fb9c24be91
2023-03-14 10:31:55 (UTC) iota_wallet::account::operations::participation DEBUG [get_client_for_event]
2023-03-14 10:31:55 (UTC) iota_wallet::storage::participation        DEBUG get_participation_events
2023-03-14 10:31:55 (UTC) iota_client::node_manager::http_client     DEBUG GET: 0 ms for 200 OK http://localhost:14265/api/participation/v1/outputs/0x52d6cb454169a206be0acf209ad148ae35a5341b500d584567775d4f61dd98a40000
2023-03-14 10:31:55 (UTC) iota_client::node_manager::http_client     DEBUG GET: 0 ms for 200 OK http://localhost:14265/api/participation/v1/outputs/0x14afa29c052f440a2b6366d0235101299c9a750d2ca73ae493a05baa98700f310000
2023-03-14 10:31:55 (UTC) iota_wallet::account::operations::participation DEBUG [get_participation_overview] requesting 2 outputs for event 0xadcad4c0703e0e1099eda402c49584bd390238518c31c89f3dea9f8aca850b1f
2023-03-14 10:31:55 (UTC) iota_wallet::account::operations::participation DEBUG [get_client_for_event]
2023-03-14 10:31:55 (UTC) iota_wallet::storage::participation        DEBUG get_participation_events
2023-03-14 10:31:55 (UTC) iota_wallet::account::operations::participation DEBUG [get_participation_overview] skip requesting already known 0x52d6cb454169a206be0acf209ad148ae35a5341b500d584567775d4f61dd98a40000 for event 0xadcad4c0703e0e1099eda402c49584bd390238518c31c89f3dea9f8aca850b1f
2023-03-14 10:31:55 (UTC) iota_wallet::account::operations::participation DEBUG [get_participation_overview] skip requesting already known 0x14afa29c052f440a2b6366d0235101299c9a750d2ca73ae493a05baa98700f310000 for event 0xadcad4c0703e0e1099eda402c49584bd390238518c31c89f3dea9f8aca850b1f
2023-03-14 10:31:55 (UTC) iota_wallet::account::operations::participation DEBUG [get_participation_overview] new spent_cached_outputs: 3
2023-03-14 10:31:55 (UTC) iota_wallet::storage::participation        DEBUG set_cached_participation
2023-03-14 10:31:55 (UTC) wallet::command::account                   INFO  Participation overview: AccountParticipationOverview { participations: {ParticipationEventId(0xfb52886a80b081f3a1d4ea948870d54de406a5084603a159a93510fb9c24be91): {OutputId(0x52d6cb454169a206be0acf209ad148ae35a5341b500d584567775d4f61dd98a40000): TrackedParticipation { block_id: BlockId(0x6f65789c523d662cc07e0d488c9a0c5e4dd7f7d19bb028b2839b4e79518b5821), amount: 1000000, start_milestone_index: 279, end_milestone_index: 428, answers: Some([1]) }, OutputId(0x14afa29c052f440a2b6366d0235101299c9a750d2ca73ae493a05baa98700f310000): TrackedParticipation { block_id: BlockId(0x2d34ace0bbbdd358cf3828c09bc0cd2e058581aa4ddc8fc70090a9e0f9232fb1), amount: 1000000, start_milestone_index: 428, end_milestone_index: 0, answers: Some([2]) }, OutputId(0xf4a2203393cc900051522d3909ec3257e08b50b9ada5716682697f7a641bac550000): TrackedParticipation { block_id: BlockId(0x75fac9456b4bcb2885b43b32ed4332c633ad33f32a66501265e84c237db8d686), amount: 1000000, start_milestone_index: 201, end_milestone_index: 279, answers: Some([1]) }}, ParticipationEventId(0xadcad4c0703e0e1099eda402c49584bd390238518c31c89f3dea9f8aca850b1f): {OutputId(0x52d6cb454169a206be0acf209ad148ae35a5341b500d584567775d4f61dd98a40000): TrackedParticipation { block_id: BlockId(0x6f65789c523d662cc07e0d488c9a0c5e4dd7f7d19bb028b2839b4e79518b5821), amount: 1000000, start_milestone_index: 279, end_milestone_index: 428, answers: Some([2]) }, OutputId(0x32f2603504517e5efd03bbabc6349c589948b404db8cf8d7ba1e2ddedf301c9b0000): TrackedParticipation { block_id: BlockId(0xa10535a2573f538b3877a3b811bcd63e4eba544cac99358d5b62ce417aa91d61), amount: 1000000, start_milestone_index: 149, end_milestone_index: 201, answers: Some([1]) }, OutputId(0x14afa29c052f440a2b6366d0235101299c9a750d2ca73ae493a05baa98700f310000): TrackedParticipation { block_id: BlockId(0x2d34ace0bbbdd358cf3828c09bc0cd2e058581aa4ddc8fc70090a9e0f9232fb1), amount: 1000000, start_milestone_index: 428, end_milestone_index: 0, answers: Some([2]) }, OutputId(0xf4a2203393cc900051522d3909ec3257e08b50b9ada5716682697f7a641bac550000): TrackedParticipation { block_id: BlockId(0x75fac9456b4bcb2885b43b32ed4332c633ad33f32a66501265e84c237db8d686), amount: 1000000, start_milestone_index: 201, end_milestone_index: 279, answers: Some([1]) }}} }


2023-03-14 10:32:19 (UTC) iota_wallet::account::operations::participation DEBUG [get_participation_overview]
2023-03-14 10:32:19 (UTC) iota_wallet::storage::participation        DEBUG get_cached_participation
2023-03-14 10:32:19 (UTC) iota_wallet::account::operations::participation DEBUG [get_participation_overview] restored_spent_cached_outputs_len: 3
2023-03-14 10:32:19 (UTC) iota_wallet::account::operations::participation DEBUG [get_participation_overview] requesting 1 outputs for event 0xadcad4c0703e0e1099eda402c49584bd390238518c31c89f3dea9f8aca850b1f
2023-03-14 10:32:19 (UTC) iota_wallet::account::operations::participation DEBUG [get_client_for_event]
2023-03-14 10:32:19 (UTC) iota_wallet::storage::participation        DEBUG get_participation_events
2023-03-14 10:32:19 (UTC) iota_client::node_manager::http_client     DEBUG GET: 0 ms for 200 OK http://localhost:14265/api/participation/v1/outputs/0x14afa29c052f440a2b6366d0235101299c9a750d2ca73ae493a05baa98700f310000
2023-03-14 10:32:19 (UTC) iota_wallet::account::operations::participation DEBUG [get_participation_overview] requesting 1 outputs for event 0xfb52886a80b081f3a1d4ea948870d54de406a5084603a159a93510fb9c24be91
2023-03-14 10:32:19 (UTC) iota_wallet::account::operations::participation DEBUG [get_client_for_event]
2023-03-14 10:32:19 (UTC) iota_wallet::storage::participation        DEBUG get_participation_events
2023-03-14 10:32:19 (UTC) iota_wallet::account::operations::participation DEBUG [get_participation_overview] skip requesting already known 0x14afa29c052f440a2b6366d0235101299c9a750d2ca73ae493a05baa98700f310000 for event 0xfb52886a80b081f3a1d4ea948870d54de406a5084603a159a93510fb9c24be91
2023-03-14 10:32:19 (UTC) iota_wallet::account::operations::participation DEBUG [get_participation_overview] new spent_cached_outputs: 3
2023-03-14 10:32:19 (UTC) wallet::command::account                   INFO  Participation overview: AccountParticipationOverview { participations: {ParticipationEventId(0xfb52886a80b081f3a1d4ea948870d54de406a5084603a159a93510fb9c24be91): {OutputId(0xf4a2203393cc900051522d3909ec3257e08b50b9ada5716682697f7a641bac550000): TrackedParticipation { block_id: BlockId(0x75fac9456b4bcb2885b43b32ed4332c633ad33f32a66501265e84c237db8d686), amount: 1000000, start_milestone_index: 201, end_milestone_index: 279, answers: Some([1]) }, OutputId(0x52d6cb454169a206be0acf209ad148ae35a5341b500d584567775d4f61dd98a40000): TrackedParticipation { block_id: BlockId(0x6f65789c523d662cc07e0d488c9a0c5e4dd7f7d19bb028b2839b4e79518b5821), amount: 1000000, start_milestone_index: 279, end_milestone_index: 428, answers: Some([1]) }, OutputId(0x14afa29c052f440a2b6366d0235101299c9a750d2ca73ae493a05baa98700f310000): TrackedParticipation { block_id: BlockId(0x2d34ace0bbbdd358cf3828c09bc0cd2e058581aa4ddc8fc70090a9e0f9232fb1), amount: 1000000, start_milestone_index: 428, end_milestone_index: 0, answers: Some([2]) }}, ParticipationEventId(0xadcad4c0703e0e1099eda402c49584bd390238518c31c89f3dea9f8aca850b1f): {OutputId(0x32f2603504517e5efd03bbabc6349c589948b404db8cf8d7ba1e2ddedf301c9b0000): TrackedParticipation { block_id: BlockId(0xa10535a2573f538b3877a3b811bcd63e4eba544cac99358d5b62ce417aa91d61), amount: 1000000, start_milestone_index: 149, end_milestone_index: 201, answers: Some([1]) }, OutputId(0x14afa29c052f440a2b6366d0235101299c9a750d2ca73ae493a05baa98700f310000): TrackedParticipation { block_id: BlockId(0x2d34ace0bbbdd358cf3828c09bc0cd2e058581aa4ddc8fc70090a9e0f9232fb1), amount: 1000000, start_milestone_index: 428, end_milestone_index: 0, answers: Some([2]) }, OutputId(0x52d6cb454169a206be0acf209ad148ae35a5341b500d584567775d4f61dd98a40000): TrackedParticipation { block_id: BlockId(0x6f65789c523d662cc07e0d488c9a0c5e4dd7f7d19bb028b2839b4e79518b5821), amount: 1000000, start_milestone_index: 279, end_milestone_index: 428, answers: Some([2]) }, OutputId(0xf4a2203393cc900051522d3909ec3257e08b50b9ada5716682697f7a641bac550000): TrackedParticipation { block_id: BlockId(0x75fac9456b4bcb2885b43b32ed4332c633ad33f32a66501265e84c237db8d686), amount: 1000000, start_milestone_index: 201, end_milestone_index: 279, answers: Some([1]) }}} }

```

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
