### PR TITLE
Docs - Production - Remove Bee

### DIFF
--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -11,7 +11,7 @@ For all the optional values, the default values are the same as the ones in the 
 | ------ | ----- | ----------- | ------------------------ |
 | config | `str` | `undefined` | The logger configuration |
 
-The config is the dumped string from the JSON, which key:value pairs are from the [bee logger](https://github.com/iotaledger/bee/blob/dev/bee-common/bee-common/src/logger/config.rs).
+The config is the dumped string from the JSON, which key:value pairs are from the [fern logger](https://github.com/iotaledger/common-rs/blob/main/fern-logger/src/config.rs).
 
 Please check the `example/logger_example.py` to see how to use it.
 

--- a/documentation/docs/reference/python.md
+++ b/documentation/docs/reference/python.md
@@ -21,7 +21,7 @@ For all optional values, the default values are the same as in the [Rust API](ru
 | ------ | ----- | ----------- | ------------------------ |
 | config | `str` | `undefined` | The logger configuration |
 
-The config is the dumped string from the JSON, which key:value pairs are from the [bee logger](https://github.com/iotaledger/bee/blob/dev/bee-common/bee-common/src/logger/config.rs).
+The config is the dumped string from the JSON, which key:value pairs are from the [fern logger](https://github.com/iotaledger/common-rs/blob/main/fern-logger/src/config.rs).
 
 Please check the `example/logger_example.py` to see how to use it.
 


### PR DESCRIPTION
Docs - Production - Remove Bee

# Description

Removed bee from docs as it's no longer relevant.

fixes https://github.com/iotaledger/guild-devx/issues/89

## Type of change

- [x] Documentation Fix

# How Has This Been Tested?

Wiki was built locally.

# Checklist:

- [x] I have made corresponding changes to the documentation
